### PR TITLE
Migrate STIB API to Belgian Mobility API

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,4 @@
-STIB_API_KEY=
+BELGIAN_API_KEY=
 
 APP_NAME=Laravel
 APP_ENV=local

--- a/README.md
+++ b/README.md
@@ -8,26 +8,29 @@ Work in progress.
 
 - Follow the usual Laravel project installation process.
 - Run `php artisan migrate` to initialize the database.
-- Run `php artisan stib:messages` to fetch data from the [real-time STIB API](https://data.stib-mivb.brussels/explore/dataset/travellers-information-rt-production/information/) **or** run `php artisan stib:sample` to use samples data.
+- Run `php artisan stib:messages` to fetch STIB messages data from the [real-time Belgian Mobility API](https://api-management-opendata-production.developer.azure-api.net/api-details#api=_api_datasets_stibmivb_rt_TravellersInformation&operation=api-datasets-stibmivb-rt-TravellersInformation) **or** run `php artisan stib:sample` to use samples data from 2024 and 2026.
 
 You can also run `php artisan schedule:work` on your machine to fetch data on a periodic basis.
 
 In your browser, visit the `/stib/subways` route.
 
-## STIB API
+## Belgian Mobility API
 
-Without API key, the API is rate-limited to 100 calls per day, which makes an average of 1 call every 14 minutes and 24 seconds. [With API key](https://help.opendatasoft.com/apis/ods-explore-v2/#section/Authentication/Finding-and-generating-API-keys), you get 10000 calls per day, which makes an average of 1 call every 8.64 seconds.
+Without API key, the [API is rate-limited](https://data.belgianmobility.io/en/terms.html#access) to 100 calls per day with up to 10 per minute, which makes an average of 1 call every 14 minutes and 24 seconds. With API key, you get 10000 calls per day with up to 500 per minute, which makes an average of 1 call every 8.64 seconds. There’s also a higher tier requiring to contact Belgian Mobility
 
-To get an API key, create yourself a user on the STIB API portal, then go to the [dedicated section](https://data.stib-mivb.brussels/account/api-keys/).
+To get an API key, create yourself a user on the [Belgian Mobility API portal](https://api-management-opendata-production.developer.azure-api.net/profile).
 
 Example code using Laravel [`Http` client](https://laravel.com/docs/11.x/http-client):
 
 ```php
-$baseUrl = 'https://data.stib-mivb.brussels/api/explore/v2.1/catalog/datasets';
+$baseUrl = 'https://api-management-opendata-production.azure-api.net/api/datasets/stibmivb';
+$key = config('services.belgian-mobility.api.key');
 
-Http::withHeader('Authorization', 'ApiKey '.config('services.stib.api.key'))
-  ->get($baseUrl.'/travellers-information-rt-production/exports/json');
+Http::withHeader('Authorization', 'ApiKey '$key)
+  ->get($baseUrl.'/travellers-information-rt-production');
 ```
+
+General information about datasets and available APIs can also be found on [Belgian Mobility website](https://data.belgianmobility.io).
 
 ---
 

--- a/app/Console/Commands/StibSampleData.php
+++ b/app/Console/Commands/StibSampleData.php
@@ -28,9 +28,13 @@ class StibSampleData extends Command
             ->line('Feeding the database with sample STIB messages…');
 
         $data = collect([
+            // Former STIB API
             Storage::json('samples/2024-04-29-travellers-information-rt-production.json'),
             // Storage::json('samples/2024-05-10-travellers-information-rt-production.json'),
             // Storage::json('samples/2024-05-16-travellers-information-rt-production.json'),
+
+            // Current STIB API
+            Storage::json('samples/2026-03-22-travellers-information-rt-production.json')['results'],
         ])
             ->flatten(1);
 

--- a/app/Services/StibDataFetchingService.php
+++ b/app/Services/StibDataFetchingService.php
@@ -10,7 +10,7 @@ use Illuminate\Support\Facades\Http;
 
 class StibDataFetchingService
 {
-    protected string $baseUrl = 'https://data.stib-mivb.brussels/api/explore/v2.1/catalog/datasets';
+    protected string $baseUrl = 'https://api-management-opendata-production.azure-api.net/api/datasets/stibmivb';
 
     protected Collection $activeStatuses;
     protected Collection $lines;
@@ -30,16 +30,14 @@ class StibDataFetchingService
     {
         /** @todo Test `config('app.timezone')`. */
         $res = Http::timeout(60)
-            ->withHeader('Authorization', 'ApiKey '.config('services.stib.api.key'))
-
-            /** @todo: check what’s the effect of the timezone or if we can ignore it */
-            ->get($this->baseUrl.'/travellers-information-rt-production/exports/json?timezone=Europe%2FBrussels');
+            ->withHeader('Authorization', 'ApiKey '.config('services.belgian-mobility.api.key'))
+            ->get($this->baseUrl.'/rt/TravellersInformation');
 
         if (! $res->ok()) {
             return false;
         }
 
-        return $this->process(collect($res->json()));
+        return $this->process(collect($res->json()['results']));
     }
 
     /**

--- a/config/services.php
+++ b/config/services.php
@@ -14,6 +14,12 @@ return [
     |
     */
 
+    'belgian-mobility' => [
+        'api' => [
+            'key' => env('BELGIAN_API_KEY'),
+        ],
+    ],
+
     'postmark' => [
         'token' => env('POSTMARK_TOKEN'),
     ],
@@ -28,12 +34,6 @@ return [
         'notifications' => [
             'bot_user_oauth_token' => env('SLACK_BOT_USER_OAUTH_TOKEN'),
             'channel' => env('SLACK_BOT_USER_DEFAULT_CHANNEL'),
-        ],
-    ],
-
-    'stib' => [
-        'api' => [
-            'key' => env('STIB_API_KEY'),
         ],
     ],
 

--- a/storage/app/samples/2024-04-29-travellers-information-rt-production.json
+++ b/storage/app/samples/2024-04-29-travellers-information-rt-production.json
@@ -1,1 +1,2746 @@
-[{"content": "[{\"text\": [{\"en\": \"Obstacle on the tracks: T81-T97 are not operated between BAREEL and JANSON\", \"fr\": \"Obstacle sur les voies: T81-T97 Trafic interrompu entre BARRIERE et JANSON\", \"nl\": \"Obstakel op de sporen: T81-T97 Geen verkeer tussen BAREEL en JANSON\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"81\"}]", "priority": 2, "points": "[{\"id\": \"6462F\"}]"},{"content": "[{\"text\": [{\"en\": \"Obstacle on the tracks: T81-T97 are not operated between BAREEL and JANSON\", \"fr\": \"Obstacle sur les voies: T81-T97 Trafic interrompu entre BARRIERE et JANSON\", \"nl\": \"Obstakel op de sporen: T81-T97 Geen verkeer tussen BAREEL en JANSON\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"81\"}]", "priority": 2, "points": "[{\"id\": \"6099\"}, {\"id\": \"6121F\"}, {\"id\": \"3611F\"}, {\"id\": \"6113F\"}, {\"id\": \"3613F\"}, {\"id\": \"3123\"}, {\"id\": \"6858G\"}, {\"id\": \"6705F\"}, {\"id\": \"2260F\"}, {\"id\": \"1805F\"}, {\"id\": \"6799F\"}, {\"id\": \"6860G\"}, {\"id\": \"6106\"}, {\"id\": \"6008\"}, {\"id\": \"6109\"}, {\"id\": \"2971F\"}, {\"id\": \"2331F\"}, {\"id\": \"6120\"}, {\"id\": \"6077F\"}, {\"id\": \"2539F\"}, {\"id\": \"3612F\"}, {\"id\": \"6114F\"}, {\"id\": \"3371F\"}, {\"id\": \"0631\"}, {\"id\": \"6427F\"}, {\"id\": \"6117\"}, {\"id\": \"2259F\"}, {\"id\": \"6856\"}, {\"id\": \"3508F\"}, {\"id\": \"2257G\"}, {\"id\": \"6857\"}, {\"id\": \"2960F\"}]"},{"content": "[{\"text\": [{\"en\": \"Obstacle on the tracks: T81-T97 are not operated between BAREEL and JANSON\", \"fr\": \"Obstacle sur les voies: T81-T97 Trafic interrompu entre BARRIERE et JANSON\", \"nl\": \"Obstakel op de sporen: T81-T97 Geen verkeer tussen BAREEL en JANSON\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"81\"}]", "priority": 2, "points": "[{\"id\": \"6153\"}, {\"id\": \"6175\"}, {\"id\": \"6078\"}, {\"id\": \"6809F\"}, {\"id\": \"1042\"}, {\"id\": \"3370F\"}, {\"id\": \"3572F\"}, {\"id\": \"2220F\"}, {\"id\": \"6157F\"}, {\"id\": \"2931F\"}, {\"id\": \"6009\"}, {\"id\": \"6155F\"}, {\"id\": \"6166\"}, {\"id\": \"6165\"}, {\"id\": \"3610F\"}, {\"id\": \"6068\"}, {\"id\": \"2218F\"}, {\"id\": \"6808G\"}, {\"id\": \"6162\"}, {\"id\": \"2671F\"}, {\"id\": \"2285G\"}, {\"id\": \"6425F\"}, {\"id\": \"2380F\"}, {\"id\": \"2217F\"}, {\"id\": \"6810\"}, {\"id\": \"6156F\"}, {\"id\": \"6158H\"}, {\"id\": \"6811\"}, {\"id\": \"2336G\"}, {\"id\": \"3608\"}, {\"id\": \"3609F\"}, {\"id\": \"6792F\"}, {\"id\": \"2972F\"}, {\"id\": \"0636\"}]"},{"content": "[{\"text\": [{\"en\": \"Obstacle on the tracks: T81-T97 are not operated between BAREEL and JANSON\", \"fr\": \"Obstacle sur les voies: T81-T97 Trafic interrompu entre BARRIERE et JANSON\", \"nl\": \"Obstakel op de sporen: T81-T97 Geen verkeer tussen BAREEL en JANSON\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"81\"}]", "priority": 2, "points": "[{\"id\": \"2286G\"}]"},{"content": "[{\"text\": [{\"en\": \"Obstacle on the tracks: T81-T97 are not operated between BAREEL and JANSON\", \"fr\": \"Obstacle sur les voies: T81-T97 Trafic interrompu entre BARRIERE et JANSON\", \"nl\": \"Obstakel op de sporen: T81-T97 Geen verkeer tussen BAREEL en JANSON\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"97\"}]", "priority": 2, "points": "[{\"id\": \"5152G\"}]"},{"content": "[{\"text\": [{\"en\": \"Obstacle on the tracks: T81-T97 are not operated between BAREEL and JANSON\", \"fr\": \"Obstacle sur les voies: T81-T97 Trafic interrompu entre BARRIERE et JANSON\", \"nl\": \"Obstakel op de sporen: T81-T97 Geen verkeer tussen BAREEL en JANSON\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"97\"}]", "priority": 2, "points": "[{\"id\": \"2334F\"}]"},{"content": "[{\"text\": [{\"en\": \"Obstacle on the tracks: T81-T97 are not operated between BAREEL and JANSON\", \"fr\": \"Obstacle sur les voies: T81-T97 Trafic interrompu entre BARRIERE et JANSON\", \"nl\": \"Obstakel op de sporen: T81-T97 Geen verkeer tussen BAREEL en JANSON\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"97\"}]", "priority": 2, "points": "[{\"id\": \"5154F\"}]"},{"content": "[{\"text\": [{\"en\": \"Obstacle on the tracks: T81-T97 are not operated between BAREEL and JANSON\", \"fr\": \"Obstacle sur les voies: T81-T97 Trafic interrompu entre BARRIERE et JANSON\", \"nl\": \"Obstakel op de sporen: T81-T97 Geen verkeer tussen BAREEL en JANSON\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"97\"}]", "priority": 2, "points": "[{\"id\": \"5151\"}, {\"id\": \"2668\"}, {\"id\": \"5155\"}, {\"id\": \"2667F\"}]"},{"content": "[{\"text\": [{\"en\": \"Obstacle on the tracks: T81-T97 are not operated between BAREEL and JANSON\", \"fr\": \"Obstacle sur les voies: T81-T97 Trafic interrompu entre BARRIERE et JANSON\", \"nl\": \"Obstakel op de sporen: T81-T97 Geen verkeer tussen BAREEL en JANSON\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"97\"}]", "priority": 2, "points": "[{\"id\": \"5917F\"}]"},{"content": "[{\"text\": [{\"en\": \"Obstacle on the tracks: T81-T97 are not operated between BAREEL and JANSON\", \"fr\": \"Obstacle sur les voies: T81-T97 Trafic interrompu entre BARRIERE et JANSON\", \"nl\": \"Obstakel op de sporen: T81-T97 Geen verkeer tussen BAREEL en JANSON\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"97\"}]", "priority": 2, "points": "[{\"id\": \"5953F\"}, {\"id\": \"6361\"}, {\"id\": \"5120\"}, {\"id\": \"5175\"}, {\"id\": \"6077F\"}, {\"id\": \"5123\"}, {\"id\": \"2604F\"}, {\"id\": \"5158\"}, {\"id\": \"5068F\"}, {\"id\": \"5066F\"}, {\"id\": \"2603\"}, {\"id\": \"2462F\"}, {\"id\": \"6427F\"}, {\"id\": \"9972F\"}, {\"id\": \"6430F\"}, {\"id\": \"5119\"}, {\"id\": \"6109\"}, {\"id\": \"2333F\"}, {\"id\": \"2463F\"}]"},{"content": "[{\"text\": [{\"en\": \"Obstacle on the tracks: T81-T97 are not operated between BAREEL and JANSON\", \"fr\": \"Obstacle sur les voies: T81-T97 Trafic interrompu entre BARRIERE et JANSON\", \"nl\": \"Obstakel op de sporen: T81-T97 Geen verkeer tussen BAREEL en JANSON\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"97\"}]", "priority": 2, "points": "[{\"id\": \"5156F\"}]"},{"content": "[{\"text\": [{\"en\": \"Obstacle on the tracks: T81-T97 are not operated between BAREEL and JANSON\", \"fr\": \"Obstacle sur les voies: T81-T97 Trafic interrompu entre BARRIERE et JANSON\", \"nl\": \"Obstakel op de sporen: T81-T97 Geen verkeer tussen BAREEL en JANSON\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"97\"}]", "priority": 2, "points": "[{\"id\": \"5116\"}]"},{"content": "[{\"text\": [{\"en\": \"Obstacle on the tracks: T81-T97 are not operated between BAREEL and JANSON\", \"fr\": \"Obstacle sur les voies: T81-T97 Trafic interrompu entre BARRIERE et JANSON\", \"nl\": \"Obstakel op de sporen: T81-T97 Geen verkeer tussen BAREEL en JANSON\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"81\"}]", "priority": 2, "points": "[{\"id\": \"6463F\"}]"},{"content": "[{\"text\": [{\"en\": \"Obstacle on the tracks: T81-T97 are not operated between BAREEL and JANSON\", \"fr\": \"Obstacle sur les voies: T81-T97 Trafic interrompu entre BARRIERE et JANSON\", \"nl\": \"Obstakel op de sporen: T81-T97 Geen verkeer tussen BAREEL en JANSON\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"97\"}]", "priority": 2, "points": "[{\"id\": \"6078\"}, {\"id\": \"6428F\"}, {\"id\": \"5018F\"}, {\"id\": \"5016F\"}, {\"id\": \"2404F\"}, {\"id\": \"6314\"}, {\"id\": \"2336G\"}, {\"id\": \"6162\"}]"},{"content": "[{\"text\": [{\"en\": \"Obstacle on the tracks: T81-T97 are not operated between BAREEL and JANSON\", \"fr\": \"Obstacle sur les voies: T81-T97 Trafic interrompu entre BARRIERE et JANSON\", \"nl\": \"Obstakel op de sporen: T81-T97 Geen verkeer tussen BAREEL en JANSON\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"97\"}]", "priority": 2, "points": "[{\"id\": \"5161F\"}]"},{"content": "[{\"text\": [{\"en\": \"Obstacle on the tracks: T81-T97 are not operated between BAREEL and JANSON\", \"fr\": \"Obstacle sur les voies: T81-T97 Trafic interrompu entre BARRIERE et JANSON\", \"nl\": \"Obstakel op de sporen: T81-T97 Geen verkeer tussen BAREEL en JANSON\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"97\"}]", "priority": 2, "points": "[{\"id\": \"5121F\"}]"},{"content": "[{\"text\": [{\"en\": \"Obstacle on the tracks: T81-T97 are not operated between BAREEL and JANSON\", \"fr\": \"Obstacle sur les voies: T81-T97 Trafic interrompu entre BARRIERE et JANSON\", \"nl\": \"Obstakel op de sporen: T81-T97 Geen verkeer tussen BAREEL en JANSON\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"97\"}]", "priority": 2, "points": "[{\"id\": \"2765\"}, {\"id\": \"2764G\"}]"},{"content": "[{\"text\": [{\"en\": \"Obstacle on the tracks: T81-T97 are not operated between BAREEL and JANSON\", \"fr\": \"Obstacle sur les voies: T81-T97 Trafic interrompu entre BARRIERE et JANSON\", \"nl\": \"Obstakel op de sporen: T81-T97 Geen verkeer tussen BAREEL en JANSON\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"97\"}]", "priority": 2, "points": "[{\"id\": \"5115F\"}]"},{"content": "[{\"text\": [{\"en\": \"Obstacle on the tracks: T81-T97 are not operated between BAREEL and JANSON\", \"fr\": \"Obstacle sur les voies: T81-T97 Trafic interrompu entre BARRIERE et JANSON\", \"nl\": \"Obstakel op de sporen: T81-T97 Geen verkeer tussen BAREEL en JANSON\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"97\"}]", "priority": 2, "points": "[{\"id\": \"5756F\"}, {\"id\": \"1258G\"}]"},{"content": "[{\"text\": [{\"en\": \"Obstacle on the tracks: T81-T97 are not operated between BAREEL and JANSON\", \"fr\": \"Obstacle sur les voies: T81-T97 Trafic interrompu entre BARRIERE et JANSON\", \"nl\": \"Obstakel op de sporen: T81-T97 Geen verkeer tussen BAREEL en JANSON\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"97\"}]", "priority": 2, "points": "[{\"id\": \"5916F\"}]"},{"content": "[{\"text\": [{\"en\": \"Obstacle on the tracks: T81-T97 are not operated between BAREEL and JANSON\", \"fr\": \"Obstacle sur les voies: T81-T97 Trafic interrompu entre BARRIERE et JANSON\", \"nl\": \"Obstakel op de sporen: T81-T97 Geen verkeer tussen BAREEL en JANSON\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"97\"}]", "priority": 2, "points": "[{\"id\": \"2708G\"}, {\"id\": \"5952F\"}, {\"id\": \"2709F\"}, {\"id\": \"2710G\"}, {\"id\": \"1984G\"}]"},{"content": "[{\"text\": [{\"en\": \"Obstacle on the tracks: T81-T97 are not operated between BAREEL and JANSON\", \"fr\": \"Obstacle sur les voies: T81-T97 Trafic interrompu entre BARRIERE et JANSON\", \"nl\": \"Obstakel op de sporen: T81-T97 Geen verkeer tussen BAREEL en JANSON\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"97\"}]", "priority": 2, "points": "[{\"id\": \"1985G\"}]"},{"content": "[{\"text\": [{\"en\": \"Obstacle on the tracks: T81-T97 are not operated between BAREEL and JANSON\", \"fr\": \"Obstacle sur les voies: T81-T97 Trafic interrompu entre BARRIERE et JANSON\", \"nl\": \"Obstakel op de sporen: T81-T97 Geen verkeer tussen BAREEL en JANSON\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"97\"}]", "priority": 2, "points": "[{\"id\": \"5722F\"}]"},{"content": "[{\"text\": [{\"en\": \"Obstacle on the tracks: T81-T97 are not operated between BAREEL and JANSON\", \"fr\": \"Obstacle sur les voies: T81-T97 Trafic interrompu entre BARRIERE et JANSON\", \"nl\": \"Obstakel op de sporen: T81-T97 Geen verkeer tussen BAREEL en JANSON\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"97\"}]", "priority": 2, "points": "[{\"id\": \"5723G\"}]"},{"content": "[{\"text\": [{\"en\": \"Obstacle on the tracks: T81-T97 are not operated between BAREEL and JANSON\", \"fr\": \"Obstacle sur les voies: T81-T97 Trafic interrompu entre BARRIERE et JANSON\", \"nl\": \"Obstakel op de sporen: T81-T97 Geen verkeer tussen BAREEL en JANSON\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"97\"}]", "priority": 2, "points": "[{\"id\": \"5719H\"}]"},{"content": "[{\"text\": [{\"en\": \"Obstacle on the tracks: T81-T97 are not operated between BAREEL and JANSON\", \"fr\": \"Obstacle sur les voies: T81-T97 Trafic interrompu entre BARRIERE et JANSON\", \"nl\": \"Obstakel op de sporen: T81-T97 Geen verkeer tussen BAREEL en JANSON\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"97\"}]", "priority": 2, "points": "[{\"id\": \"5163F\"}]"},{"content": "[{\"text\": [{\"en\": \"Obstacle on the tracks: T81-T97 are not operated between BAREEL and JANSON\", \"fr\": \"Obstacle sur les voies: T81-T97 Trafic interrompu entre BARRIERE et JANSON\", \"nl\": \"Obstakel op de sporen: T81-T97 Geen verkeer tussen BAREEL en JANSON\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"97\"}]", "priority": 2, "points": "[{\"id\": \"5164F\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. As of Apr 15, bus 12 diverted btw MEISER and LUXEMBOURG via MAELBEEK. Stop SCHUMAN moved rue Franklinstr.\", \"fr\": \"Travaux. D\u00e8s le 15/4, bus 12 d\u00e9vi\u00e9 entre MEISER et LUXEMBOURG via MAELBEEK. Arr\u00eat SCHUMAN d\u00e9plac\u00e9 rue Franklin.\", \"nl\": \"Werken. Vanaf 15/4, bus 12 omgeleid tss MEISER en LUXEMBURG via MAALBEEK. Halte SCHUMAN verplaatst Franklinstr.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"12\"}]", "priority": 6, "points": "[{\"id\": \"3017\"}, {\"id\": \"2695\"}, {\"id\": \"5048\"}, {\"id\": \"9600B\"}, {\"id\": \"2250\"}]"},{"content": "[{\"text\": [{\"en\": \"Bus 17: From Sep 5 6AM, works. Diversion between BRILLANT/BRILJANT and BEAULIEU via Michiels\", \"fr\": \"Bus 17: D\u00e8s le 5/9 6h, travaux. D\u00e9viation entre BRILLANT et BEAULIEU via Michiels\", \"nl\": \"Bus 17: Vanaf 5/9 6u, werken. Omleiding tussen BRILJANT en BEAULIEU via Michiels\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"17\"}]", "priority": 6, "points": "[{\"id\": \"9059\"}, {\"id\": \"4351\"}, {\"id\": \"4341\"}, {\"id\": \"1455\"}, {\"id\": \"4287\"}, {\"id\": \"4355\"}, {\"id\": \"4357\"}, {\"id\": \"4358\"}, {\"id\": \"4348\"}, {\"id\": \"4292\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. Until mid-2024, T19 interrupted at this stop. Stop of T-bus 19: av. Jette 232 (next to this stop)\", \"fr\": \"Travaux. Jusque mi-2024, T19 interrompu \u00e0 cet arr\u00eat. Arr\u00eat du T-bus 19: av. de Jette, 232 (\u00e0 c\u00f4t\u00e9 de cet arr\u00eat).\", \"nl\": \"Werken. Tot midden 2024, T19 onderbroken aan deze halte. Halte van T-bus 19: Jetselaan 232 (naast deze halte)\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"19\"}]", "priority": 4, "points": "[{\"id\": \"6865F\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. Until mid-2024, stop not served. T-bus at VERBEYST (bd de Smet de Naeyer 234, stop of bus 14 to UZ-VUB).\", \"fr\": \"Travaux. Jusque mi-2024, arr\u00eat non desservi. T-bus \u00e0 VERBEYST (bd de Smet de Naeyer 234, arr\u00eat B14 vers UZ-VUB).\", \"nl\": \"Werken. Tot midden 2024, halte niet bediend. T-bus aan VERBEYST (de Smet de Naeyerlaan 234, halte B14 naar UZ-VUB).\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"19\"}]", "priority": 4, "points": "[{\"id\": \"6867F\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. Until mid-2024, tram 19 replaced by T-bus btw DE WAND and MIROIR / SPIEGEL. Take T-bus at CIM. DE JETTE.\", \"fr\": \"Travaux. Jusque mi-2024, tram 19 remplac\u00e9 par des T-bus entre DE WAND et MIROIR. Prenez le T-bus \u00e0 CIMETIERE DE JETTE.\", \"nl\": \"Werken. Tot midden 2024, tram 19 vervangen door T-bus tss DE WAND en SPIEGEL. Neem de T-bus aan KERKHOF VAN JETTE\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"19\"}]", "priority": 4, "points": "[{\"id\": \"6800F\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. Until mid-2024, stop not served. T-bus at LEOPOLD I (bd de Smet de Naeyer 59), or T19 at MIROIR.\", \"fr\": \"Travaux, jusque mi-2024, arr\u00eat non desservi. T-bus \u00e0 LEOPOLD I (bd de Smet de Naeyer 59), ou T19 \u00e0 MIROIR.\", \"nl\": \"Werken. Tot midden 2024, halte niet bediend. T-bus aan LEOPOLD I (de Smet de Naeyerlaan 59), of T19 aan SPIEGEL.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"19\"}]", "priority": 4, "points": "[{\"id\": \"6804F\"}]"},{"content": "[{\"text\": [{\"en\": \"From Dec 4, works. STOP NOT SERVED. Take bus 20 at the previous stop, GARE DU NORD / NOORDSTATION.\", \"fr\": \"D\u00e8s le 4/12, travaux. ARRET NON DESSERVI. Prenez le bus 20 \u00e0 l'arr\u00eat pr\u00e9c\u00e9dent, GARE DU NORD.\", \"nl\": \"Vanaf 4/12, werken. HALTE NIET BEDIEND. Neem bus 20 aan de vorige halte, NOORDSTATION.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"20\"}]", "priority": 4, "points": "[{\"id\": \"3400\"}]"},{"content": "[{\"text\": [{\"en\": \"From Apr 29 at 7AM, works. STOP NOT SERVED. Take bus 21 at the stop DIAMANT of bus 28 to BRABANCONNE.\", \"fr\": \"D\u00e8s le 29/4,7h, travaux. ARRET NON DESSERVI. Prenez le bus 21 \u00e0 l'arr\u00eat DIAMANT du bus 28 vers BRABANCONNE.\", \"nl\": \"Vanaf 29/4, 7u, werken. HALTE NIET BEDIEND. Neem bus 21 aan de halte DIAMANT van bus 28 naar BRABANCONNE.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"21\"}]", "priority": 4, "points": "[{\"id\": \"6454\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. As of Apr 15, STOP NOT SERVED. Stop of bus 21: rue Archim\u00e8de / Archimedesstraat 16.\", \"fr\": \"Travaux. D\u00e8s le 15/4, ARRET NON DESSERVI. Arr\u00eat du bus 21: rue Archim\u00e8de 16.\", \"nl\": \"Werken. Vanaf 15/4, HALTE NIET BEDIEND. Halte van bus 21: Archimedesstraat 16.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"21\"}]", "priority": 4, "points": "[{\"id\": \"2083\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. As of Apr 15, bus 21 diverted btw TREVES and MICHEL-ANGE via MAELBEEK. Stop SCHUMAN moved rue Archim\u00e8de.\", \"fr\": \"Travaux. D\u00e8s le 15/4,bus 21 d\u00e9vi\u00e9 entre TREVES et MICHEL-ANGE via MAELBEEK. Arr\u00eat SCHUMAN d\u00e9plac\u00e9 rue Archim\u00e8de.\", \"nl\": \"Werken. Vanaf 15/4, bus 21 omgeleid tss TRIER en MICHELANGELO via MAALBEEK. Halte SCHUMAN verplaatst Archimedesstr\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"21\"}]", "priority": 6, "points": "[{\"id\": \"1132\"}, {\"id\": \"1262B\"}]"},{"content": "[{\"text\": [{\"en\": \"From Apr 29, 7AM,works. Bus 21 N05 diverted. Take the bus at the stop of bus 28 to BRABANCONNE.\", \"fr\": \"D\u00e8s le 29/4,7h, travaux. BUS 21 N05 DEVIES. Prenez le bus \u00e0 l'arr\u00eat du bus 28 vers BRABANCONNE.\", \"nl\": \"Vanaf 29/4, 7u, werken. Bus 21 N05 omgeleid. Neem de bus aan de halte van bus 28 naar BRABANCONNE.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"21\"}]", "priority": 4, "points": "[{\"id\": \"3707\"}]"},{"content": "[{\"text\": [{\"en\": \"From Apr 29, works. Bus 28 diverted. Bus 28 at STADE FALLON: chemin du Struykbekenweg.\", \"fr\": \"D\u00e8s le 29/4, travaux. Bus 28 d\u00e9vi\u00e9.. Bus 28 \u00e0 STADE FALLON: chemin du Struykbeken.\", \"nl\": \"Vanaf 29/4, werken. Bus 28 omgeleid. Bus 28 aan FALLON STADION: Struykbekenweg.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"28\"}]", "priority": 4, "points": "[{\"id\": \"1832\"}, {\"id\": \"1830\"}]"},{"content": "[{\"text\": [{\"en\": \"From Apr 29, works. STOP NOT SERVED. Go to KONKEL on foot.\", \"fr\": \"D\u00e8s le 29/4, travaux. ARRET NON DESSERVI. Continuez \u00e0 pied jusqu'\u00e0 KONKEL.\", \"nl\": \"Vanaf 29/4, werken. HALTE NIET BEDIEND. Ga te voet tot KONKEL.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"28\"}]", "priority": 4, "points": "[{\"id\": \"1415\"}, {\"id\": \"1831\"}]"},{"content": "[{\"text\": [{\"en\": \"From Jan 18, works. STOP NOT SERVED. Temporary stop: Avenue de Roodebeeklaan 45.\", \"fr\": \"D\u00e8s le 18/1, travaux. ARRET NON DESSERVI. Arr\u00eat provisoire: Avenue de Roodebeek 45.\", \"nl\": \"Vanaf 18/1, werken. HALTE NIET BEDIEND. Tijdelijke halte: Roodebeeklaan 45.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"28\"}]", "priority": 4, "points": "[{\"id\": \"1404\"}]"},{"content": "[{\"text\": [{\"en\": \"From FEB 2, works. Stop SAINT-JOSSE moved, go to the temporary stop: chauss\u00e9e de Louvain 73.\", \"fr\": \"D\u00e8s le 26/2, travaux. Arr\u00eat SAINT-JOSSE d\u00e9plac\u00e9, allez \u00e0 l'arr\u00eat provisoire : chauss\u00e9e de Louvain 73.\", \"nl\": \"Vanaf 26/2, werken. Halte SINT-JOOST verplaatst, ga naar de tijdelijke halte: Leuvensesteenweg 73.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"29\"}]", "priority": 4, "points": "[{\"id\": \"1570\"}]"},{"content": "[{\"text\": [{\"en\": \"From Apr 29, 7AM,works. STOP NOT SERVED. Take bus 29 at the stop PLASKY of bus 63 to GARE CENTRALE.\", \"fr\": \"D\u00e8s le 29/4,7h, travaux. ARRET NON DESSERVI. Prenez le bus 29 \u00e0 l'arr\u00eat PLASKY du bus 63 vers GARE CENTRALE.\", \"nl\": \"Vanaf 29/4, 7u, werken. HALTE NIET BEDIEND. Neem bus 29 aan de halte PLASKY van bus 63 naar CENTRAAL STATION.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"29\"}]", "priority": 4, "points": "[{\"id\": \"3367\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. As of April 7th, stop served only by bus 66. Take bus 29, 63 or 65 at the stop of bus 71 to DELTA.\", \"fr\": \"Travaux. D\u00e8s le 7/4, arr\u00eat uniquement desservi par bus 66. Bus 29, 63 ou 65 \u00e0 l'arr\u00eat du bus 71 vers DELTA.\", \"nl\": \"Werken. Vanaf 7/4, halte enkel bediend door bus 66. Neem bus 29, 63 of 65 aan de halte van bus 71 naar DELTA.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"29\"}]", "priority": 4, "points": "[{\"id\": \"6445\"}]"},{"content": "[{\"text\": [{\"en\": \"From Apr 29, 7AM, works. STOP NOT SERVED. Temporary stop: B29: avenue E. Plaskylaan 76.\", \"fr\": \"D\u00e8s 29/4 \u00e0 7h, travaux. ARRET NON DESSERVI. Arr\u00eat provisoire: avenue E. Plasky 76.\", \"nl\": \"Vanaf 29/4, 7u, werken. HALTE NIET BEDIEND. Tijdelijke halte: E. Plaskylaan 76.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"29\"}]", "priority": 4, "points": "[{\"id\": \"3366\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. STOP NOT OPERATED. Temporary stop: rue de Pavie / Paviastraat 53.\", \"fr\": \"Travaux. ARRET NON DESSERVI. Arr\u00eat provisoire: rue de Pavie 53.\", \"nl\": \"Werken. HALTE NIET BEDIEND. Tijdelijke halte: Paviastraat 53.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"29\"}]", "priority": 5, "points": "[{\"id\": \"1568\"}]"},{"content": "[{\"text\": [{\"en\": \"Jan 7, 9PM-Jun 28, works.Tram 3 diverted to the stop DOCKS BRUXSEL of tram 7 and replaced by T-bus to ESPLANADE.\", \"fr\": \"7/1, 21h-28/6, travaux. Tram 3 d\u00e9vi\u00e9 vers l'arr\u00eat DOCKS BRUXSEL du tram 7 et remplac\u00e9 par des T-bus jsq ESPLANADE.\", \"nl\": \"7/1, 21u-28/6, werken. Tram 3 omgeleid naar de halte DOCKS BRUXSEL van tram 7 en vervangen door T-bus tot ESPLANADE.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"3\"}]", "priority": 4, "points": "[{\"id\": \"2337F\"}]"},{"content": "[{\"text\": [{\"en\": \"Jan 7, 9PM-Jun 28, works. Stop not served. Stop  T-bus to ESPLANADE : av. Croix du Feu, crossing r. Heembeek.\", \"fr\": \"7/1, 21h-28/6, travaux. Arr\u00eat non desservi.Arr\u00eat T-bus vers ESPLANADE:av. Croix du Feu, carrefour rue de Heembeek.\", \"nl\": \"7/1, 21u-28/6, werken. Halte niet bediend.Halte T-bus naar ESPLANADE : Vuurkruisenlaan, kruispunt Heembeeklaan.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"3\"}]", "priority": 4, "points": "[{\"id\": \"5771\"}]"},{"content": "[{\"text\": [{\"en\": \"Jan 7, 9PM-Jun 28,works. Tram 3 interrupted btw ESPLANADE and DOCKS BRUXSEL. Stop of the T-bus: av. Araucarialn.\", \"fr\": \"7/1, 21h-28/6, travaux. Tram 3 interrompu entre ESPLANADE et DOCKS BRUXSEL. Arr\u00eat du T-bus: avenue de l'Araucaria.\", \"nl\": \"7/1, 21u-28/6, werken. Tram 3 onderbroken tss ESPLANADE en DOCKS BRUXSEL. Halte van de T-bus: Araucarialaan.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"3\"}]", "priority": 4, "points": "[{\"id\": \"5704F\"}]"},{"content": "[{\"text\": [{\"en\": \"Jan 7, 9PM-Jun 28,works. Tram 3 and 7 replaced by T-bus to DOCKS BRUXSEL. T-bus at this stop.\", \"fr\": \"7/1, 21h-28/6, travaux. Tram 3 et 7 remplac\u00e9s par des T-bus jusqu'\u00e0 DOCKS BRUXSEL. T-bus \u00e0 cet arr\u00eat.\", \"nl\": \"7/1, 21u-28/6, werken. Tram 3 en 7 vervangen door T-bus tot DOCKS BRUXSEL. T-bus aan deze halte.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"3\"}]", "priority": 4, "points": "[{\"id\": \"5707\"}]"},{"content": "[{\"text\": [{\"en\": \"From Jan 7 at 9PM to Jun 28, works. Tram 3 replaced by T-bus. Stop T-bus: av. Croix du Feu / Vuurkruisenln, 211-213\", \"fr\": \"Du 7/1 \u00e0 21h au 28/6, travaux. Tram 3 remplac\u00e9 par des T-bus. Arr\u00eat du T-bus: avenue des Croix du Feu, 211-213\", \"nl\": \"Van 7/1 om 21u tot en met 28/6, werken. Tram 3 vervangen door T-bus. Halte T-bus: Vuurkruisenlaan, 211-213\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"3\"}]", "priority": 4, "points": "[{\"id\": \"5773\"}]"},{"content": "[{\"text\": [{\"en\": \"From jan 15, works. STOP NOT SERVED. Take bus 34 at the stop CLESSE of bus 72 to ADEPS.\", \"fr\": \"D\u00e8s le 15/1, travaux. ARRET NON DESSERVI. Prenez le bus 34 \u00e0 l'arr\u00eat CLESSE du bus 72 vers ADEPS.\", \"nl\": \"Vanaf 15/1, werken. HALTE NIET BEDIEND. Neem bus 34 aan de halte CLESSE van bus 72 naar ADEPS.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"34\"}]", "priority": 4, "points": "[{\"id\": \"1719\"}]"},{"content": "[{\"text\": [{\"en\": \"From Apr 3 at 6AM, works. STOP NOT SERVED. Bus 38 at the stop LANGEVELD of bus 60 to AMBIORIX.\", \"fr\": \"D\u00e8s le 3/4 \u00e0 6h, travaux. ARRET NON DESSERVI. Bus 38 \u00e0 l'arr\u00eat LANGEVELD du bus 60 vers AMBIORIX.\", \"nl\": \"Vanaf 3/4 om 6u, werken. HALTE NIET BEDIEND. Bus 38 aan halte LANGEVELD van bus 60 naar AMBIORIX.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"38\"}]", "priority": 4, "points": "[{\"id\": \"1919\"}]"},{"content": "[{\"text\": [{\"en\": \"From Apr 3 at 6AM, works. STOP NOT SERVED. Bus 38 at the stop LANGEVELD of bus 60 to UCCLE CALEVOET.\", \"fr\": \"D\u00e8s le 3/4 \u00e0 6h, travaux. ARRET NON DESSERVI. Bus 38 \u00e0 l'arr\u00eat LANGEVELD du bus 60 vers UCCLE CALEVOET.\", \"nl\": \"Vanaf 3/4 om 6u, werken. HALTE NIET BEDIEND. Bus 38 aan halte LANGEVELD van bus 60 naar UKKEL KALEVOET.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"38\"}]", "priority": 4, "points": "[{\"id\": \"1971\"}]"},{"content": "[{\"text\": [{\"en\": \"From Apr 3 at 6AM, works. Bus 38 diverted between LONGCHAMP and HOUZEAU via rue Edith Cavellstraat.\", \"fr\": \"D\u00e8s le 3/4 \u00e0 6h, travaux. Bus 38 d\u00e9vi\u00e9 entre LONGCHAMP et HOUZEAU via rue Edith Cavell.\", \"nl\": \"Vanaf 3/4 om 6u, werken. Bus 38 omgeleid tussen LONGCHAMP en HOUZEAU via Edith Cavellstraat.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"38\"}]", "priority": 5, "points": "[{\"id\": \"1910\"}, {\"id\": \"3503\"}, {\"id\": \"1909\"}, {\"id\": \"1233\"}, {\"id\": \"6433\"}, {\"id\": \"3122\"}, {\"id\": \"1906\"}, {\"id\": \"1729\"}, {\"id\": \"1903\"}, {\"id\": \"1912\"}]"},{"content": "[{\"text\": [{\"fr\": \"Bon voyage sur nos lignes !\", \"nl\": \"Een goede reis op onze lijnen gewenst!\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"39\"}]", "priority": 9, "points": "[{\"id\": \"5519\"}]"},{"content": "[{\"text\": [{\"en\": \"Obstacle on the road: B41 diverted between BOONDAAL STATION and MONTANA direction HELDEN\", \"fr\": \"Obstacle sur la route: B41 d\u00e9vi\u00e9 entre BOONDAEL GARE et MONTANA direction HEROS\", \"nl\": \"Hindernis op de weg: B41 omgeleid tussen BOONDAAL STATION en MONTANA richting HELDEN\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"41\"}]", "priority": 2, "points": "[{\"id\": \"4310\"}]"},{"content": "[{\"text\": [{\"en\": \"Obstacle on the road: B41 diverted between BOONDAAL STATION and MONTANA direction HELDEN\", \"fr\": \"Obstacle sur la route: B41 d\u00e9vi\u00e9 entre BOONDAEL GARE et MONTANA direction HEROS\", \"nl\": \"Hindernis op de weg: B41 omgeleid tussen BOONDAAL STATION en MONTANA richting HELDEN\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"41\"}]", "priority": 2, "points": "[{\"id\": \"2080\"}, {\"id\": \"6440\"}, {\"id\": \"2076\"}, {\"id\": \"2074\"}, {\"id\": \"1921\"}, {\"id\": \"4408\"}, {\"id\": \"3549\"}, {\"id\": \"1942\"}, {\"id\": \"2721\"}, {\"id\": \"2115\"}, {\"id\": \"1723B\"}, {\"id\": \"2046\"}, {\"id\": \"6469\"}, {\"id\": \"4401\"}, {\"id\": \"4402\"}, {\"id\": \"4403\"}, {\"id\": \"5415\"}, {\"id\": \"5416\"}, {\"id\": \"4405\"}, {\"id\": \"2715\"}, {\"id\": \"1724\"}]"},{"content": "[{\"text\": [{\"en\": \"Obstacle on the road: B41 diverted between BOONDAAL STATION and MONTANA direction HELDEN\", \"fr\": \"Obstacle sur la route: B41 d\u00e9vi\u00e9 entre BOONDAEL GARE et MONTANA direction HEROS\", \"nl\": \"Hindernis op de weg: B41 omgeleid tussen BOONDAAL STATION en MONTANA richting HELDEN\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"41\"}]", "priority": 2, "points": "[{\"id\": \"1920\"}]"},{"content": "[{\"text\": [{\"en\": \"From Mar 4, works. Bus 43 and N11 diverted. Take the bus at GRIOTTES / NOORDKRIEKEN.\", \"fr\": \"D\u00e8s le 4/3, travaux. Bus 43 et N11 d\u00e9vi\u00e9s. Prenez le bus \u00e0 GRIOTTES.\", \"nl\": \"Vanaf 4/3, werken. Bus 43 en N11 omgeleid. Neem de bus aan NOORDKRIEKEN.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"43\"}]", "priority": 4, "points": "[{\"id\": \"1957B\"}, {\"id\": \"1933B\"}, {\"id\": \"1939\"}]"},{"content": "[{\"text\": [{\"en\": \"As from 21 Sept, works. Stop moved +-60m forwards.\", \"fr\": \"D\u00e8s le 21/9, travaux. Arr\u00eat avanc\u00e9 de +-60m.\", \"nl\": \"Vanaf 21/9, werken. Halte +-60m vooruitgebracht.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"45\"}]", "priority": 4, "points": "[{\"id\": \"3462\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. Until end of August, bus 46 not operated btw WTC-GLIBERT and CENTRAL STATION. Walk to the center.\", \"fr\": \"Travaux. Jsq fin ao\u00fbt, bus 46 ne circule pas entre WTC-GLIBERT et GARE CENTRALE.Pour le centre, continuez \u00e0 pied\", \"nl\": \"Werken. Tot einde augustus rijdt bus 46 niet tss WTC-GLIBERT en CENTRAAL STATION. Voor het centrum, ga te voet.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"46\"}]", "priority": 5, "points": "[{\"id\": \"2835\"}]"},{"content": "[{\"text\": [{\"en\": \"From Jan 22 at 7AM, works. STOP NOT SERVED. Stop of bus 46: rue de Laeken / Lakensestraat 34.\", \"fr\": \"D\u00e8s le 22/1 \u00e0 7h, travaux. ARRET NON DESSERVI. Arr\u00eat du bus 46: rue de Laeken 34.\", \"nl\": \"Van 22/1 om 7u, werken. HALTE NIET BEDIEND. Halte van bus 46: Lakensestraat 34.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"46\"}]", "priority": 4, "points": "[{\"id\": \"3469\"}]"},{"content": "[{\"text\": [{\"en\": \"From Feb 7, works. STOP NOT SERVED. Temporary stop: Vlierkensstraat 174.\", \"fr\": \"D\u00e8s le 7/2, travaux. ARRET NON DESSERVI. Arr\u00eat provisoire: Vlierkensstraat 174.\", \"nl\": \"Vanaf 7/2, werken. HALTE NIET BEDIEND. Tijdelijke halte: Vlierkensstraat 174.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"47\"}]", "priority": 4, "points": "[{\"id\": \"9605\"}]"},{"content": "[{\"text\": [{\"en\": \"From Jan 9th at 6AM, works. STOP UNSERVED. Go to the stop HOP. MILITAIR(E) HOSP. from B53.\", \"fr\": \"D\u00e8s le 9/1 \u00e0 6h, travaux. ARRET NON DESSERVI. Aller \u00e0 l'arr\u00eat HOP. MILITAIRE du B53.\", \"nl\": \"Vanaf 9/1 om 6u, werken. HALTE NIET BEDIEND. Ga naar de halte MILITAIR HOSP. van B53.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"47\"}]", "priority": 4, "points": "[{\"id\": \"3067\"}]"},{"content": "[{\"text\": [{\"en\": \"Until Summer of 2024, works. As of Mar 3, STOP NOT SERVED. Stop of bus 47 57: ANTOON VAN OSS.\", \"fr\": \"Jusqu'\u00e0 l'\u00e9t\u00e9 2024, travaux. D\u00e8s le 4/3, ARRET NON DESSERVI. Arr\u00eat des bus 47 57 : ANTOON VAN OSS.\", \"nl\": \"Tot zomer 2024, werken. Vanaf 4/3, HALTE NIET BEDIEND. Halte van bus 47 57: ANTOON VAN OSS\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"47\"}]", "priority": 4, "points": "[{\"id\": \"1827\"}]"},{"content": "[{\"text\": [{\"en\": \"Until Summer of 2024, works. Bus 47 diverted btw VTM and RAMIER. As of Mar 18, stop HOPITAL MILITAIRE in rue Bruyn.\", \"fr\": \"Jsq \u00e9t\u00e9 2024, travaux. Bus 47 d\u00e9vi\u00e9 entre VTM et RAMIER. D\u00e8s le 18/3, arr\u00eat HOPITAL MILITAIRE rue Bruyn.\", \"nl\": \"Tot zomer 2024, werken. Bus 47 omgeleid tussen VTM en BOSDUIF. Vanaf 18/3,halte MILITAIR HOSP in de Bruynstraat.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"47\"}]", "priority": 5, "points": "[{\"id\": \"9786\"}]"},{"content": "[{\"text\": [{\"en\": \"From Oct 7, works. STOP NOT OPERATED. Temporary stop: David Terniersstraat 115\", \"fr\": \"D\u00e8s le 7/10, travaux. ARRET NON DESSERVI. Arr\u00eat provisoire : David Terniersstraat 115\", \"nl\": \"Vanaf 7/10, werken. HALTE NIET BEDIEND. Tijdelijke halte: David Terniersstraat 115\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"47\"}]", "priority": 4, "points": "[{\"id\": \"9627\"}]"},{"content": "[{\"text\": [{\"en\": \"Until Summer of 2024, works. B47 diverted btw CHEMIN VERT and ANT VAN OSS. As of Mar 3, diverted to H. MILITAIRE\", \"fr\": \"Jsq \u00e9t\u00e9 2024, travaux. B47 d\u00e9vi\u00e9 entre CHEMIN VERT et ANTOON VAN OSS. D\u00e8s le 4/3, d\u00e9vi\u00e9 jsq HOPITAL MILITAIRE.\", \"nl\": \"Tot zomer 2024, werken. Bus 47 omgeleid tss GROENWEG en ANTOON VAN OSS. Vanaf 4/3, omgeleid tot MILITAIR HOSPITAAL\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"47\"}]", "priority": 5, "points": "[{\"id\": \"2314\"}]"},{"content": "[{\"text\": [{\"en\": \"Until Summer of 2024, works. Stop not served. Stop of bus 47: CROIX DE GUERRE / OORLOGSKRUISEN.\", \"fr\": \"Jusqu'\u00e0 l'\u00e9t\u00e9 2024, travaux. Arr\u00eat non desservi. Arr\u00eat du bus 47 : CROIX DE GUERRE.\", \"nl\": \"Tot zomer 2024, werken. Halte niet bediend. Halte van bus 47: OORLOGSKRUISEN.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"47\"}]", "priority": 4, "points": "[{\"id\": \"1987\"}]"},{"content": "[{\"text\": [{\"en\": \"Until Summer of 2024, works. Stop not served. Take bus 47 or 56 at ANTOON VAN OSS. For HOP MILITAIRE , walk.\", \"fr\": \"Jsq \u00e9t\u00e9 2024, travaux. Arr\u00eat non desservi. Bus 47 ou 56 \u00e0 ANTOON VAN OSS. Pour HOPITAL MILITAIRE, \u00e0 pied.\", \"nl\": \"Tot zomer 2024, werken. Halte niet bediend. Neem bus 47 of 56 aan ANTOON VAN OSS. Voor MILITAIR HOSPITAAL, ga te voet.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"47\"}]", "priority": 4, "points": "[{\"id\": \"1838\"}]"},{"content": "[{\"text\": [{\"en\": \"Until Summer of 2024, works. Stop not served. Stop of bus 47: VERGER / BOOMGAARD (av. Croix de Guerre/Oorlogskruisenln)\", \"fr\": \"Jusqu'\u00e0 l'\u00e9t\u00e9 2024, travaux. Arr\u00eat non desservi. Arr\u00eat du bus 47 : VERGER (avenue des Croix de Guerre).\", \"nl\": \"Tot zomer 2024, werken. Halte niet bediend. Halte van bus 47: BOOMGAARD (Oorlogskruisenlaan).\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"47\"}]", "priority": 4, "points": "[{\"id\": \"2312\"}, {\"id\": \"2363\"}]"},{"content": "[{\"text\": [{\"en\": \"From Apr 23 at 7AM, works. STOP NOT SERVED. Temporary stop: avenue Besmelaan 77.\", \"fr\": \"D\u00e8s le 23/4 \u00e0 7h, travaux. ARRET NON DESSERVI. Arr\u00eat provisoire: avenue Besme 77.\", \"nl\": \"Vanaf 23/4 om 7u, werken. HALTE NIET BEDIEND. Tijdelijke halte: Besmelaan 77.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"48\"}]", "priority": 4, "points": "[{\"id\": \"2408\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. From Apr 17 at 7AM, until May 10 at 5PM, stop moved av. Victor Besmelaan, before the roundabout.\", \"fr\": \"Travaux. Du 17/4 \u00e0 7h au 10/5 \u00e0 17h, arr\u00eat d\u00e9plac\u00e9 avenue Victor Besme, avant le rond-point\", \"nl\": \"Werken. Van 17/4 om 7u tot 10/5 om 17u, halte verplaatst naar de Victor Besmelaan, voor de rotonde.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"48\"}]", "priority": 4, "points": "[{\"id\": \"2459\"}]"},{"content": "[{\"text\": [{\"en\": \"From Apr 20, works. Stop not served. Take B49 next to number 26 (100m before this stop).\", \"fr\": \"D\u00e8s le 20/4, travaux. Arr\u00eat non desservi. Arr\u00eat du B49 \u00e0  hauteur du num\u00e9ro 26 (100 m avant cet arr\u00eat).\", \"nl\": \"Vanaf 20/4, werken. Halte niet bediend. Neem B49 ter hoogte van nummer 26 (100m voor deze halte).\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"49\"}]", "priority": 4, "points": "[{\"id\": \"2225\"}]"},{"content": "[{\"text\": [{\"en\": \"Until 2026, works. Bus 50 diverted to FOREST CENTRE / VORST CENTRUM. Stop of bus 50: r. Abbesses / Abdissenstr.\", \"fr\": \"Jusqu'en 2026, travaux. Bus 50 d\u00e9vi\u00e9 jusqu'\u00e0 FOREST CENTRE. Arr\u00eat du bus 50: rue des Abbesses.\", \"nl\": \"Tot 2026, werken. Bus 50 omgeleid tot VORST CENTRUM. Halte van bus 50: Abdissenstraat.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"50\"}]", "priority": 4, "points": "[{\"id\": \"5152\"}]"},{"content": "[{\"text\": [{\"en\": \"From Apr 22 at 12PM, works. STOP NOT SERVED. Stop of bus 50: avenue Paul Gilsonlaan, just before this stop.\", \"fr\": \"D\u00e8s 22/4 \u00e0 12h, travaux. ARRET NON DESSERVI. Arr\u00eat du bus 50: avenue Paul Gilson, peu avant cet arr\u00eat.\", \"nl\": \"Vanaf 22/4 om 12u, werken. HALTE NIET BEDIEND. Halte van bus 50: Paul Gilsonlaan, net voor deze halte.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"50\"}]", "priority": 4, "points": "[{\"id\": \"2609\"}]"},{"content": "[{\"text\": [{\"en\": \"Until Summer of 2024, works. Stop not served. Stop of bus 53: KRUIPWEG (rue du Paturage / Weilandstraat).\", \"fr\": \"Jusqu'\u00e0 l'\u00e9t\u00e9 2024, travaux. Arr\u00eat non desservi. Arr\u00eat du bus 53 : KRUIPWEG (rue du Paturage)\", \"nl\": \"Tot zomer 2024, werken. Halte niet bediend. Halte van bus 53: KRUIPWEG (Weilandstraat)\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"53\"}]", "priority": 4, "points": "[{\"id\": \"2312\"}, {\"id\": \"2363\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. From Apr 29 until May 8 at 7PM, STOP NOT SERVED. Stop of bus 54: avenue du Globelaan 43.\", \"fr\": \"Travaux. Du 29/4 au 8/5 \u00e0 19h, ARRET NON DESSERVI. Arr\u00eat du bus 54: avenue du Globe, 43.\", \"nl\": \"Werken. Van 29/4 tot 8/5 om 19u, HALTE NIET BEDIEND. Halte van bus 54: Globelaan 43.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"54\"}]", "priority": 4, "points": "[{\"id\": \"2953\"}]"},{"content": "[{\"text\": [{\"en\": \"From Apr 2, 2024 to June 2025, works. STOP NOT SERVED. To go to BERVOETS, take bus 50 or T-bus(stop: r. Abbesses)\", \"fr\": \"Du 2/4/2024 \u00e0 juin 2025, travaux. ARRET NON DESSERVI. Pour rejoindre BERVOETS,bus 50 ou T-bus (arr\u00eat: r. des Abbesses)\", \"nl\": \"Van 2/4/2024 tot juni 2025, werken. HALTE NIET BEDIEND. Voor BERVOETS, neem bus 50 of de T-bus (halte: Abdissenstraat)\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"54\"}]", "priority": 4, "points": "[{\"id\": \"5161\"}]"},{"content": "[{\"text\": [{\"en\": \"From Apr 2, 2024 to June 2025, works. STOP NOT SERVED. To go to BERVOETS, take bus 50 or T-bus at FOREST CENTRE.\", \"fr\": \"Du 2/4/2024 \u00e0 juin 2025, travaux. ARRET NON DESSERVI. Pour rejoindre BERVOETS, bus 50 ou T-bus \u00e0 FOREST CENTRE.\", \"nl\": \"Van 2/4/2024 tot juni 2025, werken. HALTE NIET BEDIEND. Voor BERVOETS, neem bus 50 of de T-bus aan VORST CENTRUM.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"54\"}]", "priority": 4, "points": "[{\"id\": \"5152\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. From Apr 2 until June 2025, STOP NOT SERVED. Take bus 54 at the previous stop, FOREST CENTRE.\", \"fr\": \"Travaux. Du 2/4 \u00e0 juin 2025, ARRET NON DESSERVI. Prenez le bus 54 \u00e0 l'arr\u00eat pr\u00e9c\u00e9dent, FOREST CENTRE.\", \"nl\": \"Werken. Vanaf 2/4 tot juni 2025, HALTE NIET BEDIEND. Neem bus 54 aan de vorige halte, VORST CENTRUM.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"54\"}]", "priority": 4, "points": "[{\"id\": \"5719\"}]"},{"content": "[{\"text\": [{\"en\": \"From Apr 11 at 7AM, works. STOP NOT SERVED. Take the tram at the stop that is installed 25m further.\", \"fr\": \"D\u00e8s le 11/4 \u00e0 7h, travaux. ARRET NON DESSERVI. Prenez le tram \u00e0 l'arr\u00eat avanc\u00e9 de 25m.\", \"nl\": \"Vanaf 11/4 om 7u, werken. HALTE NIET BEDIEND. Neem de tram 25 meter verder.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"55\"}]", "priority": 4, "points": "[{\"id\": \"2902\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. STOP NOT SERVED. Temporary stop: avenue des Croix de Guerre 78\", \"fr\": \"Jusqu'\u00e0 l'\u00e9t\u00e9 2024, travaux. Arr\u00eat des bus 47 et 56 : avenue des Croix de Guerre 78.\", \"nl\": \"Tot zomer 2024, werken. Halte van bus 47 en 56: Oorlogskruisenlaan 78.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"56\"}]", "priority": 4, "points": "[{\"id\": \"2377\"}, {\"id\": \"2299\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. STOP NOT SERVED. Take bus 47 56 at the usual stop of trams 3 7 direction CHURCHILL / VANDERKINDERE.\", \"fr\": \"Travaux. ARRET NON DESSERVI. Prenez le bus 47 56 \u00e0 l'arr\u00eat habituel des trams 3 7 vers CHURCHILL/VANDERKINDERE.\", \"nl\": \"Werken. HALTE NIET BEDIEND. Neem bus 47 56 aan de gebruikelijke halte van tram 3 7 naar CHURCHILL/VANDERKINDERE.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"56\"}]", "priority": 4, "points": "[{\"id\": \"6368C\"}]"},{"content": "[{\"text\": [{\"en\": \"Until Summer of 2024, works. Bus 56 diverted. Take bus 56 at ANTOON VAN OSS.\", \"fr\": \"Jusqu'\u00e0 l'\u00e9t\u00e9 2024, travaux. Bus 56 d\u00e9vi\u00e9. Prenez le bus 56 \u00e0 ANTOON VAN OSS.\", \"nl\": \"Tot zomer 2024, werken. Bus 56 omgeleid. Neem bus 56 aan ANTOON VAN OSS.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"56\"}]", "priority": 4, "points": "[{\"id\": \"1827\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. As of Apr 15, bus 56 diverted from AMBIORIX to MAELBEEK. Connection metro at MAELBEEK / MAALBEEK.\", \"fr\": \"Travaux. D\u00e8s le 15/4, bus 56 d\u00e9vi\u00e9 depuis AMBIORIX vers MAELBEEK. Correspondance m\u00e9tro \u00e0 MAELBEEK.\", \"nl\": \"Werken. Vanaf 15/4, bus 56 omgeleid vanaf AMBIORIX naar MAALBEEK. Aansluiting metro aan MAALBEEK.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"56\"}]", "priority": 6, "points": "[{\"id\": \"2092\"}, {\"id\": \"6461\"}, {\"id\": \"5740\"}, {\"id\": \"2100\"}, {\"id\": \"2067\"}, {\"id\": \"6191\"}, {\"id\": \"9291\"}, {\"id\": \"2097\"}, {\"id\": \"2096\"}, {\"id\": \"2094\"}, {\"id\": \"1007\"}, {\"id\": \"2920\"}, {\"id\": \"3414\"}, {\"id\": \"2105\"}, {\"id\": \"2102\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. As of March 18, bus 56 operates normally between HOP. MILITAIRE / MILITAIR HOSP. and ANTOON VAN OSS.\", \"fr\": \"Travaux. D\u00e8s le 18/3, bus 56 circule \u00e0 nouveau normalement entre HOPITAL MILITAIRE et ANTOON VAN OSS.\", \"nl\": \"Werken. Vanaf 18/3 rijdt B56 opnieuw langs zijn gebruikelijke reisweg tss MILITAIR HOSPITAAL en ANTOON VAN OSS.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"56\"}]", "priority": 5, "points": "[{\"id\": \"2365\"}, {\"id\": \"2827\"}, {\"id\": \"1989\"}]"},{"content": "[{\"text\": [{\"en\": \"Until Summer of 2024, works. Bus 56 diverted. Stop of bus 56: avenue des Croix de l'Yser / IJzerkruisenlaan 36.\", \"fr\": \"Jusqu'\u00e0 l'\u00e9t\u00e9 2024, travaux. Bus 56 d\u00e9vi\u00e9. Arr\u00eat du bus 56 : avenue des Croix de l'Yser 36.\", \"nl\": \"Tot zomer 2024, werken. Bus 56 omgeleid. Halte van bus 56: IJzerkruisenlaan 36.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"56\"}]", "priority": 4, "points": "[{\"id\": \"2093\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. As of Apr 15, STOP NOT SERVED. Take bus 56 at AMBIORIX (stop of bus 64 to Bordet Station).\", \"fr\": \"Travaux. D\u00e8s le 15/4, ARRET NON DESSERVI. Prenez le bus 56 \u00e0 AMBIORIX (arr\u00eat du bus 64 vers Bordet Station).\", \"nl\": \"Werken. Vanaf 15/4, HALTE NIET BEDIEND. Neem bus 56 aan AMBIORIX (halte van bus 64 naar Bordet Station).\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"56\"}]", "priority": 4, "points": "[{\"id\": \"1474B\"}, {\"id\": \"2083\"}]"},{"content": "[{\"text\": [{\"en\": \"Until Summer of 2024, works. Stop not served. Take bus 47 or 57 at ANTOON VAN OSS (stop of bus 56 to BUDA).\", \"fr\": \"Jsq \u00e9t\u00e9 2024, travaux. Arr\u00eat non desservi. Prenez le bus 47 ou 57 \u00e0 ANTOON VAN OSS (arr\u00eat du bus 56 vers BUDA).\", \"nl\": \"Tot zomer 2024, werken. Halte niet bediend. Neem bus 47 of 57 aan ANTOON VAN OSS (halte van bus 56 naar BUDA).\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"56\"}]", "priority": 4, "points": "[{\"id\": \"1837\"}]"},{"content": "[{\"text\": [{\"en\": \"Until Summer 2024,works. B56 diverted btw P. BENOIT and VAN PRAET. As of Mar 18, bus 56 serves the stop MERCATOR.\", \"fr\": \"Jsq \u00e9t\u00e9 2024, travaux. Bus 56 d\u00e9vi\u00e9 entre P. BENOIT et VAN PRAET. D\u00e8s le 18/3, bus 56 dessert \u00e0 nouveau MERCATOR.\", \"nl\": \"Tot zomer 2024, werken. Bus 56 omgeleid tss P. BENOIT en VAN PRAET. Vanaf 18/3 bedient bus 56 opnieuw MERCATOR.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"56\"}]", "priority": 4, "points": "[{\"id\": \"2379\"}, {\"id\": \"1991\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. Bus 56 diverted between VERGER and VAN PRAET via avenue des Croix de Guerre\", \"fr\": \"Travaux. Bus 56 d\u00e9vi\u00e9 entre VERGER et VAN PRAET via avenue des Croix de Guerre\", \"nl\": \"Werken. Bus 56 omgeleid tussen BOOMGAARD en VAN PRAET via Oorlogskruisenlaan\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"56\"}]", "priority": 5, "points": "[{\"id\": \"2823B\"}, {\"id\": \"2766\"}]"},{"content": "[{\"text\": [{\"en\": \"Until Summer of 2024, works. Stop not served. Stop of bus 57: chauss\u00e9e de Vilvorde, in front of number 150.\", \"fr\": \"Jusqu'\u00e0 l'\u00e9t\u00e9 2024, travaux. Arr\u00eat non desservi. Arr\u00eat du bus 57: ch\u00e9e de Vilvorde, en face du num\u00e9ro 150.\", \"nl\": \"Tot zomer 2024, werken. Halte niet bediend. Halte van bus 57: Vilvoordsesteenweg, tegenover nummer 150.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"57\"}]", "priority": 4, "points": "[{\"id\": \"3063\"}]"},{"content": "[{\"text\": [{\"en\": \"Until Summer of 2024, works. Stop not served. Take bus 47 or 56 at ANTOON VAN OSS. For HOP MILITAIRE , walk.\", \"fr\": \"Jsq \u00e9t\u00e9 2024, travaux. Arr\u00eat non desservi. Bus 47 ou 56 \u00e0 ANTOON VAN OSS. Pour HOPITAL MILITAIRE, \u00e0 pied.\", \"nl\": \"Tot zomer 2024, werken. Halte niet bediend. Neem bus 47 of 56 aan ANTOON VAN OSS. Voor MILITAIR HOSPITAAL, ga te voet.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"57\"}]", "priority": 4, "points": "[{\"id\": \"1838\"}]"},{"content": "[{\"text\": [{\"en\": \"From Dec 4, works. STOP NOT SERVED. Take bus 14 and 57 under the CCN building, at the terminus of bus 61.\", \"fr\": \"D\u00e8s le 4/12, travaux. ARRET NON DESSERVI. Prenez le bus 14 et 57 sous le b\u00e2timent CCN, au terminus du bus 61.\", \"nl\": \"Vanaf 4/12, werken. HALTE NIET BEDIEND. Neem bus 14 en 57 onder het CCN-gebouw, aan eindhalte bus 61.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"57\"}]", "priority": 4, "points": "[{\"id\": \"1082\"}]"},{"content": "[{\"text\": [{\"en\": \"Until Summer of 2024, works. As of Mar 18, stop served normally by bus 57.\", \"fr\": \"Jusqu'\u00e0 l'\u00e9t\u00e9 2024, travaux. D\u00e8s le 18/3, arr\u00eat \u00e0 nouveau desservi par les bus 57.\", \"nl\": \"Tot zomer 2024, werken. Vanaf 18/3, halte opnieuw bediend door bus 57.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"57\"}]", "priority": 4, "points": "[{\"id\": \"2352\"}]"},{"content": "[{\"text\": [{\"en\": \"Until Summer of 2024, works. Stop not served. Stop of bus 57: MARLY.\", \"fr\": \"Jsq \u00e9t\u00e9 2024, travaux. Arr\u00eat non desservi. Arr\u00eat du bus 57 : MARLY.\", \"nl\": \"Tot zomer 2024, werken. Halte niet bediend. Halte van bus 57: MARLY.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"57\"}]", "priority": 4, "points": "[{\"id\": \"2360\"}]"},{"content": "[{\"text\": [{\"en\": \"From Dec 4, works. STOP NOT SERVED. Take bus 58 at the stop WTC of bus 14 direction UZ-VUB.\", \"fr\": \"D\u00e8s le 4/12, travaux. ARRET NON DESSERVI. Prenez le bus 58 \u00e0 l'arr\u00eat WTC du bus 14 direction UZ-VUB.\", \"nl\": \"Vanaf 4/12, werken. HALTE NIET BEDIEND. Neem bus 58 aan de halte WTC van bus 14 richting UZ-VUB.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"58\"}]", "priority": 4, "points": "[{\"id\": \"3400\"}]"},{"content": "[{\"text\": [{\"en\": \"From Dec 4, works. STOP NOT SERVED. Stop of bus 58 and 88 : rue du Progr\u00e8s, after crossing rue des Charbonniers.\", \"fr\": \"D\u00e8s le 4/12, travaux. ARRET NON DESSERVI. Arr\u00eat des bus 58 et 88 : rue du Progr\u00e8s, apr\u00e8s rue des Charbonniers.\", \"nl\": \"Vanaf 4/12, werken. HALTE NIET BEDIEND. Halte bus 58 en 88 : Vooruitgangstraat, na Koolbrandersstraat.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"58\"}]", "priority": 4, "points": "[{\"id\": \"1083\"}]"},{"content": "[{\"text\": [{\"en\": \"From Oct 22, works. The stop is moved : Rue du Pavillon, 86. (Moved 20m forwards).\", \"fr\": \"A partir du 22/10, travaux. Arr\u00eat d\u00e9plac\u00e9 : rue du Pavillon, 86. (Avanc\u00e9 de 20m).\", \"nl\": \"Vanaf 22/10, werken. De halte is verplaatst : Palvijoenstraat, 86. (20m vooruitgebracht).\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"58\"}]", "priority": 4, "points": "[{\"id\": \"5741\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. As of Apr 24 at 6.30AM, STOP NOT SERVED. Stop of bus 59: rue Willemsstraat 9.\", \"fr\": \"Travaux. D\u00e8s le 24/4 \u00e0 6h30, ARRET NON DESSERVI. Arr\u00eat du bus 59: rue Willems, 9.\", \"nl\": \"Werken. Vanaf 24/4 om 6. 30u, HALTE NIET BEDIEND. Halte van bus 59: Willemsstraat 9.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"59\"}]", "priority": 4, "points": "[{\"id\": \"1582\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. As of Apr 24 at 6.30AM, bus 59 diverted between COTEAUX / WIJNHEUVELEN and GUTENBERG via DAILLY.\", \"fr\": \"Travaux. D\u00e8s le 24/4 \u00e0 6h30, bus 59 d\u00e9vi\u00e9 entre COTEAUX et GUTENBERG via BREMER et DAILLY.\", \"nl\": \"Werken. Vanaf 24/4 om 6. 30u, bus 59 omgeleid tussen WIJNHEUVELEN en GUTENBERG via BREMER en DAILLY.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"59\"}]", "priority": 5, "points": "[{\"id\": \"6461\"}, {\"id\": \"5298\"}, {\"id\": \"5740\"}, {\"id\": \"3101\"}, {\"id\": \"3111\"}, {\"id\": \"3099\"}, {\"id\": \"3098\"}, {\"id\": \"3109\"}, {\"id\": \"3106\"}, {\"id\": \"3126\"}, {\"id\": \"3104\"}, {\"id\": \"3103\"}, {\"id\": \"3102\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. As of Apr 24 at 6.30AM, bus 59 diverted between ST-JOSSE / ST-JOOST and COTEAUX / WIJNHEUVELEN via DAILLY.\", \"fr\": \"Travaux. D\u00e8s le 24/4 \u00e0 6h30, bus 59 d\u00e9vi\u00e9 entre SAINT-JOSSE et COTEAUX via DAILLY et BREMER.\", \"nl\": \"Werken. Vanaf 24/4 om 6. 30u, bus 59 omgeleid tussen SINT-JOOST en WIJNHEUVELEN via DAILLY en BREMER.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"59\"}]", "priority": 5, "points": "[{\"id\": \"1569B\"}, {\"id\": \"3081\"}, {\"id\": \"1280B\"}, {\"id\": \"3158B\"}, {\"id\": \"6464\"}, {\"id\": \"1476\"}, {\"id\": \"3125\"}, {\"id\": \"6158\"}, {\"id\": \"3156\"}, {\"id\": \"3155\"}, {\"id\": \"3160\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. As of Apr 24 at 6.30AM, STOP NOT SERVED. Stop of bus 59: rue des Eburons / Eburonenstraat 10.\", \"fr\": \"Travaux. D\u00e8s le 24/4 \u00e0 6h30, ARRET NON DESSERVI. Arr\u00eat du bus 59: rue des Eburons, 10\", \"nl\": \"Werken. Vanaf 24/4 om 6. 30u, HALTE NIET BEDIEND. Halte van bus 59: Eburonenstraat 10.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"59\"}]", "priority": 4, "points": "[{\"id\": \"3100\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. As of Apr 15, bus 60 diverted. Take bus 60 at the previous stop, at the St-Cyr house.\", \"fr\": \"Travaux. D\u00e8s le 15/4,bus 60 d\u00e9vi\u00e9. Prenez le bus 60 \u00e0 l'arr\u00eat pr\u00e9c\u00e9dent, devant la maison Saint-Cyr.\", \"nl\": \"Werken. Vanaf 15/4, bus 60 omgeleid. Neem bus 60 aan de vorige halte, voor het St-Cyr-huis.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"60\"}]", "priority": 4, "points": "[{\"id\": \"1273\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. As of Apr 15, STOP NOT SERVED. Take bus 60 at the stop of bus 27 to LUXEMBOURG / LUXEMBURG.\", \"fr\": \"Travaux. D\u00e8s le 15/4, ARRET NON DESSERVI. Prenez le bus 60 \u00e0 l'arr\u00eat du bus 27 vers LUXEMBOURG.\", \"nl\": \"Werken. Vanaf 15/4, HALTE NIET BEDIEND. Neem bus 60 aan de halte van bus 27 naar LUXEMBURG.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"60\"}]", "priority": 4, "points": "[{\"id\": \"1416\"}]"},{"content": "[{\"text\": [{\"en\": \"From Mar 5 at 9AM, works. STOP NOT SERVED. Temporary stop: avenue Jean & Pierre Carsoellaan 4.\", \"fr\": \"D\u00e8s le 5/3 \u00e0 9h, travaux. ARRET NON DESSERVI. Arr\u00eat provisoire: avenue Jean et Pierre Carsoel 4.\", \"nl\": \"Vanaf 5/3 om 9u, werken. HALTE NIET BEDIEND. Tijdelijke halte: Jean en Pierre Carsoellaan 4.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"60\"}]", "priority": 4, "points": "[{\"id\": \"6931B\"}]"},{"content": "[{\"text\": [{\"en\": \"From Mar 11, works. Bus 60 diverted between GROELSTVELD and DE WANSIJN via DIEWEG.\", \"fr\": \"D\u00e8s le 11/3, travaux. Bus 60 d\u00e9vi\u00e9 entre GROELSTVELD et DE WANSIJN via DIEWEG.\", \"nl\": \"Vanaf 11/3, werken. Bus 60 omgeleid tussen GROELSTVELD en DE WANSIJN via DIEWEG.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"60\"}]", "priority": 5, "points": "[{\"id\": \"2702\"}, {\"id\": \"2701\"}, {\"id\": \"1929\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. As of April 7th, stop served only by bus 66. Take bus 29, 63 or 65 at the stop of bus 71 to DELTA.\", \"fr\": \"Travaux. D\u00e8s le 7/4, arr\u00eat uniquement desservi par bus 66. Bus 29, 63 ou 65 \u00e0 l'arr\u00eat du bus 71 vers DELTA.\", \"nl\": \"Werken. Vanaf 7/4, halte enkel bediend door bus 66. Neem bus 29, 63 of 65 aan de halte van bus 71 naar DELTA.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"65\"}]", "priority": 4, "points": "[{\"id\": \"6445\"}]"},{"content": "[{\"text\": [{\"en\": \"From Apr 14 at 7AM, works. STOP NOT SERVED. Take bus 66 at the drop off stop.\", \"fr\": \"D\u00e8s le 14/4 \u00e0 7h, travaux. ARRET NON DESSERVI. Prenez le bus 66 \u00e0 l'arr\u00eat de d\u00e9barquement.\", \"nl\": \"Vanaf 14/4 om 7u, werken. HALTE NIET BEDIEND. Neem bus 66 aan de afstaphalte.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"66\"}]", "priority": 4, "points": "[{\"id\": \"3284\"}]"},{"content": "[{\"text\": [{\"en\": \"From Jan 8 to Jun 28, works. After CHURCHILL, tram 7 continues on line 3 direction ESPLANADE.\", \"fr\": \"Du 8/1 au 28/6, travaux. Apr\u00e8s CHURCHILL, tram 7 continue sur la ligne 3 direction ESPLANADE.\", \"nl\": \"Van 8/1 tot en met 28/6, werken. Na CHURCHILL rijdt tram 7 verder op lijn 3 richting ESPLANADE.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"7\"}]", "priority": 6, "points": "[{\"id\": \"5307H\"}, {\"id\": \"5317G\"}, {\"id\": \"5305G\"}, {\"id\": \"5220F\"}, {\"id\": \"5200F\"}, {\"id\": \"5266F\"}, {\"id\": \"3481\"}, {\"id\": \"0821\"}, {\"id\": \"0901\"}, {\"id\": \"2246F\"}, {\"id\": \"0801\"}, {\"id\": \"5306G\"}, {\"id\": \"5308F\"}, {\"id\": \"5210\"}, {\"id\": \"5211\"}, {\"id\": \"5758F\"}, {\"id\": \"5311\"}, {\"id\": \"5212\"}, {\"id\": \"5213\"}, {\"id\": \"5312\"}, {\"id\": \"1049F\"}, {\"id\": \"6457F\"}, {\"id\": \"5303\"}, {\"id\": \"5205\"}, {\"id\": \"5208\"}, {\"id\": \"9969F\"}, {\"id\": \"0811\"}]"},{"content": "[{\"text\": [{\"en\": \"Jan 8-Jun 28, works. Stop not served. Stop of tram 7: av. Croix du Feu in front of av. Pagodes.\", \"fr\": \"8/1-28/6, travaux. Arr\u00eat non desservi. Arr\u00eat du tram 7: avenue des Croix du Feu, \u00e0 hauteur de l'avenue des Pagodes.\", \"nl\": \"8/1-28/6, werken. Halte niet bediend. Halte van tram 7: Vuurkruisenlaan, ter hoogte van de Pagodenlaan.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"7\"}]", "priority": 5, "points": "[{\"id\": \"5771\"}]"},{"content": "[{\"text\": [{\"en\": \"Jan 8-Jun 28, works. Tram 7 interrupted btw HEEMBEEK and DOCKS BXL. Stop of the T-bus to DOCKS BXL: av. Araucaria\", \"fr\": \"8/1-28/6, travaux. T7 interrompu de HEEMBEEK \u00e0 DOCKS BRUXSEL. Arr\u00eat du T-bus vers DOCKS BRUXSEL: av. Araucaria\", \"nl\": \"8/1-28/6, werken. T7 onderbroken tss HEEMBEEK en DOCKS BRUXSEL. Halte T-bus naar DOCKS BRUXSEL: Araucarialaan.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"7\"}]", "priority": 5, "points": "[{\"id\": \"5704F\"}]"},{"content": "[{\"text\": [{\"en\": \"Jan 8-Jun 28, works. Stop not served. T-bus to HEEMBEEK and DE WAND at the stop of bus 56 to BUDA.\", \"fr\": \"8/1-28/6, travaux. Arr\u00eat non desservi. T-bus vers HEEMBEEK et DE WAND \u00e0 l'arr\u00eat du bus 56 vers BUDA.\", \"nl\": \"8/1-28/6, werken. Halte niet bediend. T-bus naar HEEMBEEK en DE WAND aan de halte van bus 56 naar BUDA.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"7\"}]", "priority": 5, "points": "[{\"id\": \"5770F\"}]"},{"content": "[{\"text\": [{\"en\": \"Jan 8-Jun 28, works. Tram 7 interrupted btw HEEMBEEK and DOCKS BXL. Stop T-bus to DOCKS BXL: next to this stop.\", \"fr\": \"8/1-28/6, travaux. T7 interrompu de HEEMBEEK \u00e0 DOCKS BXL. Arr\u00eat du T-bus vers DOCKS BXL: \u00e0 c\u00f4t\u00e9 de cet arr\u00eat.\", \"nl\": \"8/1-28/6, werken. T7 onderbroken tss HEEMBEEK en DOCKS BXL. Halte T-bus naar DOCKS BXL: naast deze halte.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"7\"}]", "priority": 5, "points": "[{\"id\": \"5705\"}]"},{"content": "[{\"text\": [{\"en\": \"Jan 8-Jun 28, works. Tram 7 replaced by T-bus between DOCKS BRUXSEL and HEEMBEEK. Info: stib-mivb.brussels\", \"fr\": \"8/1-28/6, travaux. Tram 7 remplac\u00e9 par des T-bus entre DOCKS BRUXSEL et HEEMBEEK. Info: stib. brussels.\", \"nl\": \"8/1-28/6, werken. Tram 7 vervangen door T-bus tussen DOCKS BRUXSEL en HEEMBEEK. info: mivb. brussels.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"7\"}]", "priority": 6, "points": "[{\"id\": \"5261\"}, {\"id\": \"5267\"}, {\"id\": \"5264F\"}, {\"id\": \"5256F\"}, {\"id\": \"5355F\"}, {\"id\": \"1048F\"}, {\"id\": \"5222F\"}, {\"id\": \"3480\"}, {\"id\": \"6456F\"}, {\"id\": \"5258\"}, {\"id\": \"0806\"}, {\"id\": \"5357\"}, {\"id\": \"0906\"}, {\"id\": \"5359\"}, {\"id\": \"0826\"}, {\"id\": \"5253\"}, {\"id\": \"5352\"}, {\"id\": \"5254\"}, {\"id\": \"5356\"}, {\"id\": \"5265F\"}, {\"id\": \"5221F\"}, {\"id\": \"5354H\"}, {\"id\": \"5255F\"}, {\"id\": \"5350G\"}, {\"id\": \"9963F\"}, {\"id\": \"0816\"}, {\"id\": \"2243F\"}]"},{"content": "[{\"text\": [{\"en\": \"Jan 7, 9PM-Jun 28,works. Stop not served. Stop T-bus to DOCKS BRUXSEL: av. Croix du Feu, crossing av. Pagodes.\", \"fr\": \"7/1, 21h-28/6, travaux. Arr\u00eat non desservi.Arr\u00eat du T-bus vers DOCKS BRUXSEL: av. Croix du Feu, carr. av. Pagodes.\", \"nl\": \"7/1, 21u-28/6, werken. Halte niet bediend.Halte van de T-bus naar DOCKS BRUXSEL: Vuurkruisenln, kruispt Pagodenln.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"7\"}]", "priority": 5, "points": "[{\"id\": \"5706\"}]"},{"content": "[{\"text\": [{\"en\": \"From Mar 18, works. STOP NOT SERVED. Temporary stop: avenue de la Couronne / Kroonlaan 439-443.\", \"fr\": \"D\u00e8s le 18/3, travaux. ARRET NON DESSERVI. Arr\u00eat provisoire: avenue de la Couronne 439-443.\", \"nl\": \"Vanaf 18/3, werken. HALTE NIET BEDIEND. Tijdelijke halte: Kroonlaan 439-443.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"72\"}]", "priority": 4, "points": "[{\"id\": \"3558\"}]"},{"content": "[{\"text\": [{\"en\": \"From Apr 2, 2024 to June 2025, works. STOP NOT SERVED. Stop of bus 74: av. du Globelaan 43.\", \"fr\": \"Du 2/4/2024 \u00e0 juin 2025, travaux. ARRET NON DESSERVI. Arr\u00eat du bus 74: avenue du Globe 43.\", \"nl\": \"Van 2/4/2024 tot juni 2025, werken. HALTE NIET BEDIEND. Halte van bus 74: Globelaan 43.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"74\"}]", "priority": 4, "points": "[{\"id\": \"2732\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. From Apr 2 until June 2025, STOP NOT SERVED. Take bus 74 at the previous stop, FOREST CENTRE.\", \"fr\": \"Travaux. Du 2/4 \u00e0 juin 2025, ARRET NON DESSERVI. Prenez le bus 74 \u00e0 l'arr\u00eat pr\u00e9c\u00e9dent, FOREST CENTRE.\", \"nl\": \"Werken. Vanaf 2/4 tot juni 2025, HALTE NIET BEDIEND. Neem bus 74 aan de vorige halte, VORST CENTRUM.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"74\"}]", "priority": 4, "points": "[{\"id\": \"5719\"}]"},{"content": "[{\"text\": [{\"en\": \"From Apr 2, 2024 to June 2025, works. STOP NOT SERVED. Stop of bus 74: FOREST NATIONAL (av. du Globelaan 43)\", \"fr\": \"Du 2/4/2024 \u00e0 juin 2025, travaux. ARRET NON DESSERVI. Arr\u00eat du bus 74: FOREST NATIONAL (avenue du Globe 43).\", \"nl\": \"Van 2/4/2024 tot juni 2025, werken. HALTE NIET BEDIEND. Halte van bus 74: VORST NATIONAAL (Globelaan 43)\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"74\"}]", "priority": 4, "points": "[{\"id\": \"2952B\"}]"},{"content": "[{\"text\": [{\"en\": \"Apr 2, 2024-June 2025, works. Bus 74 diverted between FOREST NATIONAL and FOREST CENTRE. Info: stib-mivb.brussels\", \"fr\": \"Du 2/4/2024 \u00e0 juin 2025, travaux. Bus 74 d\u00e9vi\u00e9 entre FOREST NATIONAL et FOREST CENTRE. Info: stib.brussels.\", \"nl\": \"2/4/2024-juni 2025, werken. Bus 74 omgeleid tussen VORST NATIONAAL en VORST CENTRUM. Info: mivb.brussels\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"74\"}]", "priority": 5, "points": "[{\"id\": \"2632\"}, {\"id\": \"2453\"}, {\"id\": \"2452\"}]"},{"content": "[{\"text\": [{\"en\": \"From Mar 18, works. Bus 74 limited to DECROLY. Walk to UCCLE-STALLE / UKKEL-STALLE.\", \"fr\": \"D\u00e8s le 18/3, travaux. Bus 74 limit\u00e9 \u00e0 DECROLY. Continuez \u00e0 pied jusqu'\u00e0 UCCLE-STALLE.\", \"nl\": \"Vanaf 18/3, werken. Bus 74 beperkt tot DECROLY. Ga te voet tot UKKEL-STALLE.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"74\"}]", "priority": 4, "points": "[{\"id\": \"2416\"}, {\"id\": \"2415\"}, {\"id\": \"2414\"}]"},{"content": "[{\"text\": [{\"en\": \"From Apr 2, 2024 to June 2025, works. STOP NOT SERVED. Stop of bus 74: FOREST NATIONAL (av. du Globelaan 8).\", \"fr\": \"Du 2/4/2024 \u00e0 juin 2025, travaux. ARRET NON DESSERVI. Arr\u00eat des bus 74: FOREST NATIONAL. (avenue du Globe 8).\", \"nl\": \"Van 2/4/2024 tot juni 2025, werken. HALTE NIET BEDIEND. Halte van bus 74: VORST NATIONAAL (Globelaan 8)\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"74\"}]", "priority": 4, "points": "[{\"id\": \"2939B\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. As of Apr 15, bus 79 diverted from MICHEL-ANGE to MAELBEEK. Stop SCHUMAN moved rue Franklin.\", \"fr\": \"Travaux. D\u00e8s le 15/4, bus 79 d\u00e9vi\u00e9 depuis MICHEL-ANGE vers MAELBEEK. Arr\u00eat SCHUMAN d\u00e9plac\u00e9 rue Franklin.\", \"nl\": \"Werken. Vanaf 15/4, bus 79 omgeleid vanaf MICHELANGELO naar MAALBEEK. Halte SCHUMAN verplaatst Franklinstr.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"79\"}]", "priority": 6, "points": "[{\"id\": \"6450\"}, {\"id\": \"6055\"}, {\"id\": \"9853\"}, {\"id\": \"1462\"}, {\"id\": \"2043\"}, {\"id\": \"2042\"}, {\"id\": \"2041\"}, {\"id\": \"3902\"}, {\"id\": \"3903\"}, {\"id\": \"3904\"}, {\"id\": \"2028\"}, {\"id\": \"3905\"}, {\"id\": \"1533\"}, {\"id\": \"1531\"}, {\"id\": \"1464\"}, {\"id\": \"1463\"}, {\"id\": \"1320\"}, {\"id\": \"3920\"}, {\"id\": \"3911\"}, {\"id\": \"1339\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. From Apr 29 at 7AM until May 3 at 5PM, bus 80 diverted between CARENE / CARINA and FEVRIER / FEBRUARI.\", \"fr\": \"Travaux. Du 29/4 \u00e0 7h au 3/5 \u00e0 17h, bus 80 d\u00e9vi\u00e9 entre CARENE et FEVRIER.\", \"nl\": \"Werken. Van 29/4 om 7u tot 3/5 om 17u, bus 80 omgeleid tussen CARINA en FEBRUARI.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"80\"}]", "priority": 5, "points": "[{\"id\": \"2988\"}, {\"id\": \"3207\"}, {\"id\": \"2292B\"}, {\"id\": \"5362\"}, {\"id\": \"3210B\"}, {\"id\": \"5045\"}, {\"id\": \"3401\"}, {\"id\": \"2895\"}, {\"id\": \"2908B\"}, {\"id\": \"3200\"}, {\"id\": \"3176\"}, {\"id\": \"3898\"}]"},{"content": "[{\"text\": [{\"en\": \"T81-T97 operate normally againBAREEL and JANSON\", \"fr\": \"T81-T97 circulent \u00e0 nouveau entre BARRIERE et JANSON\", \"nl\": \"T81-T97 worden weer bediend tussen BAREEL en JANSON\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"81\"}]", "priority": 3, "points": "[{\"id\": \"6153\"}, {\"id\": \"6175\"}, {\"id\": \"6078\"}, {\"id\": \"6809F\"}, {\"id\": \"1042\"}, {\"id\": \"3370F\"}, {\"id\": \"3572F\"}, {\"id\": \"2220F\"}, {\"id\": \"6157F\"}, {\"id\": \"2931F\"}, {\"id\": \"6009\"}, {\"id\": \"6155F\"}, {\"id\": \"6166\"}, {\"id\": \"6165\"}, {\"id\": \"3610F\"}, {\"id\": \"6068\"}, {\"id\": \"2218F\"}, {\"id\": \"6808G\"}, {\"id\": \"6162\"}, {\"id\": \"2671F\"}, {\"id\": \"2285G\"}, {\"id\": \"6425F\"}, {\"id\": \"2380F\"}, {\"id\": \"2217F\"}, {\"id\": \"6810\"}, {\"id\": \"6156F\"}, {\"id\": \"6158H\"}, {\"id\": \"6811\"}, {\"id\": \"2336G\"}, {\"id\": \"3608\"}, {\"id\": \"3609F\"}, {\"id\": \"6792F\"}, {\"id\": \"2972F\"}, {\"id\": \"0636\"}]"},{"content": "[{\"text\": [{\"en\": \"Until 2026,works.Tram 82 replaced by T-bus btw FOREST CENTRE / VORST CENTRUM and DROGENBOS. More info: stib-mivb.be.\", \"fr\": \"Jusqu'en 2026, travaux. Tram 82 remplac\u00e9 par des T-bus entre FOREST CENTRE et DROGENBOS. Info: stib.brussels.\", \"nl\": \"Tot 2026, werken. Tram 82 wordt vervangen door T-bus tussen VORST CENTRUM en DROGENBOS. Info: mivb.brussels.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"82\"}]", "priority": 4, "points": "[{\"id\": \"5163F\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. Until 2026, stop not served. Stop of the T-bus: Grote Baan 227 (stop of De Lijn to Anderlecht).\", \"fr\": \"Travaux. Jsq 2026, arr\u00eat non desservi. Arr\u00eat du T-bus: Grand'Route 227 (arr\u00eat des bus De Lijn vers Anderlecht).\", \"nl\": \"Werken. Tot 2026, halte niet bediend. Halte van de T-bus: Grote Baan 227 (halte van De Lijn naar Anderlecht).\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"82\"}]", "priority": 4, "points": "[{\"id\": \"5732F\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. Until 2026, tram 82 and 97 interrupted. Stop of the T-bus and of bus 50: ch. de Neerstalsestwg 236.\", \"fr\": \"Travaux. Jsq 2026, tram 82 et 97 interrompus. Arr\u00eat du T-bus et du bus 50: chauss\u00e9e de Neerstalle 236\", \"nl\": \"Werken. Tot 2026, tram 82 en 97 onderbroken. Halte van de T-bus en van bus 50: Neerstalsesteenweg 236\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"82\"}]", "priority": 4, "points": "[{\"id\": \"5164F\"}]"},{"content": "[{\"text\": [{\"en\": \"Until 2026, works. T-bus 82/97 diverted. Stop T-bus 82/97: bd 2e Arm\u00e9e Britannique / Britse Tweedelegerlaan.\", \"fr\": \"Jsq 2026, travaux. T-bus 82/97 d\u00e9vi\u00e9. Arr\u00eat T-bus 82/97: bd 2e Arm\u00e9e Britannique, carrefour rue de la Station.\", \"nl\": \"Tot 2026, werken. T-bus 82/97 omgeleid. Halte T-bus 82/97: Britse Tweedelegerlaan, kruispunt Stationstraat.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"82\"}]", "priority": 4, "points": "[{\"id\": \"5719H\"}]"},{"content": "[{\"text\": [{\"en\": \"As of Nov 16 at 6AM, works. Stop moved to av. Port / Havenln, in front of number 100 (moved backward of +/- 120m)\", \"fr\": \"D\u00e8s le 16/11 \u00e0 6h, travaux. Arr\u00eat d\u00e9plac\u00e9 avenue du Port, en face du num\u00e9ro 100 (recul\u00e9 de +/- 120m).\", \"nl\": \"Vanaf 16/11 om 6u,werken Halte verplaatst naar de Havenlaan, tegenover nr 100 (achteruitgebracht van +/- 120m)\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"86\"}]", "priority": 4, "points": "[{\"id\": \"2305\"}]"},{"content": "[{\"text\": [{\"en\": \"Jan 22, 6AM-end of June, works. Bus 86 diverted between GARE DE L'OUEST/ WESTSTATION and SUZAN DANIEL via ETANGS NOIRS.\", \"fr\": \"Du 22/1 \u00e0 6h jusqu'\u00e0 fin juin, travaux. Bus 86 d\u00e9vi\u00e9 entre GARE DE L'OUEST et SUZAN DANIEL via ETANGS NOIRS.\", \"nl\": \"Van 22/1 om 6u tot eind juni, werken. Bus 86 omgeleid tussen WESTSTATION-SUZAN DANIEL via ZWARTE VIJVERS.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"86\"}]", "priority": 5, "points": "[{\"id\": \"3238\"}, {\"id\": \"3234\"}, {\"id\": \"3253\"}, {\"id\": \"3252\"}, {\"id\": \"3282\"}, {\"id\": \"3281\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. As of Apr 22 at 9.30AM, bus 89 diverted btw TRIANGLE and QUATRE- VENTS. For DUCHESSE, T82 at TRIANGLE.\", \"fr\": \"Travaux. D\u00e8s le 22/4 \u00e0 9h30, bus 89 d\u00e9vi\u00e9 entre TRIANGLE et QUATRE- VENTS. Pour DUCHESSE, tram 82 \u00e0 TRIANGLE.\", \"nl\": \"Werken. Vanaf 22/4 om 9. 30u, bus 89 omgeleid tussen DRIEHOEK en VIER WINDEN. Voor HERTOGIN, tram 82 aan DRIEHOEK.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"89\"}]", "priority": 5, "points": "[{\"id\": \"1895\"}, {\"id\": \"3223B\"}, {\"id\": \"3222\"}, {\"id\": \"3221\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. As of Apr 22 at 9.30AM, bus 89 diverted btw TRIANGLE and QUATRE- VENTS. For DUCHESSE, T82 at TRIANGLE.\", \"fr\": \"Travaux. D\u00e8s le 22/4 \u00e0 9h30, bus 89 d\u00e9vi\u00e9 entre TRIANGLE et QUATRE- VENTS. Pour DUCHESSE, tram 82 \u00e0 TRIANGLE.\", \"nl\": \"Werken. Vanaf 22/4 om 9. 30u, bus 89 omgeleid tussen DRIEHOEK en VIER WINDEN. Voor HERTOGIN, tram 82 aan DRIEHOEK.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"89\"}]", "priority": 5, "points": "[{\"id\": \"3347\"}, {\"id\": \"2301\"}, {\"id\": \"2595\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. From Apr 26 at 9PM until May 12, tram 9 replaced by T-bus btw UZ BRUSSEL and ROI BAUDOUIN / KONING BOUDEWIJN.\", \"fr\": \"Travaux. Du 26/4 \u00e0 21h au 12/5, tram 9 remplac\u00e9 par des T-bus entre UZ BRUSSEL et ROI BAUDOUIN.\", \"nl\": \"Werken. Van 26/4 om 21u tot en met 12/5, tram 9 vervangen door T-bus tussen UZ BRUSSEL en KONING BOUDEWIJN.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"9\"}]", "priority": 5, "points": "[{\"id\": \"1681F\"}, {\"id\": \"1679F\"}, {\"id\": \"0470F\"}, {\"id\": \"6864F\"}, {\"id\": \"6865F\"}, {\"id\": \"1675F\"}, {\"id\": \"1677F\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. From Apr 26 at 9PM until May 12, stop not served. T-bus to ROI BAUDOUIN at the stop of bus 83 to VAL MARIA.\", \"fr\": \"Travaux. Du 26/4 \u00e0 21h au 12/5, arr\u00eat non desservi. T-bus vers ROI BAUDOUIN \u00e0 l'arr\u00eat du bus 83 vers VAL MARIA.\", \"nl\": \"Werken. 26/4, 21u-12/5, halte niet bediend.T-bus naar KONING BOUDEWIJN aan de halte van bus 83 naar MARIENDAAL.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"9\"}]", "priority": 4, "points": "[{\"id\": \"1691F\"}, {\"id\": \"1689F\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. Apr 26, 9PM-May 12, stop not served. Stop of the T-bus: PALFIJN (stop of bus 83 to GARE DE BERCHEM).\", \"fr\": \"Travaux. 26/4, 21h-12/5, arr\u00eat non desservi. Arr\u00eat du T-bus: PALFIJN (arr\u00eat du bus 83 vers GARE DE BERCHEM).\", \"nl\": \"Werken. 26/4, 21u-12/5, halte niet bediend. Halte van de T-bus: PALFIJN (halte van bus 83 naar STATION BERCHEM)\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"9\"}]", "priority": 4, "points": "[{\"id\": \"1692F\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. Apr 26, 9PM-May 12, stop not served. T-bus to UZ BRUSSEL at the stop of bus 83 to GARE DE BERCHEM.\", \"fr\": \"Travaux. Du 26/4 \u00e0 21h au 12/5, arr\u00eat non desservi. T-bus vers UZ BRUSSEL \u00e0 l'arr\u00eat du bus 83 vers GARE DE BERCHEM.\", \"nl\": \"Werken. 26/4, 21u-12/5, halte niet bediend.T-bus naar UZ BRUSSEL aan de halte van bus 83 naar STATION BERCHEM.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"9\"}]", "priority": 4, "points": "[{\"id\": \"1690F\"}, {\"id\": \"1695F\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. From Apr 26 at 9PM until May 12, stop not served. Take tram 9 at the next stop, UZ BRUSSEL.\", \"fr\": \"Travaux. Du 26/4 \u00e0 21h au 12/5, arr\u00eat non desservi. Prenez le tram 9 \u00e0 l'arr\u00eat suivant, UZ BRUSSEL.\", \"nl\": \"Werken. Van 26/4 om 21u tot en met 12/5, halte niet bediend. Neem tram 9 aan de volgende halte, UZ BRUSSEL.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"9\"}]", "priority": 4, "points": "[{\"id\": \"1684F\"}]"},{"content": "[{\"text\": [{\"en\": \"T81-T97 operate normally againBAREEL and JANSON\", \"fr\": \"T81-T97 circulent \u00e0 nouveau entre BARRIERE et JANSON\", \"nl\": \"T81-T97 worden weer bediend tussen BAREEL en JANSON\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"97\"}]", "priority": 3, "points": "[{\"id\": \"5152G\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. As of Apr 15, STOP NOT SERVED. Stop of bus 12: rue Franklinstraat 2a.\", \"fr\": \"Travaux. D\u00e8s le 15/4, ARRET NON DESSERVI. Arr\u00eat du bus 12: rue Franklin, 2a.\", \"nl\": \"Werken. Vanaf 15/4, HALTE NIET BEDIEND. Halte van bus 12: Franklinstraat 2a.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"12\"}]", "priority": 4, "points": "[{\"id\": \"1270B\"}]"},{"content": "[{\"text\": [{\"en\": \"T81-T97 operate normally againBAREEL and JANSON\", \"fr\": \"T81-T97 circulent \u00e0 nouveau entre BARRIERE et JANSON\", \"nl\": \"T81-T97 worden weer bediend tussen BAREEL en JANSON\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"97\"}]", "priority": 3, "points": "[{\"id\": \"5154F\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. As of Apr 15, B12 diverted btw LUXEMBOURG and MEISER via MAELBEEK. Stop SCHUMAN moved rue Archim\u00e8destr. 16.\", \"fr\": \"Travaux. D\u00e8s le 15/4,B12 d\u00e9vi\u00e9 entre LUXEMBOURG et MEISER via MAELBEEK. Arr\u00eat SCHUMAN d\u00e9plac\u00e9 rue Archim\u00e8de 16.\", \"nl\": \"Werken. Vanaf 15/4, bus 12 omgeleid ts LUXEMBURG en MEISER via MAALBEEK. Halte SCHUMAN verplaatst Archimedesstraat 16.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"12\"}]", "priority": 6, "points": "[{\"id\": \"6433\"}, {\"id\": \"1780\"}, {\"id\": \"1131B\"}]"},{"content": "[{\"text\": [{\"en\": \"T81-T97 operate normally againBAREEL and JANSON\", \"fr\": \"T81-T97 circulent \u00e0 nouveau entre BARRIERE et JANSON\", \"nl\": \"T81-T97 worden weer bediend tussen BAREEL en JANSON\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"97\"}]", "priority": 3, "points": "[{\"id\": \"2334F\"}]"},{"content": "[{\"text\": [{\"en\": \"From Dec 4, works. STOP NOT SERVED. Take bus 14 and 57 under the CCN building, at the terminus of bus 61.\", \"fr\": \"D\u00e8s le 4/12, travaux. ARRET NON DESSERVI. Prenez le bus 14 et 57 sous le b\u00e2timent CCN, au terminus du bus 61.\", \"nl\": \"Vanaf 4/12, werken. HALTE NIET BEDIEND. Neem bus 14 en 57 onder het CCN-gebouw, aan eindhalte bus 61.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"14\"}]", "priority": 4, "points": "[{\"id\": \"1082\"}]"},{"content": "[{\"text\": [{\"en\": \"T81-T97 operate normally againBAREEL and JANSON\", \"fr\": \"T81-T97 circulent \u00e0 nouveau entre BARRIERE et JANSON\", \"nl\": \"T81-T97 worden weer bediend tussen BAREEL en JANSON\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"97\"}]", "priority": 3, "points": "[{\"id\": \"5756F\"}, {\"id\": \"1258G\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. As of Mar 27, STOP MOVED. Stop of bus 17: rue des Thuyas / Thujastraat 13.\", \"fr\": \"Travaux. D\u00e8s le 27/3, ARRET DEPLACE. Arr\u00eat du bus 17: rue des Thuyas, 13.\", \"nl\": \"Werken. Vanaf 27/3, HALTE VERPLAATST. Halte van bus 17: Thujastraat 13.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"17\"}]", "priority": 4, "points": "[{\"id\": \"4310\"}]"},{"content": "[{\"text\": [{\"en\": \"T81-T97 operate normally againBAREEL and JANSON\", \"fr\": \"T81-T97 circulent \u00e0 nouveau entre BARRIERE et JANSON\", \"nl\": \"T81-T97 worden weer bediend tussen BAREEL en JANSON\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"97\"}]", "priority": 3, "points": "[{\"id\": \"5116\"}]"},{"content": "[{\"text\": [{\"en\": \"From Sep 5 6AM, works. STOP NOT SERVED. Temporary stop: av. Charles Michiels across no. 205\", \"fr\": \"D\u00e8s le 5/9 6h, travaux. ARRET NON DESSERVI. Arr\u00eat provisoire : av. Charles Michiels face au num. 205\", \"nl\": \"Vanaf 5/9 6u, werken. HALTE NIET BEDIEND. Tijdelijke halte: Charles Michielslaan tegenover nr. 205\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"17\"}]", "priority": 4, "points": "[{\"id\": \"4294\"}]"},{"content": "[{\"text\": [{\"en\": \"T81-T97 operate normally againBAREEL and JANSON\", \"fr\": \"T81-T97 circulent \u00e0 nouveau entre BARRIERE et JANSON\", \"nl\": \"T81-T97 worden weer bediend tussen BAREEL en JANSON\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"97\"}]", "priority": 3, "points": "[{\"id\": \"5156F\"}]"},{"content": "[{\"text\": [{\"en\": \"Wroks. Until mid-2024, stop not served. T-bus at LEOPOLD I (bd de Smet de Naeyer 54, stop of bus 14 to UZ-VUB).\", \"fr\": \"Travaux. Jusque mi-2024, arr\u00eat non desservi. T-bus \u00e0 LEOPOLD I (bd de Smet de Naeyer 54, arr\u00eat du bus 14 vers UZ-VUB).\", \"nl\": \"Werken. Tot midden 2024, halte niet bediend. T-bus aan LEOPOLD I (de Smet de Naeyerlaan 54, halte B14 naar UZ-VUB).\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"19\"}]", "priority": 4, "points": "[{\"id\": \"6866F\"}]"},{"content": "[{\"text\": [{\"en\": \"T81-T97 operate normally againBAREEL and JANSON\", \"fr\": \"T81-T97 circulent \u00e0 nouveau entre BARRIERE et JANSON\", \"nl\": \"T81-T97 worden weer bediend tussen BAREEL en JANSON\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"97\"}]", "priority": 3, "points": "[{\"id\": \"5115F\"}]"},{"content": "[{\"text\": [{\"en\": \"From Apr 29, 7AM,works. STOP NOT SERVED. Take bus 21 at the stop VICTOR HUGO of bus 28 to BRABANCONNE.\", \"fr\": \"D\u00e8s le 29/4,7h, travaux. ARRET NON DESSERVI. Prenez le bus 21 \u00e0 l'arr\u00eat VICTOR HUGO du bus 28 vers BRABANCONNE.\", \"nl\": \"Vanaf 29/4, 7u, werken. HALTE NIET BEDIEND. Neem bus 21 aan de halte VICTOR HUGO van bus 28 naar BRABANCONNE.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"21\"}]", "priority": 4, "points": "[{\"id\": \"3367\"}]"},{"content": "[{\"text\": [{\"en\": \"Until 2026, works. Stop of T-bus 82/97: ch. de Neerstalsesteenweg in front of 348.\", \"fr\": \"Jusqu'en 2026, travaux. Arr\u00eat du T-bus 82/97: chauss\u00e9e de Neerstalle, en face du num\u00e9ro 348.\", \"nl\": \"Tot 2026, werken. Halte van T-bus 82/97: Neerstalsesteenweg, tegenover nummer 348.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"T82\"}]", "priority": 4, "points": "[{\"id\": \"3242\"}]"},{"content": "[{\"text\": [{\"en\": \"From Apr 29 at 7AM, works. Bus 21 diverted between DIVIN SAUVEUR / GODD. ZALIGMAKER and JAMBLINNE DE MEUX.\", \"fr\": \"D\u00e8s le 29/4 \u00e0 7h, travaux. Bus 21 d\u00e9vi\u00e9 entre DIVIN SAUVEUR et JAMBLINNE DE MEUX.\", \"nl\": \"Vanaf 29/4 om 7u, werken. Bus 21 omgeleid tussen GODD. ZALIGMAKER en JAMBLINNE DE MEUX.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"21\"}]", "priority": 5, "points": "[{\"id\": \"3199\"}, {\"id\": \"3361\"}, {\"id\": \"3904\"}, {\"id\": \"3905\"}, {\"id\": \"3425\"}, {\"id\": \"3458\"}, {\"id\": \"3204\"}, {\"id\": \"3468\"}, {\"id\": \"3203\"}, {\"id\": \"3214\"}, {\"id\": \"3466\"}, {\"id\": \"2695\"}, {\"id\": \"3201\"}, {\"id\": \"4500\"}, {\"id\": \"3911\"}, {\"id\": \"4505\"}, {\"id\": \"2924\"}]"},{"content": "[{\"text\": [{\"en\": \"As of Oct 25, stop moved +/- 50m behind, side square Lain\u00e9square.\", \"fr\": \"D\u00e8s le 25/10, arr\u00eat recul\u00e9 de +/- 50m, c\u00f4t\u00e9 square Lain\u00e9\", \"nl\": \"Vanaf 25/10, werken. Halte achteruitgebracht van +/- 50m, kant Lain\u00e9square.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"T82\"}]", "priority": 4, "points": "[{\"id\": \"2023\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. As of Apr 15, bus 21 diverted. Take bus 21 at MAELBEEK / MAALBEEK (stop of bus 64 to PORTE DE NAMUR / NAAMSEPOORT).\", \"fr\": \"Travaux. D\u00e8s le 15/4, bus 21 d\u00e9vi\u00e9. Prenez le bus 21 \u00e0 MAELBEEK (arr\u00eat du bus 64 vers PORTE DE NAMUR).\", \"nl\": \"Werken. Vanaf 15/4, bus 21 omgeleid. Neem bus 21 aan MAALBEEK (halte van bus 64 naar NAAMSEPOORT) .\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"21\"}]", "priority": 4, "points": "[{\"id\": \"1476\"}]"},{"content": "[{\"text\": [{\"en\": \"From Apr 29, 7AM, works. STOP NOT SERVED.Take bus 21 at the stop VICTOR HUGO of bus 28  to KONKEL.\", \"fr\": \"D\u00e8s 29/4 \u00e0 7h, travaux. ARRET NON DESSERVI. Prenez le bus 21 \u00e0 l'arr\u00eat VICTOR HUGO du bus 28 vers KONKEL.\", \"nl\": \"Vanaf 29/4, 7u, werken. HALTE NIET BEDIEND. Neem bus 21 aan halte VICTOR HUGO van bus 28 naar KONKEL.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"21\"}]", "priority": 4, "points": "[{\"id\": \"3366\"}]"},{"content": "[{\"text\": [{\"en\": \"From Apr 29, works. Bus 28 limited to the stop STADE FALLON STADION.\", \"fr\": \"D\u00e8s le 29/4, travaux. Bus 28 limit\u00e9 \u00e0 l'arr\u00eat STADE FALLON.\", \"nl\": \"Vanaf 29/4, werken. Bus 28 beperkt tot de halte FALLON STADION.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"28\"}]", "priority": 5, "points": "[{\"id\": \"6021\"}, {\"id\": \"6476\"}, {\"id\": \"1141\"}, {\"id\": \"1140\"}, {\"id\": \"1403\"}, {\"id\": \"1424\"}, {\"id\": \"1412\"}, {\"id\": \"1423\"}, {\"id\": \"1422\"}, {\"id\": \"1421\"}, {\"id\": \"1410\"}, {\"id\": \"2919\"}, {\"id\": \"6449\"}, {\"id\": \"1408\"}, {\"id\": \"1406\"}]"},{"content": "[{\"text\": [{\"en\": \"From Apr 29, works. STOP NOT SERVED. Temporary stop: chemin du Struykbekenweg.\", \"fr\": \"D\u00e8s le 29/4, travaux. ARRET NON DESSERVI. Arr\u00eat provisoire: chemin du Struykbeken.\", \"nl\": \"Vanaf 29/4, werken. HALTE NIET BEDIEND. Tijdelijke halte: Struykbekenweg.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"28\"}]", "priority": 4, "points": "[{\"id\": \"1833B\"}]"},{"content": "[{\"text\": [{\"en\": \"From Apr 29 at 7AM, works. STOP NOT SERVED. Take bus 29 at the stop DIAMANT of bus 28 to KONKEL.\", \"fr\": \"D\u00e8s le 29/4 \u00e0 7h, travaux. ARRET NON DESSERVI. Prenez le bus 29 \u00e0 l'arr\u00eat DIAMANT du bus 28 vers KONKEL.\", \"nl\": \"Vanaf 29/4, 7u, werken. HALTE NIET BEDIEND. Neem bus 29 aan de halte DIAMANT van bus 28 naar KONKEL.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"29\"}]", "priority": 4, "points": "[{\"id\": \"6451\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. As of April 7th, STOP NOT SERVED. To go to DE BROUCKERE, take metro lines 1 or 5.\", \"fr\": \"Travaux. D\u00e8s le 7/4, ARRET NON DESSERVI. Pour rejoindre DE BROUCKERE, prenez le m\u00e9tro 1 ou 5.\", \"nl\": \"Werken. Vanaf 7/4, HALTE NIET BEDIEND. Om naar DE BROUCKERE te gaan, neem metrolijn 1 of 5.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"29\"}]", "priority": 4, "points": "[{\"id\": \"6447\"}]"},{"content": "[{\"text\": [{\"en\": \"From Apr 29 at 5AM to May 3 at 5PM, works. Bus 29 diverted between SPEECKAERT and LEVIE.\", \"fr\": \"Du 29/4 \u00e0 5h au 3/5 \u00e0 17h, travaux. Bus 29 d\u00e9vi\u00e9 entre SPEECKAERT et LEVIE.\", \"nl\": \"Van 29/4 om 5u tot 3/5 om 17u, werken. Bus 29 omgeleid tussen SPEECKAERT en LEVIE.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"29\"}]", "priority": 4, "points": "[{\"id\": \"1558\"}, {\"id\": \"1557\"}, {\"id\": \"1578\"}, {\"id\": \"1554\"}, {\"id\": \"1553\"}, {\"id\": \"1552\"}, {\"id\": \"1550\"}, {\"id\": \"1385\"}, {\"id\": \"3910\"}, {\"id\": \"1528\"}]"},{"content": "[{\"text\": [{\"en\": \"Bus 29: works. Stop CLOVIS not served. Temporary stop: rue de Pavie / Paviastraat 53.\", \"fr\": \"Bus 29 : travaux. Arr\u00eat CLOVIS non desservi. Arr\u00eat provisoire: rue de Pavie 53.\", \"nl\": \"Bus 29: werken. Halte CLOVIS niet bediend. Tijdelijke halte: Paviastraat 53.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"29\"}]", "priority": 6, "points": "[{\"id\": \"1567\"}, {\"id\": \"1566\"}, {\"id\": \"1565B\"}, {\"id\": \"1561\"}]"},{"content": "[{\"text\": [{\"en\": \"From Apr 29 at 5AM to May 3 at 5PM, works. STOP NOT SERVED. Temporary stop: avenue du Mai / Meilaan 208.\", \"fr\": \"Du 29/4 \u00e0 5h au 3/5 \u00e0 17h, travaux. ARRET NON DESSERVI. Arr\u00eat provisoire: avenue du Mai 208.\", \"nl\": \"Van 29/4 om 5u tot 3/5 om 17u, werken. HALTE NIET BEDIEND. Tijdelijke halte: Meilaan 208.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"29\"}]", "priority": 4, "points": "[{\"id\": \"1560\"}]"},{"content": "[{\"text\": [{\"en\": \"From Apr 29 at 5AM to May 3 at 5PM, works. STOP NOT SERVED. Temporary stop: avenue du Mai / Meilaan 148.\", \"fr\": \"Du 29/4 \u00e0 5h au 3/5 \u00e0 17h, travaux. ARRET NON DESSERVI. Arr\u00eat provisoire: avenue du Mai 148.\", \"nl\": \"Van 29/4 om 5u tot 3/5 om 17u, werken. HALTE NIET BEDIEND. Tijdelijke halte: Meilaan 148.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"29\"}]", "priority": 4, "points": "[{\"id\": \"1559\"}]"},{"content": "[{\"text\": [{\"en\": \"From Apr 29 at 7AM, works. Bus 29 diverted between RADIUM and LEVIE.\", \"fr\": \"D\u00e8s le 29/4 \u00e0 7h, travaux. Bus 29 d\u00e9vi\u00e9 entre RADIUM et LEVIE.\", \"nl\": \"Vanaf 29/4 om 7u, werken. Bus 29 omgeleid tussen RADIUM en LEVIE.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"29\"}]", "priority": 5, "points": "[{\"id\": \"1514B\"}, {\"id\": \"1513\"}, {\"id\": \"1820\"}, {\"id\": \"1512\"}, {\"id\": \"3354\"}, {\"id\": \"2594\"}, {\"id\": \"2296\"}, {\"id\": \"1509\"}, {\"id\": \"2680\"}, {\"id\": \"1508\"}, {\"id\": \"3150\"}, {\"id\": \"3072\"}]"},{"content": "[{\"text\": [{\"en\": \"Jan 7, 9PM-Jun 28, works. Tram 3 replaced by T-bus. Stop T-bus: av. Croix du Feu, crossing av. Buissonnets\", \"fr\": \"7/1, 21h-28/6, travaux. Tram 3 remplac\u00e9 par des T-bus. Arr\u00eat du T-bus: av. Croix du Feu, carrefour av.Buissonnets\", \"nl\": \"7/1, 21u-28/6, werken. Tram 3 vervangen door T- bus. Halte T-bus: Vuurkruisenlaan, kruispunt Braambosjesln.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"3\"}]", "priority": 4, "points": "[{\"id\": \"5772\"}]"},{"content": "[{\"text\": [{\"en\": \"Jan 7, 9PM-Jun 28, works. Tram 3 replaced by T-bus. Stop T-bus: av. Croix du Feu, after rue De Wandstraat.\", \"fr\": \"7/1, 21h-28/6, travaux. Tram 3 remplac\u00e9 par des T-bus. Arr\u00eat du T-bus: avenue des Croix du Feu, apr\u00e8s la rue De Wand.\", \"nl\": \"7/1, 21u-28/6, werken. Tram 3 vervangen door T-bus. Halte T-bus: Vuurkruisenlaan, na de De Wandstraat.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"3\"}]", "priority": 4, "points": "[{\"id\": \"5806\"}]"},{"content": "[{\"text\": [{\"en\": \"From Jan 8 to Jun 28, works. After CHURCHILL, tram 3 continues on line 7 direction HEYSEL / HEIZEL.\", \"fr\": \"Du 8/1 au 28/6, travaux. Apr\u00e8s CHURCHILL, tram 3 continue sur la ligne 7 direction HEYSEL.\", \"nl\": \"Van 8/1 tot en met 28/6, werken. Na CHURCHILL rijdt tram 3 verder op lijn 7 richting HEIZEL.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"3\"}]", "priority": 6, "points": "[{\"id\": \"6253\"}, {\"id\": \"6178\"}, {\"id\": \"2318G\"}, {\"id\": \"5221F\"}, {\"id\": \"0611\"}, {\"id\": \"0501\"}, {\"id\": \"0601\"}, {\"id\": \"0621\"}, {\"id\": \"0511\"}, {\"id\": \"0531\"}, {\"id\": \"2338F\"}, {\"id\": \"6422F\"}, {\"id\": \"0705\"}, {\"id\": \"0706\"}, {\"id\": \"0703\"}, {\"id\": \"5714\"}, {\"id\": \"2543F\"}, {\"id\": \"0704\"}, {\"id\": \"0702\"}]"},{"content": "[{\"text\": [{\"en\": \"Jan 7, 9PM-Jun 28,works. Stop not served. Stop T-bus to DOCKS BRUXSEL: av. Croix du Feu, crossing av. Pagodes.\", \"fr\": \"7/1, 21h-28/6, travaux. Arr\u00eat non desservi.Arr\u00eat du T-bus vers DOCKS BRUXSEL: av. Croix du Feu, carr. av. Pagodes.\", \"nl\": \"7/1, 21u-28/6, werken. Halte niet bediend.Halte van de T-bus naar DOCKS BRUXSEL: Vuurkruisenln, kruispt Pagodenln.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"3\"}]", "priority": 4, "points": "[{\"id\": \"5706\"}]"},{"content": "[{\"text\": [{\"en\": \"From Jan 15, works. STOP NOT SERVED. Stop of bus 34: chauss\u00e9e de Wavre / Waversesteenweg 1303.\", \"fr\": \"D\u00e8s le 15/1, travaux. ARRET NON DESSERVI. Arr\u00eat du bus 34: chauss\u00e9e de Wavre 1303.\", \"nl\": \"Vanaf 15/1, werken. HALTE NIET BEDIEND. Halte van bus 34: Waversesteenweg 1303.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"34\"}]", "priority": 4, "points": "[{\"id\": \"1718B\"}]"},{"content": "[{\"text\": [{\"en\": \"From Mar 5 at 9AM, works. STOP NOT SERVED. Temporary stop: avenue Jean & Pierre Carsoellaan 4.\", \"fr\": \"D\u00e8s le 5/3 \u00e0 9h, travaux. ARRET NON DESSERVI. Arr\u00eat provisoire: avenue Jean et Pierre Carsoel 4.\", \"nl\": \"Vanaf 5/3 om 9u, werken. HALTE NIET BEDIEND. Tijdelijke halte: Jean en Pierre Carsoellaan 4.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"37\"}]", "priority": 4, "points": "[{\"id\": \"6931B\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. As of April 7th, stop of bus 38 moved to the Cantersteen, at the stop of bus 52 to FOREST / VORST (BERVOETS)\", \"fr\": \"Travaux. D\u00e8s le 7/4, arr\u00eat du bus 38 d\u00e9plac\u00e9 Cantersteen, \u00e0 l'arr\u00eat du bus 52 vers FOREST (BERVOETS).\", \"nl\": \"Werken. Vanaf 7/4, halte van bus 38 verplaatst naar de Kantersteen, aan de halte van bus 52 naar VORST (BERVOETS).\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"38\"}]", "priority": 4, "points": "[{\"id\": \"6443\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. As of Apr 29, STOP NOT SERVED. Take bus 38 at the next stop, BASCULE.\", \"fr\": \"Travaux. D\u00e8s le 29/4, ARRET NON DESSERVI. Prenez le bus 38 \u00e0 l'arr\u00eat suivant, BASCULE.\", \"nl\": \"Werken. Vanaf 29/4, HALTE NIET BEDIEND. Neem bus 38 aan de volgende halte, BASCULE.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"38\"}]", "priority": 4, "points": "[{\"id\": \"1914\"}]"},{"content": "[{\"text\": [{\"en\": \"From Apr 3 at 6AM, works. STOP NOT SERVED. Temporary stop: avenue Winston Churchilllaan 202.\", \"fr\": \"D\u00e8s le 3/4 \u00e0 6h, travaux. ARRET NON DESSERVI. Arr\u00eat provisoire: avenue Winston Churchill 202.\", \"nl\": \"Vanaf 3/4 om 6u, werken. HALTE NIET BEDIEND. Tijdelijke halte: Winston Churchilllaan 202.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"38\"}]", "priority": 4, "points": "[{\"id\": \"1973\"}]"},{"content": "[{\"text\": [{\"en\": \"From Apr 3 at 6AM, works. Bus 38 diverted between HOUZEAU and LONGCHAMP via rue Edith Cavellstraat.\", \"fr\": \"D\u00e8s le 3/4 \u00e0 6h, travaux. Bus 38 d\u00e9vi\u00e9 entre HOUZEAU et LONGCHAMP via rue Edith Cavell.\", \"nl\": \"Vanaf 3/4 om 6u, werken. Bus 38 omgeleid tussen HOUZEAU en LONGCHAMP via Edith Cavellstraat.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"38\"}]", "priority": 5, "points": "[{\"id\": \"1943\"}, {\"id\": \"4076\"}, {\"id\": \"1969\"}, {\"id\": \"1968\"}]"},{"content": "[{\"text\": [{\"en\": \"From Apr 3 at 6AM, works. STOP NOT SERVED. Take bus 38 and 41 at the next stop, HOUZEAU.\", \"fr\": \"D\u00e8s le 3/4 \u00e0 6h, travaux. ARRET NON DESSERVI. Prenez les bus 38 et 41 \u00e0 l'arr\u00eat suivant, HOUZEAU.\", \"nl\": \"Vanaf 3/4 om 6u, werken. HALTE NIET BEDIEND. Neem bus 38 en 41 aan de volgende halte, HOUZEAU.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"38\"}]", "priority": 4, "points": "[{\"id\": \"1920\"}]"},{"content": "[{\"text\": [{\"en\": \"Obstacle on the road: B41 diverted between BOONDAAL STATION and MONTANA direction HELDEN\", \"fr\": \"Obstacle sur la route: B41 d\u00e9vi\u00e9 entre BOONDAEL GARE et MONTANA direction HEROS\", \"nl\": \"Hindernis op de weg: B41 omgeleid tussen BOONDAAL STATION en MONTANA richting HELDEN\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"41\"}]", "priority": 2, "points": "[{\"id\": \"2714\"}]"},{"content": "[{\"text\": [{\"en\": \"Obstacle on the road: B41 diverted between BOONDAAL STATION and MONTANA direction HELDEN\", \"fr\": \"Obstacle sur la route: B41 d\u00e9vi\u00e9 entre BOONDAEL GARE et MONTANA direction HEROS\", \"nl\": \"Hindernis op de weg: B41 omgeleid tussen BOONDAAL STATION en MONTANA richting HELDEN\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"41\"}]", "priority": 2, "points": "[{\"id\": \"1970\"}]"},{"content": "[{\"text\": [{\"en\": \"Obstacle on the road: B41 diverted between BOONDAAL STATION and MONTANA direction HELDEN\", \"fr\": \"Obstacle sur la route: B41 d\u00e9vi\u00e9 entre BOONDAEL GARE et MONTANA direction HEROS\", \"nl\": \"Hindernis op de weg: B41 omgeleid tussen BOONDAAL STATION en MONTANA richting HELDEN\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"41\"}]", "priority": 2, "points": "[{\"id\": \"5451\"}, {\"id\": \"4452\"}, {\"id\": \"4454\"}, {\"id\": \"2107\"}, {\"id\": \"2018\"}, {\"id\": \"1754\"}, {\"id\": \"1753\"}, {\"id\": \"2016\"}, {\"id\": \"1752\"}, {\"id\": \"2762\"}, {\"id\": \"2079\"}, {\"id\": \"4455\"}, {\"id\": \"4456\"}, {\"id\": \"6468\"}, {\"id\": \"5458\"}, {\"id\": \"4358\"}, {\"id\": \"5459\"}, {\"id\": \"6439\"}, {\"id\": \"4449\"}, {\"id\": \"1725\"}, {\"id\": \"4407\"}]"},{"content": "[{\"text\": [{\"en\": \"Obstacle on the road: B41 diverted between BOONDAAL STATION and MONTANA direction HELDEN\", \"fr\": \"Obstacle sur la route: B41 d\u00e9vi\u00e9 entre BOONDAEL GARE et MONTANA direction HEROS\", \"nl\": \"Hindernis op de weg: B41 omgeleid tussen BOONDAAL STATION en MONTANA richting HELDEN\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"41\"}]", "priority": 2, "points": "[{\"id\": \"1943\"}, {\"id\": \"4076\"}, {\"id\": \"1969\"}, {\"id\": \"1968\"}]"},{"content": "[{\"text\": [{\"en\": \"From Mar 4, works. Bus 43 and N11 diverted. Take the bus at HOMBORCH (via B43 from this stop on weekdays or B37).\", \"fr\": \"D\u00e8s le 4/3, travaux. Bus 43 et N11 d\u00e9vi\u00e9s. Prenez le bus \u00e0 HOMBORCH (via B43 depuis cet arr\u00eat en semaine ou B37).\", \"nl\": \"Vanaf 4/3, werken. Bus 43 en N11 omgeleid. Neem de bus aan HOMBORCH (via B43 vanaf deze halte op weekdagen of B37).\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"43\"}]", "priority": 4, "points": "[{\"id\": \"1955\"}]"},{"content": "[{\"text\": [{\"en\": \"From Mar 4, works. Bus 43 diverted. Take the bus at HOMBORCH (via B43 from this stop on weekdays before 8PM).\", \"fr\": \"D\u00e8s le 4/3, travaux. Bus 43 d\u00e9vi\u00e9. Prenez le bus \u00e0 HOMBORCH (via B43 depuis cet arr\u00eat en semaine avant 20h).\", \"nl\": \"Vanaf 4/3, werken. Bus 43 omgeleid. Neem de bus aan HOMBORCH (via B43 vanaf deze halte op weekdagen voor 20u).\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"43\"}]", "priority": 4, "points": "[{\"id\": \"1944\"}]"},{"content": "[{\"text\": [{\"en\": \"From Mar 4, works. Bus 43 and N11 diverted. Take the bus at HOMBORCH (via B43 from this stop on weekdays or B37).\", \"fr\": \"D\u00e8s le 4/3, travaux. Bus 43 et N11 d\u00e9vi\u00e9s. Prenez le bus \u00e0 HOMBORCH (via B43 depuis cet arr\u00eat en semaine ou B37).\", \"nl\": \"Vanaf 4/3, werken. Bus 43 en N11 omgeleid. Neem de bus aan HOMBORCH (via B43 vanaf deze halte op weekdagen of B37).\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"43\"}]", "priority": 4, "points": "[{\"id\": \"1936\"}, {\"id\": \"1935\"}]"},{"content": "[{\"text\": [{\"en\": \"From Mar 4, works. Bus 43 diverted between CABRIS / GEITJES and GRIOTTES / NOORDKRIEKEN.\", \"fr\": \"D\u00e8s le 4/3, travaux. Bus 43 d\u00e9vi\u00e9 entre CABRIS et GRIOTTES.\", \"nl\": \"Vanaf 4/3, werken. Bus 43 omgeleid tussen GEITJES en NOORDKRIEKEN.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"43\"}]", "priority": 5, "points": "[{\"id\": \"2144\"}, {\"id\": \"2142\"}, {\"id\": \"2140\"}, {\"id\": \"2161\"}, {\"id\": \"2109B\"}, {\"id\": \"1953\"}, {\"id\": \"2143B\"}, {\"id\": \"2168\"}, {\"id\": \"2157\"}, {\"id\": \"2146\"}, {\"id\": \"2147B\"}, {\"id\": \"2156\"}, {\"id\": \"2167\"}, {\"id\": \"2145\"}]"},{"content": "[{\"text\": [{\"en\": \"From Mar 4, works. Bus 43 and N11 diverted. Take the bus at HOMBORCH (via B43 at stop B43 VIVIER D'OIE or B37).\", \"fr\": \"D\u00e8s le 4/3, travaux. Bus 43 et N11 d\u00e9vi\u00e9s. Prenez le bus \u00e0 HOMBORCH (via B43 \u00e0 l'arr\u00eat du B43 VIVIER D'OIE ou B37).\", \"nl\": \"Vanaf 4/3, werken. Bus 43 en N11 omgeleid. Neem de bus aan HOMBORCH (via B43 aan halte B43 DIESDELLE of B37).\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"43\"}]", "priority": 4, "points": "[{\"id\": \"1954\"}]"},{"content": "[{\"text\": [{\"en\": \"From Mar 4, works. Bus 43 diverted between GRIOTTES and HOMBORCH. B43 HOMBORCH extended to BRAVES.\", \"fr\": \"D\u00e8s le 4/3, travaux. Bus 43 d\u00e9vi\u00e9 entre GRIOTTES et HOMBORCH. B43 barr\u00e9 HOMBORCH prolong\u00e9 jusqu'\u00e0 BRAVES.\", \"nl\": \"Vanaf 4/3, werken. Bus 43 omgeleid tussen NOORDKRIEKEN en HOMBORCH. B43 HOMBORCH rijdt tot DAPPEREN.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"43\"}]", "priority": 5, "points": "[{\"id\": \"2165\"}, {\"id\": \"1250\"}, {\"id\": \"1921\"}, {\"id\": \"1932\"}, {\"id\": \"1931\"}, {\"id\": \"1942\"}, {\"id\": \"5817\"}, {\"id\": \"1984B\"}, {\"id\": \"2355\"}, {\"id\": \"4854C\"}, {\"id\": \"1929\"}, {\"id\": \"1926B\"}, {\"id\": \"1937\"}]"},{"content": "[{\"text\": [{\"en\": \"Until end of August, works. Stop not served. Take bus 46 at the next stop, PORTE D'ANDERLECHT\", \"fr\": \"Jusque fin ao\u00fbt, travaux. Arr\u00eat non desservi. Prenez le bus 46 \u00e0 l'arr\u00eat suivant, PORTE D'ANDERLECHT.\", \"nl\": \"Tot einde augustus, werken. Halte niet bediend. Neem bus 46 aan de volgende halte, ANDERLECHTSEPOORT.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"46\"}]", "priority": 4, "points": "[{\"id\": \"2213\"}]"},{"content": "[{\"text\": [{\"en\": \"As of Sep 13 at 6AM, works. Stop moved to rue de Laeken / Lakensestraat, next to numbers 57-59.\", \"fr\": \"D\u00e8s le 13/9 \u00e0 6h, travaux. Arr\u00eat d\u00e9plac\u00e9 rue de Laeken, \u00e0 hauteur des num\u00e9ros 57-59.\", \"nl\": \"Vanaf 13/9 om 6u, werken. Halte verplaatst naar de Lakensestraat, ter hoogte van huisnummer 57-59.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"46\"}]", "priority": 4, "points": "[{\"id\": \"3465\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. Until end of August, bus 46 not operated btw WTC-GLIBERT and CENTRAL STATION. Walk to WTC-GLIBERT\", \"fr\": \"Travaux. Jsq fin ao\u00fbt, bus 46 ne circule pas entre WTC-GLIBERT et GARE CENTRALE. Allez \u00e0 pied \u00e0 WTC-GLIBERT\", \"nl\": \"Werken. Tot einde augustus rijdt bus 46 niet tss WTC- GLIBERT en CENTRAAL STATION. Ga te voet naar WTC-GLIBERT.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"46\"}]", "priority": 5, "points": "[{\"id\": \"2269\"}, {\"id\": \"2587\"}, {\"id\": \"3075\"}]"},{"content": "[{\"text\": [{\"en\": \"Until end August 2024, works. B46 diverted to ANNEESSENS. Stops between BUANDERIE and WTC-GLIBERT not served.\", \"fr\": \"Jsq fin ao\u00fbt 2024, travaux. Bus 46 d\u00e9vi\u00e9 vers ANNEESSENS. Arr\u00eats entre BUANDERIE et WTC- GLIBERT non desservis.\", \"nl\": \"Tot einde augustus 2024, werken. Bus 46 omgeleid naar ANNEESSENS. Haltes tussen WASHUIS en WTC-GLIBERT niet bediend\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"46\"}]", "priority": 5, "points": "[{\"id\": \"2405\"}, {\"id\": \"2259\"}, {\"id\": \"2264\"}, {\"id\": \"2262\"}, {\"id\": \"2261\"}, {\"id\": \"2260\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. STOP NOT SERVED. Bus 47-56 at the stop VERGER (avenue des Croix de Guerre)\", \"fr\": \"Travaux. ARRET NON DESSERVI. Bus 47-56 \u00e0 l'arr\u00eat VERGER (avenue des Croix de Guerre)\", \"nl\": \"Werken. HALTE NIET BEDIEND. Bus 47-56 aan de halte BOOMGAARD (Oorlogskruisenlaan)\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"47\"}]", "priority": 4, "points": "[{\"id\": \"1974\"}, {\"id\": \"1967\"}]"},{"content": "[{\"text\": [{\"en\": \"Until Summer of 2024, works. Stop of bus 47 and 56: avenue des Croix de Guerre / Oorlogskruisenlaan 78.\", \"fr\": \"Jusqu'\u00e0 l'\u00e9t\u00e9 2024, travaux. Arr\u00eat des bus 47 et 56 : avenue des Croix de Guerre 78.\", \"nl\": \"Tot zomer 2024, werken. Halte van bus 47 en 56: Oorlogskruisenlaan 78.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"47\"}]", "priority": 4, "points": "[{\"id\": \"2299\"}]"},{"content": "[{\"text\": [{\"en\": \"Until Summer of 2024, works. Stop not served. Take bus 47 at the stop of bus 56 to SCHUMAN.\", \"fr\": \"Jusqu'\u00e0 l'\u00e9t\u00e9 2024, travaux. Arr\u00eat non desservi. Prenez le bus 47 \u00e0 l'arr\u00eat du bus 56 vers SCHUMAN.\", \"nl\": \"Tot zomer 2024, werken. Halte niet bediend. Neem bus 47 aan de halte van bus 56 naar SCHUMAN.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"47\"}]", "priority": 4, "points": "[{\"id\": \"2317\"}]"},{"content": "[{\"text\": [{\"en\": \"Until Summer of 2024, works. Stop not served. Take bus 47 at ANTOON VAN OSS (stop of bus 56 to SCHUMAN).\", \"fr\": \"Jsq \u00e9t\u00e9 2024, travaux. Arr\u00eat non desservi. Prenez le bus 47 \u00e0 ANTOON VAN OSS (arr\u00eat du bus 56 vers SCHUMAN).\", \"nl\": \"Tot zomer 2024, werken. Halte niet bediend. Neem bus 47 aan ANTOON VAN OSS (halte van bus 56 naar SCHUMAN).\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"47\"}]", "priority": 4, "points": "[{\"id\": \"2316\"}]"},{"content": "[{\"text\": [{\"en\": \"From Feb 6, works. STOP NOT SERVED. Temporary stop: Vlierkensstraat 94.\", \"fr\": \"D\u00e8s le 6/2, travaux. ARRET NON DESSERVI. Arr\u00eat provisoire: Vlierkensstraat 94.\", \"nl\": \"Vanaf 6/2, werken. HALTE NIET BEDIEND. Tijdelijke halte: Vlierkensstraat 94.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"47\"}]", "priority": 4, "points": "[{\"id\": \"2841\"}]"},{"content": "[{\"text\": [{\"en\": \"Until Summer of 2024, works. Stop not served. Take bus 47 at ANTOON VAN OSS (stop of bus 56 to BUDA).\", \"fr\": \"Jsq \u00e9t\u00e9 2024, travaux. Arr\u00eat non desservi. Prenez le bus 47 \u00e0 ANTOON VAN OSS (arr\u00eat du bus 56 vers BUDA).\", \"nl\": \"Tot zomer 2024, werken. Halte niet bediend. Neem bus 47 aan ANTOON VAN OSS (halte van bus 56 naar BUDA).\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"47\"}]", "priority": 4, "points": "[{\"id\": \"2359\"}]"},{"content": "[{\"text\": [{\"en\": \"Until Summer of 2024, works. Stop not served. Stop of bus 47: av. Marlylaan, next to Verano.\", \"fr\": \"Jusqu'\u00e0 l'\u00e9t\u00e9 2024, travaux. Arr\u00eat non desservi. Arr\u00eat du bus 47: avenue du Marly, pr\u00e8s de Verano.\", \"nl\": \"Tot zomer 2024, werken. Halte niet bediend. Halte van bus 47: Marlylaan, naast Verano.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"47\"}]", "priority": 4, "points": "[{\"id\": \"2315\"}]"},{"content": "[{\"text\": [{\"en\": \"Until Summer of 2024, works. Bus 47 diverted from RAMIER / BOSDUIF to DOCKS BRUXSEL via avenue des Croix de Guerre\", \"fr\": \"Jsq \u00e9t\u00e9 2024, travaux. Bus 47 d\u00e9vi\u00e9 depuis RAMIER vers DOCKS BRUXSEL via avenue des Croix de Guerre.\", \"nl\": \"Tot zomer 2024, werken. Bus 47 omgeleid vanaf BOSDUIF naar DOCKS BRUXSEL via Oorlogskruisenlaan.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"47\"}]", "priority": 5, "points": "[{\"id\": \"2361\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. As of Apr 17 at 7AM, stop moved to av. R. M.-Henriette / K. M. -Hendrikalaan, in front of the stop to Decroly.\", \"fr\": \"Travaux. D\u00e8s le 17/4 \u00e0 7h, arr\u00eat d\u00e9plac\u00e9 avenue Reine Marie-Henriette, en face de l'arr\u00eat vers Decroly.\", \"nl\": \"Werken. Vanaf 17/4 om 7u, halte verplaatst naar de Koningin Maria- Hendrikalaan, tegenover de halte naar Decroly.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"48\"}]", "priority": 4, "points": "[{\"id\": \"2460\"}]"},{"content": "[{\"text\": [{\"en\": \"End of the works. As of Monday Apr 15, stop served by bus 49 to SIMONIS. Bus 90 withdrawn.\", \"fr\": \"Fin des travaux. D\u00e8s le lundi 15/4, arr\u00eat desservi par les bus 49 vers SIMONIS. Bus 90 supprim\u00e9\", \"nl\": \"Einde van de werken. Vanaf maandag 15/4 wordt deze halte bediend door bus 49 naar SIMONIS. Bus 90 geschrapt.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"49\"}]", "priority": 4, "points": "[{\"id\": \"1257\"}]"},{"content": "[{\"text\": [{\"en\": \"End of the works. As of Monday Apr 15, bus 49 operates normally btw PRINCE DE LIEGE / PRINS VAN LUIK and MEIR.\", \"fr\": \"Fin des travaux. D\u00e8s le lundi 15/4, bus 49 circule \u00e0 nouveau normalement entre PRINCE DE LIEGE et MEIR.\", \"nl\": \"Einde van de werken. Vanaf maandag 15/4 rijdt bus 49 opnieuw normaal tussen PRINS VAN LUIK en MEIR.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"49\"}]", "priority": 5, "points": "[{\"id\": \"3638\"}]"},{"content": "[{\"text\": [{\"en\": \"Until 2026, works. Bus 50 diverted between BEMPT and FOREST CENTRE/VORST CENTRUM.\", \"fr\": \"Jusqu'en 2026, travaux. Bus 50 d\u00e9vi\u00e9 entre BEMPT et FOREST CENTRE.\", \"nl\": \"Tot 2026, werken. Bus 50 omgeleid tussen BEMPT en VORST CENTRUM.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"50\"}]", "priority": 5, "points": "[{\"id\": \"9685\"}, {\"id\": \"9683\"}, {\"id\": \"9678\"}, {\"id\": \"9679\"}, {\"id\": \"9677\"}, {\"id\": \"2661\"}, {\"id\": \"9658\"}, {\"id\": \"2662B\"}, {\"id\": \"9659\"}, {\"id\": \"9682\"}, {\"id\": \"2659\"}, {\"id\": \"9680\"}]"},{"content": "[{\"text\": [{\"en\": \"From May 2 at 5AM, works. STOP NOT SERVED. Temporary stop: Karel Gilsonstraat, 2.\", \"fr\": \"D\u00e8s le 2/5 \u00e0 5h,travaux. ARRET NON DESSERVI. Arr\u00eat provisoire: Karel Gilsonstraat, 2.\", \"nl\": \"Vanaf 2/5 om 5u, werken. HALTE NIET BEDIEND. Tijdelijke halte: Karel Gilsonstraat, 2.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"50\"}]", "priority": 4, "points": "[{\"id\": \"9651\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. Until 2026, stop not served. Stop of T-bus 82 and of bus 50: rue de la Soierie / Zijdeweverijstraat 9.\", \"fr\": \"Travaux. Jusqu'en 2026, arr\u00eat non desservi. Arr\u00eat du T-bus 82 et du bus 50 : rue de la Soierie 9.\", \"nl\": \"Werken. Tot 2026, halte niet bediend. Halte van T-bus 82 en van bus 50: Zijdeweverijstraat 9.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"50\"}]", "priority": 4, "points": "[{\"id\": \"3603\"}]"},{"content": "[{\"text\": [{\"en\": \"Until 2026, works. Stop not served. Stop of bus 50: rue de la Soierie / Zijdeweverijstraat 4.\", \"fr\": \"Jusqu'en 2026, travaux. Arr\u00eat non desservi. Arr\u00eat du bus 50: rue de la Soierie 4.\", \"nl\": \"Tot 2026, werken. Halte niet bediend. Halte van bus 50: Zijdeweverijstraat 4.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"50\"}]", "priority": 4, "points": "[{\"id\": \"3602\"}]"},{"content": "[{\"text\": [{\"en\": \"Until 2026, works. Bus 50 diverted. Stop of bus 50: rue des Abbesses / Abdissenstraat, in front of number 1.\", \"fr\": \"Jusqu'en 2026, travaux. Bus 50 d\u00e9vi\u00e9. Arr\u00eat du bus 50: rue des Abbesses, en face du num\u00e9ro 1.\", \"nl\": \"Tot 2026, werken. Bus 50 omgeleid. Halte van bus 50: Abdissenstraat, tegenover nummer 1.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"50\"}]", "priority": 4, "points": "[{\"id\": \"5161\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. As of Apr 15 at 6AM, bus 53 diverted between PETER BENOIT and BEYSEGHEM / BEIZEGEM.\", \"fr\": \"Travaux. D\u00e8s le 15/4 \u00e0 6h, bus 53 d\u00e9vi\u00e9 entre PETER BENOIT et BEYSEGHEM.\", \"nl\": \"Werken. Vanaf 15/4 om 6u, bus 53 omgeleid tussen PETER BENOIT en BEIZEGEM.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"53\"}]", "priority": 5, "points": "[{\"id\": \"2823B\"}, {\"id\": \"2766\"}]"},{"content": "[{\"text\": [{\"en\": \"Until Summer of 2024, works. Bus 53 diverted. Stop of bus 53: rue Bruynstraat, after the military area.\", \"fr\": \"Jsq \u00e9t\u00e9 2024, travaux. Bus 53 d\u00e9vi\u00e9. Arr\u00eat du bus 53 : rue Bruyn, apr\u00e8s le domaine militaire.\", \"nl\": \"Tot zomer 2024, werken. Bus 53 omgeleid. Halte van bus 53: Bruynstraat, na het militair domein.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"53\"}]", "priority": 4, "points": "[{\"id\": \"2352\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. As of Apr 15 at 6AM, bus 53 diverted between PETER BENOIT and BEYSEGHEM / BEIZEGEM.\", \"fr\": \"Travaux. D\u00e8s le 15/4 \u00e0 6h, bus 53 d\u00e9vi\u00e9 entre PETER BENOIT et BEYSEGHEM.\", \"nl\": \"Werken. Vanaf 15/4 om 6u, bus 53 omgeleid tussen PETER BENOIT en BEIZEGEM.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"53\"}]", "priority": 5, "points": "[{\"id\": \"3001B\"}]"},{"content": "[{\"text\": [{\"en\": \"From Apr 2, 2024 to June 2025, works. STOP NOT SERVED. Stop of bus 54: FOREST NATIONAL (av. du Globelaan 8).\", \"fr\": \"Du 2/4/2024 \u00e0 juin 2025, travaux. ARRET NON DESSERVI. Arr\u00eat des bus 54: FOREST NATIONAL. (avenue du Globe 8).\", \"nl\": \"Van 2/4/2024 tot juni 2025, werken. HALTE NIET BEDIEND. Halte van bus 54: VORST NATIONAAL (Globelaan 8)\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"54\"}]", "priority": 4, "points": "[{\"id\": \"2939B\"}]"},{"content": "[{\"text\": [{\"en\": \"Apr 2, 2024-June 2025, works. Bus 54 diverted btw FOREST NATIONAL and FOREST CENTRE. Info: stib-mivb.brussels\", \"fr\": \"Du 2/4/2024 \u00e0 juin 2025, travaux. Bus 54 d\u00e9vi\u00e9 entre FOREST NATIONAL et FOREST CENTRE. Info: stib.brussels.\", \"nl\": \"2/4/2024-juni 2025, werken. Bus 54 omgeleid tussen VORST NATIONAAL en VORST CENTRUM. Info: mivb.brussels\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"54\"}]", "priority": 5, "points": "[{\"id\": \"2934A\"}, {\"id\": \"1780\"}, {\"id\": \"2937B\"}, {\"id\": \"1734\"}, {\"id\": \"2932\"}, {\"id\": \"2931\"}, {\"id\": \"2972\"}, {\"id\": \"2950\"}, {\"id\": \"2411B\"}, {\"id\": \"2929\"}, {\"id\": \"2928\"}, {\"id\": \"2936\"}, {\"id\": \"2935\"}, {\"id\": \"3518B\"}, {\"id\": \"3506\"}]"},{"content": "[{\"text\": [{\"en\": \"Until Summer of 2024, works. Stop of bus 47 and 56: av. Croix de Guerre, at the other side of Delhaize.\", \"fr\": \"Jusqu'\u00e0 l'\u00e9t\u00e9 2024, travaux. Arr\u00eat des bus 47 et 56 : avenue des Croix de Guerre, de l'autre c\u00f4t\u00e9 du Delhaize\", \"nl\": \"Tot zomer 2024, werken. Halte van bus 47 en 56: Oorlogskruisenlaan, aan de andere kant van de Delhaize.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"56\"}]", "priority": 4, "points": "[{\"id\": \"1974\"}, {\"id\": \"1967\"}]"},{"content": "[{\"text\": [{\"en\": \"Until Summer of 2024, works. Stop not served. Stop of bus 56: place Peter Benoitplein 3\", \"fr\": \"Jusqu'\u00e0 l'\u00e9t\u00e9 2024, travaux. Arr\u00eat non desservi. Arr\u00eat du bus 56 : place Peter Benoit 3\", \"nl\": \"Tot zomer 2024, werken. Halte niet bediend. Halte van bus 56: Peter Benoitplein 3\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"56\"}]", "priority": 4, "points": "[{\"id\": \"1987\"}]"},{"content": "[{\"text\": [{\"en\": \"Until Summer of 2024, works. Bus 56 diverted between VAN PRAET and PETER BENOIT via avenue des Croix de Guerre.\", \"fr\": \"Jusqu'\u00e0 l'\u00e9t\u00e9 2024, travaux. Bus 56 d\u00e9vi\u00e9 entre VAN PRAET et PETER BENOIT via avenue des Croix de Guerre.\", \"nl\": \"Tot zomer 2024, werken. Bus 56 omgeleid tussen VAN PRAET en PETER BENOIT via Oorlogskruisenlaan.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"56\"}]", "priority": 5, "points": "[{\"id\": \"2098\"}, {\"id\": \"3451\"}, {\"id\": \"6190\"}, {\"id\": \"9296\"}, {\"id\": \"2051\"}, {\"id\": \"6082\"}, {\"id\": \"2898\"}, {\"id\": \"2106\"}, {\"id\": \"1006\"}, {\"id\": \"2367\"}, {\"id\": \"3412\"}, {\"id\": \"2101\"}, {\"id\": \"6459\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. As of Apr 15, bus 56 diverted. Take bus 56 at the stop of bus 64 to BORDET STATION.\", \"fr\": \"Travaux. D\u00e8s le 15/4, bus 56 d\u00e9vi\u00e9. Prenez le bus 56 \u00e0 l'arr\u00eat du bus 64 vers BORDET STATION.\", \"nl\": \"Werken. Vanaf 15/4, bus 56 omgeleid. Neem bus 56 aan de halte van bus 64 naar BORDET STATION.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"56\"}]", "priority": 4, "points": "[{\"id\": \"2068\"}]"},{"content": "[{\"text\": [{\"en\": \"Until Summer of 2024, works. As of March 18, buses 56 and 57 serve this stop normally.\", \"fr\": \"Jusqu'\u00e0 l'\u00e9t\u00e9 2024, travaux. D\u00e8s le 18/3, les bus 56 et 57 desservent \u00e0 nouveau cet arr\u00eat.\", \"nl\": \"Tot zomer 2024, werken. Vanaf 18/3 bedienen bus 56 en 57 opnieuw deze halte.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"56\"}]", "priority": 5, "points": "[{\"id\": \"2829B\"}]"},{"content": "[{\"text\": [{\"en\": \"Until Summer of 2024, works. Stop not served. Stop of bus 57: MARLY (moved to ch. Vilvorde, next to number 150)\", \"fr\": \"Jsq \u00e9t\u00e9 2024, travaux. Arr\u00eat non desservi.Arr\u00eat du bus 57: MARLY (d\u00e9plac\u00e9 ch. Vilvorde, en face du num\u00e9ro 150)\", \"nl\": \"Tot zomer 2024, werken. Halte niet bediend. Halte van bus 57:MARLY (verplaatst Vilvoordsest tegenover nr. 150)\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"57\"}]", "priority": 4, "points": "[{\"id\": \"2315\"}]"},{"content": "[{\"text\": [{\"en\": \"Until Summer of 2024, works. Stop not served. Take bus 57 at ANTOON VAN OSS (stop of bus 56 to SCHUMAN).\", \"fr\": \"Jsq \u00e9t\u00e9 2024, travaux. Arr\u00eat non desservi. Prenez le bus 57 \u00e0 ANTOON VAN OSS (arr\u00eat du bus 56 vers SCHUMAN).\", \"nl\": \"Tot zomer 2024, werken. Halte niet bediend. Neem bus 57 aan ANTOON VAN OSS (halte van bus 56 naar SCHUMAN).\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"57\"}]", "priority": 4, "points": "[{\"id\": \"2316\"}]"},{"content": "[{\"text\": [{\"en\": \"Until Summer of 2024, works. Stop not served. Take bus 57 at ANTOON VAN OSS (stop of bus 56 to BUDA).\", \"fr\": \"Jsq \u00e9t\u00e9 2024, travaux. Arr\u00eat non desservi. Prenez le bus 57 \u00e0 ANTOON VAN OSS (arr\u00eat du bus 56 vers BUDA).\", \"nl\": \"Tot zomer 2024, werken. Halte niet bediend. Neem bus 57 aan ANTOON VAN OSS (halte van bus 56 naar BUDA).\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"57\"}]", "priority": 4, "points": "[{\"id\": \"2359\"}]"},{"content": "[{\"text\": [{\"en\": \"Until Summer of 2024, works. Stop not served. Stop of bus 57: chauss\u00e9e de Vilvorde, next to ropery Barrois\", \"fr\": \"Jsq \u00e9t\u00e9 2024, travaux. Arr\u00eat non desservi. Arr\u00eat du bus 57: ch\u00e9e de Vilvorde, le long de la corderie Barrois\", \"nl\": \"Tot zomer 2024, werken. Halte niet bediend. Halte B57: Vilvoordsestwg, naast de touwslagerij Barrois\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"57\"}]", "priority": 4, "points": "[{\"id\": \"3003\"}]"},{"content": "[{\"text\": [{\"en\": \"Until Summer of 2024, works. Stop not served. Take bus 47 or 57 at ANTOON VAN OSS (stop of bus 56 to BUDA).\", \"fr\": \"Jsq \u00e9t\u00e9 2024, travaux. Arr\u00eat non desservi. Prenez le bus 47 ou 57 \u00e0 ANTOON VAN OSS (arr\u00eat du bus 56 vers BUDA).\", \"nl\": \"Tot zomer 2024, werken. Halte niet bediend. Neem bus 47 of 57 aan ANTOON VAN OSS (halte van bus 56 naar BUDA).\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"57\"}]", "priority": 4, "points": "[{\"id\": \"1837\"}]"},{"content": "[{\"text\": [{\"en\": \"Until Summer 2024,works. B57 divtd btw MARLY and ANT VAN OSS. As of Oct 16, B57 divtd btw MARLY and HOP. MILITAIRE\", \"fr\": \"Jsq \u00e9t\u00e9 2024, travaux. Bus 57 d\u00e9vi\u00e9 entre MARLY et ANT VAN OSS. D\u00e8s le 16/10, B57 d\u00e9vi\u00e9 entre MARLY et HOP MILITAIRE.\", \"nl\": \"Tot zomer 2024, werken. Bus 57 omgeleid ts MARLY en ANT VAN OSS. Vanaf 16/10, B57 omgeleid tss MARLY en MILITAIR HOSP.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"57\"}]", "priority": 5, "points": "[{\"id\": \"1090\"}, {\"id\": \"2327\"}, {\"id\": \"2305\"}, {\"id\": \"2326\"}, {\"id\": \"1356\"}, {\"id\": \"3058\"}, {\"id\": \"1052\"}, {\"id\": \"1051\"}, {\"id\": \"2308\"}, {\"id\": \"2868\"}, {\"id\": \"3061\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. As of Apr 24 at 6.30AM, STOP NOT SERVED. Stop of bus 59: COTEAUX (rue des Coteaux, 213).\", \"fr\": \"Travaux. D\u00e8s le 24/4 \u00e0 6h30, ARRET NON DESSERVI. Arr\u00eat du bus 59: COTEAUX (rue des Coteaux, 213).\", \"nl\": \"Werken. Vanaf 24/4 om 6. 30u, HALTE NIET BEDIEND. Halte van bus 59: WIJNHEUVELEN (Wijnheuvelenstr. 213).\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"59\"}]", "priority": 4, "points": "[{\"id\": \"3113\"}]"},{"content": "[{\"text\": [{\"en\": \"From Feb 8, works. STOP NOT SERVED. Temporary stop: Place de Houffalizeplein 2-6.\", \"fr\": \"D\u00e8s le 8/2, travaux. ARRET NON DESSERVI. Arr\u00eat provisoire: Place de Houffalize 2-6.\", \"nl\": \"Vanaf 8/2, werken. HALTE NIET BEDIEND. Tijdelijke halte: Houffalizeplein 2-6.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"59\"}]", "priority": 4, "points": "[{\"id\": \"3110\"}]"},{"content": "[{\"text\": [{\"en\": \"From Mar 11, works. Bus 60 diverted. Temporary stop: chauss\u00e9e de Saint- Job/Sint-Jobsesteenweg, in front of nr. 390.\", \"fr\": \"D\u00e8s le 11/3, travaux. Bus 60 d\u00e9vi\u00e9. Arr\u00eat provisoire: chauss\u00e9e de Saint-Job, face au num\u00e9ro 390.\", \"nl\": \"Vanaf 11/3, werken. Bus 60 omgeleid. Tijdelijke halte: Sint-Jobsesteenweg, tegenover nr. 390.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"60\"}]", "priority": 4, "points": "[{\"id\": \"1738\"}, {\"id\": \"2705\"}]"},{"content": "[{\"text\": [{\"en\": \"From Mar 11, works. Bus 60 diverted. Temporary stop: chauss\u00e9e de Saint- Job/Sint-Jobsesteenweg 265.\", \"fr\": \"D\u00e8s le 11/3, travaux. Bus 60 d\u00e9vi\u00e9. Arr\u00eat provisoire: chauss\u00e9e de Saint-Job 265.\", \"nl\": \"Vanaf 11/3, werken. Bus 60 omgeleid. Tijdelijke halte: Sint-Jobsesteenweg 265.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"60\"}]", "priority": 4, "points": "[{\"id\": \"2704\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. As of Apr 15, STOP NOT SERVED. Walk to AMBIORIX.\", \"fr\": \"Travaux. D\u00e8s le 15/4, ARRET NON DESSERVI. Pour rejoindre AMBIORIX, continuez \u00e0 pied.\", \"nl\": \"Werken. Vanaf 15/4, HALTE NIET BEDIEND. Ga te voet verder om naar AMBIORIX te gaan.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"60\"}]", "priority": 4, "points": "[{\"id\": \"1418B\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. As of April 7th, stop served only by bus 66. Take bus 29, 63 or 65 at the stop of bus 71 to DELTA.\", \"fr\": \"Travaux. D\u00e8s le 7/4, arr\u00eat uniquement desservi par bus 66. Bus 29, 63 ou 65 \u00e0 l'arr\u00eat du bus 71 vers DELTA.\", \"nl\": \"Werken. Vanaf 7/4, halte enkel bediend door bus 66. Neem bus 29, 63 of 65 aan de halte van bus 71 naar DELTA.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"63\"}]", "priority": 4, "points": "[{\"id\": \"6445\"}]"},{"content": "[{\"text\": [{\"en\": \"Risk of subsidence. Stop of bus 65, 66 and N04 moved to chauss\u00e9e de Haecht/Haachtsesteenweg, next to number 162\", \"fr\": \"Risque d'effondrement. Arr\u00eat des bus 65, 66 et N04 d\u00e9plac\u00e9 chauss\u00e9e de Haecht, \u00e0 hauteur du num\u00e9ro 162.\", \"nl\": \"Risico op instorting. Halte van bus 65, 66 en N04 verplaatst naar de Haachtsesteenweg, ter hoogte van nummer 162.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"65\"}]", "priority": 4, "points": "[{\"id\": \"6418\"}]"},{"content": "[{\"text\": [{\"en\": \"Jan 7, 9PM-Jun 28, works. Stop not served. To continue to HEYSEL / HEIZEL, take tram 3 direction CHURCHILL.\", \"fr\": \"7/1, 21h-28/6, travaux. Arr\u00eat non desservi. Pour continuer vers HEYSEL, prenez le tram 3 direction CHURCHILL.\", \"nl\": \"7/1, 21u-28/6, werken. Halte niet bediend. Om naar HEIZEL te reizen, neem tram 3 richting CHURCHILL.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"7\"}]", "priority": 4, "points": "[{\"id\": \"6421F\"}]"},{"content": "[{\"text\": [{\"en\": \"Jan 7, 9PM-Jun 28,works. Tram 3 and 7 replaced by T-bus to DOCKS BRUXSEL. T-bus at this stop.\", \"fr\": \"7/1, 21h-28/6, travaux. Tram 3 et 7 remplac\u00e9s par des T-bus jusqu'\u00e0 DOCKS BRUXSEL. T-bus \u00e0 cet arr\u00eat.\", \"nl\": \"7/1, 21u-28/6, werken. Tram 3 en 7 vervangen door T-bus tot DOCKS BRUXSEL. T-bus aan deze halte.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"7\"}]", "priority": 5, "points": "[{\"id\": \"5707\"}]"},{"content": "[{\"text\": [{\"en\": \"Jan 8-Jun 28, works. Tram 7 interrupted btw HEEMBEEK and DOCKS BXL. T-bus to DOCKS BXL at stop of B83 to VAL MARIA\", \"fr\": \"8/1-28/6, travaux. T7 interrompu de HEEMBEEK \u00e0 DOCKS BXL. T-bus vers DOCKS BXL \u00e0 l'arr\u00eat du B83 vers VAL MARIA.\", \"nl\": \"8/1-28/6, werken. T7 onderbroken tss HEEMBEEK en DOCKS BRUXSEL. T-bus naar DOCKS BRUXSEL aan halte B83 naar MARI\u00cbND.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"7\"}]", "priority": 5, "points": "[{\"id\": \"5700G\"}]"},{"content": "[{\"text\": [{\"en\": \"From Mar 18, works. STOP NOT SERVED. Temporary stop: avenue de la Couronne / Kroonlaan 439-443.\", \"fr\": \"D\u00e8s le 18/3, travaux. ARRET NON DESSERVI. Arr\u00eat provisoire: avenue de la Couronne 439-443.\", \"nl\": \"Vanaf 18/3, werken. HALTE NIET BEDIEND. Tijdelijke halte: Kroonlaan 439-443.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"71\"}]", "priority": 4, "points": "[{\"id\": \"3558\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. As of April 7th, STOP NOT SERVED. To go to DE BROUCKERE, take metro lines 1 or 5.\", \"fr\": \"Travaux. D\u00e8s le 7/4, ARRET NON DESSERVI. Pour rejoindre DE BROUCKERE, prenez le m\u00e9tro 1 ou 5.\", \"nl\": \"Werken. Vanaf 7/4, HALTE NIET BEDIEND. Om naar DE BROUCKERE te gaan, neem metrolijn 1 of 5.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"71\"}]", "priority": 4, "points": "[{\"id\": \"6447\"}]"},{"content": "[{\"text\": [{\"en\": \"From Mar 18, works. STOP NOT SERVED. stop of bus 72: avenue de l'Universit\u00e9 / Hogeschoollaan 4-10.\", \"fr\": \"D\u00e8s le 18/3, travaux. ARRET NON DESSERVI. Arr\u00eat du bus 72: avenue de l'Universit\u00e9 4-10.\", \"nl\": \"Vanaf 18/3, werken. HALTE NIET BEDIEND. Halte van bus 72: Hogeschoollaan 4-10.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"72\"}]", "priority": 4, "points": "[{\"id\": \"3514\"}]"},{"content": "[{\"text\": [{\"en\": \"From Apr 2, 2024 to June 2025, works. STOP NOT SERVED. Stop of bus 74: chauss\u00e9e de Bruxelles / Brusselsesteenweg 84.\", \"fr\": \"Du 2/4/2024 \u00e0 juin 2025, travaux. ARRET NON DESSERVI. Arr\u00eat du bus 74: chauss\u00e9e de Bruxelles 84.\", \"nl\": \"Van 2/4/2024 tot juni 2025, werken. HALTE NIET BEDIEND. Halte van bus 74: Brusselsesteenweg 84.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"74\"}]", "priority": 4, "points": "[{\"id\": \"5152\"}, {\"id\": \"5161\"}]"},{"content": "[{\"text\": [{\"en\": \"From Apr 20, works. Stop not served. Take B74 next to number 26 (100m before this stop).\", \"fr\": \"D\u00e8s le 20/4, travaux. Arr\u00eat non desservi. Arr\u00eat du B74 \u00e0  hauteur du num\u00e9ro 26 (100 m avant cet arr\u00eat).\", \"nl\": \"Vanaf 20/4, werken. Halte niet bediend. Neem B74 ter hoogte van nummer 26 (100m voor deze halte).\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"74\"}]", "priority": 4, "points": "[{\"id\": \"2225\"}]"},{"content": "[{\"text\": [{\"en\": \"Apr 2, 2024-June 2025, works. Bus 74 diverted btw FOREST CENTRE and FOREST NATIONAL. Info: stib-mivb.brussels.\", \"fr\": \"Du 2/4/2024 \u00e0 juin 2025, travaux. Bus 74 d\u00e9vi\u00e9 entre FOREST CENTRE et FOREST NATIONAL. Info: stib.brussels.\", \"nl\": \"2/4/2024-juni 2025, werken. Bus 74 omgeleid tussen VORST CENTRUM en VORST NATIONAAL. Info: mivb.brussels.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"74\"}]", "priority": 5, "points": "[{\"id\": \"2631\"}]"},{"content": "[{\"text\": [{\"en\": \"From Mar 18, works. STOP NOT SERVED. Take the bus at the next stop, VICTOR ALLARD.\", \"fr\": \"D\u00e8s le 18/3, travaux. ARRET NON DESSERVI. Prenez le bus \u00e0 l'arr\u00eat suivant, VICTOR ALLARD.\", \"nl\": \"Vanaf 18/3, werken. HALTE NIET BEDIEND. Neem de bus aan de volgende halte, VICTOR ALLARD.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"74\"}]", "priority": 4, "points": "[{\"id\": \"2417\"}]"},{"content": "[{\"text\": [{\"en\": \"T81-T97 operate normally againBAREEL and JANSON\", \"fr\": \"T81-T97 circulent \u00e0 nouveau entre BARRIERE et JANSON\", \"nl\": \"T81-T97 worden weer bediend tussen BAREEL en JANSON\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"81\"}]", "priority": 3, "points": "[{\"id\": \"6099\"}, {\"id\": \"6121F\"}, {\"id\": \"3611F\"}, {\"id\": \"6113F\"}, {\"id\": \"3613F\"}, {\"id\": \"3123\"}, {\"id\": \"6858G\"}, {\"id\": \"6705F\"}, {\"id\": \"2260F\"}, {\"id\": \"1805F\"}, {\"id\": \"6799F\"}, {\"id\": \"6860G\"}, {\"id\": \"6106\"}, {\"id\": \"6008\"}, {\"id\": \"6109\"}, {\"id\": \"2971F\"}, {\"id\": \"2331F\"}, {\"id\": \"6120\"}, {\"id\": \"6077F\"}, {\"id\": \"2539F\"}, {\"id\": \"3612F\"}, {\"id\": \"6114F\"}, {\"id\": \"3371F\"}, {\"id\": \"0631\"}, {\"id\": \"6427F\"}, {\"id\": \"6117\"}, {\"id\": \"2259F\"}, {\"id\": \"6856\"}, {\"id\": \"3508F\"}, {\"id\": \"2257G\"}, {\"id\": \"6857\"}, {\"id\": \"2960F\"}]"},{"content": "[{\"text\": [{\"en\": \"T81-T97 operate normally againBAREEL and JANSON\", \"fr\": \"T81-T97 circulent \u00e0 nouveau entre BARRIERE et JANSON\", \"nl\": \"T81-T97 worden weer bediend tussen BAREEL en JANSON\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"81\"}]", "priority": 3, "points": "[{\"id\": \"6462F\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. Until 2026, stop not served. Stop of T-bus 82 and of bus 50: rue de la Soierie / Zijdeweverijstraat 9.\", \"fr\": \"Travaux. Jusqu'en 2026, arr\u00eat non desservi. Arr\u00eat du T-bus 82 et du bus 50 : rue de la Soierie 9.\", \"nl\": \"Werken. Tot 2026, halte niet bediend. Halte van T-bus 82 en van bus 50: Zijdeweverijstraat 9.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"82\"}]", "priority": 4, "points": "[{\"id\": \"5156F\"}]"},{"content": "[{\"text\": [{\"en\": \"Until 2026, works. Stop not served. Stop of the T-bus: rue de la Soierie / Zijdeweverijstraat 4.\", \"fr\": \"Jusqu'en 2026, travaux. Arr\u00eat non desservi. Arr\u00eat du T-bus: rue de la Soierie 4.\", \"nl\": \"Tot 2026, werken. Halte niet bediend. Halte van de T-bus: Zijdeweverijstraat 4.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"82\"}]", "priority": 4, "points": "[{\"id\": \"5154F\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. Until 2026, tram 82 replaced by T-bus between DROGENBOS and FOREST CENTRE / VORST CENTRUM.\", \"fr\": \"Travaux. Jusqu'en 2026, tram 82 remplac\u00e9 par des T-bus entre DROGENBOS et FOREST CENTRE. T-bus \u00e0 cet arr\u00eat.\", \"nl\": \"Werken. Tot 2026, tram 82 vervangen door T-bus tussen DROGENBOS en VORST CENTRUM. T-bus aan deze halte.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"82\"}]", "priority": 4, "points": "[{\"id\": \"5753F\"}, {\"id\": \"5751\"}, {\"id\": \"5754\"}]"},{"content": "[{\"text\": [{\"en\": \"Until 2026, works. Tram 82 replaced by T-bus to FOREST CENTRE. T-bus at this stop.\", \"fr\": \"Jusqu'en 2026, travaux. Tram 82 remplac\u00e9 par des T-bus jusqu'\u00e0 FOREST CENTRE. T-bus \u00e0 cet arr\u00eat.\", \"nl\": \"Tot 2026, werken. Tram 82 vervangen door T-bus tot VORST CENTRUM. T-bus aan deze halte.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"82\"}]", "priority": 4, "points": "[{\"id\": \"5756F\"}, {\"id\": \"1258G\"}]"},{"content": "[{\"text\": [{\"en\": \"Until 2026, works. Tram 82 interrupted. T-bus to DROGENBOS at the stop of bus 54 to TRONE/TROON.\", \"fr\": \"Jusqu'en 2026, travaux. Tram 82 interrompu. T-bus vers DROGENBOS \u00e0 l'arr\u00eat du bus 54 vers TRONE.\", \"nl\": \"Tot 2026, werken. Tram 82 onderbroken. T-bus naar DROGENBOS aan de halte van bus 54 naar TROON.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"82\"}]", "priority": 4, "points": "[{\"id\": \"5121F\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. Until 2026, tram 82 replaced by T-bus btw FOREST CENTRE / VORST CENTRUM and DROGENBOS. T-bus at this stop.\", \"fr\": \"Travaux. Jusqu'en 2026, tram 82 remplac\u00e9 par des T-bus entre FOREST CENTRE et DROGENBOS. T-bus \u00e0 cet arr\u00eat.\", \"nl\": \"Werken. Tot 2026, tram 82 vervangen door T-bus tussen VORST CENTRUM en DROGENBOS. T-bus aan deze halte.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"82\"}]", "priority": 4, "points": "[{\"id\": \"5722F\"}, {\"id\": \"5723G\"}]"},{"content": "[{\"text\": [{\"en\": \"Until 2026, works. Tram 82 replaced by T-bus between FOREST CENTRE / VORST CENTRUM and DROGENBOS.\", \"fr\": \"Jusqu'en 2026, travaux. Tram 82 remplac\u00e9 par des T-bus entre FOREST CENTRE et DROGENBOS. Info: stib.brussels.\", \"nl\": \"Tot 2026, werken. Tram 82 vervangen door T-bus tussen VORST CENTRUM en DROGENBOS. Info: mivb. brussels.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"82\"}]", "priority": 5, "points": "[{\"id\": \"2603\"}, {\"id\": \"5718\"}, {\"id\": \"0631\"}, {\"id\": \"5120\"}, {\"id\": \"2539F\"}, {\"id\": \"5123\"}, {\"id\": \"2548F\"}, {\"id\": \"2604F\"}, {\"id\": \"2544F\"}, {\"id\": \"5119\"}]"},{"content": "[{\"text\": [{\"en\": \"Until 2026, works. Tram 82 interrupted. Take tram 82 at the stop in the other direction.\", \"fr\": \"Jusqu'en 2026, travaux. Tram 82 interrompu. Prenez le tram 82 \u00e0 l'arr\u00eat dans l'autre sens.\", \"nl\": \"Tot 2026, werken. Tram 82 onderbroken. Neem tram 82 aan de halte in de andere richting.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"82\"}]", "priority": 4, "points": "[{\"id\": \"5161F\"}]"},{"content": "[{\"text\": [{\"en\": \"From Jan 22 at 6AM to end of June, works. Bus 86 diverted. Take the bus at the previous stop GARE DE L'OUEST.\", \"fr\": \"Du 22/1 \u00e0 6h jusqu'\u00e0 fin juin, travaux. Bus 86 d\u00e9vi\u00e9. Prenez le bus \u00e0 l'arr\u00eat pr\u00e9c\u00e9dent GARE DE  L'OUEST.\", \"nl\": \"Van 22/1 om 6u tot eind juni, werken. Bus 86 omgeleid. Neem de bus aan vorige halte WESTSTATION.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"86\"}]", "priority": 4, "points": "[{\"id\": \"3257\"}]"},{"content": "[{\"text\": [{\"en\": \"From Jan 22 at 6AM to end of June, works. Bus 86 diverted. B86 at the stop RIBAUCOURT of bus 20 to GARE DU NORD.\", \"fr\": \"Du 22/1 \u00e0 6h jusqu'\u00e0 fin juin, travaux. Bus 86 d\u00e9vi\u00e9. Bus 86 \u00e0 l'arr\u00eat RIBAUCOURT du bus 20 vers GARE DU NORD.\", \"nl\": \"Van 22/1 om 6u tot eind juni, werken. Bus 86 omgeleid. Bus 86 aan de halte RIBAUCOURT van bus 20 naar NOORDSTATION.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"86\"}]", "priority": 4, "points": "[{\"id\": \"4253\"}]"},{"content": "[{\"text\": [{\"en\": \"From Feb 2 7AM, works. STOP NOT SERVED. Temporary halte: Boulevard Emile Jacqmainlaan 82-94.\", \"fr\": \"D\u00e8s le 8/2 7h, travaux. ARRET NON DESSERVI. Arr\u00eat provisoire: Boulevard Emile Jacqmain 82-94.\", \"nl\": \"Vanaf 8/2 7u, werken. HALTE NIET BEDIEND. Tijdelijke halte: Emile Jacqmainlaan 82-94.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"88\"}]", "priority": 4, "points": "[{\"id\": \"2070\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. From Apr 23 until Jun 2, bus 13 and 88 diverted. Take bus 13 or 88 at the stop of bus 820 to UZ Brussel.\", \"fr\": \"Travaux; Du 23/4 au 2/6, bus 13 et 88 d\u00e9vi\u00e9s. Prenez le bus 13 ou 88 \u00e0 l'arr\u00eat du bus 820 vers UZ Brussel.\", \"nl\": \"Werken. Van 23/4 tot en met 2/6, bus 13 en 88 omgeleid. Neem bus 13 of 88 aan de halte van bus 820 naar UZ Brussel.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"88\"}]", "priority": 4, "points": "[{\"id\": \"1721\"}, {\"id\": \"1328\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. As of Apr 22 at 9.30AM, bus 89 diverted. Stop of bus 89: rue des Quatre-Vents / Vier Windenstraat 141\", \"fr\": \"Travaux. D\u00e8s le 22/4 \u00e0 9h30, bus 89 d\u00e9vi\u00e9. Arr\u00eat du bus 89: rue des Quatre-Vents, 141.\", \"nl\": \"Werken. Vanaf 22/4 om 9. 30u, bus 89 omgeleid. Halte van bus 89: Vier Windenstraat 141\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"89\"}]", "priority": 4, "points": "[{\"id\": \"4594\"}]"},{"content": "[{\"text\": [{\"en\": \"Until end of August, works. Bus 89 diverted. For the city center, take metro 1 or 5 at COMTE DE FLANDRE.\", \"fr\": \"Jusque fin ao\u00fbt, travaux. Bus 89 d\u00e9vi\u00e9. Pour le centre-ville, prenez le m\u00e9tro 1 ou 5 \u00e0 COMTE DE FLANDRE.\", \"nl\": \"Tot einde augustus, werken. Bus 89 omgeleid. Om naar het stadscentrum te gaan, neem M 1 5 aan GRAAF VAN VLAANDEREN.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"89\"}]", "priority": 4, "points": "[{\"id\": \"3259C\"}, {\"id\": \"3260\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. As of Apr 22 at 9.30AM, bus 89 diverted. Stop of bus 89: rue Delaunoystraat 15.\", \"fr\": \"Travaux. D\u00e8s le 22/4 \u00e0 9h30, bus 89 d\u00e9vi\u00e9. Arr\u00eat du bus 89: rue Delaunoy, 15.\", \"nl\": \"Werken. Vanaf 22/4 om 9. 30u, bus 89 omgeleid. Halte van bus 89: Delaunoystraat 15.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"89\"}]", "priority": 4, "points": "[{\"id\": \"3228\"}]"},{"content": "[{\"text\": [{\"en\": \"Until end of August, works. Bus 89 diverted. To continue to CENTRAL STATION, take bus 29 71\", \"fr\": \"Jusque fin ao\u00fbt, travaux. Bus 89 d\u00e9vi\u00e9. Pour continuer vers GARE CENTRALE, prenez le bus 29 ou 71.\", \"nl\": \"Tot einde augustus, werken. Bus 89 omgeleid. Om verder naar CENTRAAL STATION te reizen, neem bus 29 of 71.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"89\"}]", "priority": 5, "points": "[{\"id\": \"1820\"}, {\"id\": \"2296\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. From Apr 26 at 9PM until May 12, stop not served. T-bus to ROI BAUDOUIN at the stop of bus 13 to ETANGS NOIRS.\", \"fr\": \"Travaux. Du 26/4 \u00e0 21h au 12/5, arr\u00eat non desservi. T-bus vers ROI BAUDOUIN \u00e0 l'arr\u00eat du bus 13 vers ETANGS NOIRS\", \"nl\": \"Werken. 26/4, 21u-12/5, halte niet bediend.T-bus naar KONING BOUDEWIJN aan de halte van bus 13 naar ZWARTE VIJVERS.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"9\"}]", "priority": 4, "points": "[{\"id\": \"1683F\"}, {\"id\": \"1685F\"}]"},{"content": "[{\"text\": [{\"en\": \"From Mar 25 until Jun 30, works. STOP NOT SERVED. Stop of bus 95: av. Couronne / Kroonln, in front of number 384\", \"fr\": \"Du 25/3 au 30/6, travaux. ARRET NON DESSERVI. Arr\u00eat du bus 95: av. de la Couronne, en face du num\u00e9ro 384.\", \"nl\": \"Van 25/3 tot en met 30/6, werken. HALTE NIET BEDIEND. Halte van bus 95: Kroonlaan, tegenover nummer 384\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"95\"}]", "priority": 4, "points": "[{\"id\": \"4306\"}]"},{"content": "[{\"text\": [{\"en\": \"Mar 25-Jun 30, works. STOP NOT SERVED. Stop of bus 95: CIMETIERE D'IXELLES / BEGR. VAN ELSENE.\", \"fr\": \"25/3-30/6,travaux. ARRET NON DESSERVI. Arr\u00eat du bus 95: CIM. D'IXELLES (ch\u00e9e de Boondael, avant le rond-point).\", \"nl\": \"25/3-30/6, werken. HALTE NIET BEDIEND. Halte van bus 95: BEGR. VAN ELSENE (Boondaalsestwg, voor de rotonde)\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"95\"}]", "priority": 4, "points": "[{\"id\": \"4362\"}]"},{"content": "[{\"text\": [{\"en\": \"As of September 21, works. Stop moved to av. de la Fauconnerie / Valkerijlaan, next to number 53a.\", \"fr\": \"D\u00e8s le 21/9, travaux. Arr\u00eat d\u00e9plac\u00e9 avenue de la Fauconnerie, \u00e0 hauteur du num\u00e9ro 53a.\", \"nl\": \"Vanaf 21/9, werken. Halte verplaatst naar de Valkerijlaan, ter hoogte van huisnummer 53a.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"95\"}]", "priority": 4, "points": "[{\"id\": \"4314\"}]"},{"content": "[{\"text\": [{\"en\": \"From Mar 25 until Jun 30, works. Bus 95 diverted btw CIMETIERE D'IXELLES and ETTERBEEK GARE\", \"fr\": \"Du 25/3 au 30/6, travaux. Bus 95 d\u00e9vi\u00e9 entre CIMETIERE D'IXELLES et  ETTERBEEK GARE.\", \"nl\": \"Van 25/3 tot en met 30/6, werken. Bus 95 omgeleid tussen BEGRAAFPLAATS VAN ELSENE en ETTERBEEK STATION.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"95\"}]", "priority": 5, "points": "[{\"id\": \"4360\"}, {\"id\": \"4351\"}, {\"id\": \"1455\"}, {\"id\": \"4355\"}, {\"id\": \"4357\"}, {\"id\": \"4358\"}, {\"id\": \"4359\"}, {\"id\": \"4348\"}]"},{"content": "[{\"text\": [{\"en\": \"T81-T97 operate normally againBAREEL and JANSON\", \"fr\": \"T81-T97 circulent \u00e0 nouveau entre BARRIERE et JANSON\", \"nl\": \"T81-T97 worden weer bediend tussen BAREEL en JANSON\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"97\"}]", "priority": 3, "points": "[{\"id\": \"5723G\"}]"},{"content": "[{\"text\": [{\"en\": \"T81-T97 operate normally againBAREEL and JANSON\", \"fr\": \"T81-T97 circulent \u00e0 nouveau entre BARRIERE et JANSON\", \"nl\": \"T81-T97 worden weer bediend tussen BAREEL en JANSON\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"97\"}]", "priority": 3, "points": "[{\"id\": \"6078\"}, {\"id\": \"6428F\"}, {\"id\": \"5018F\"}, {\"id\": \"5016F\"}, {\"id\": \"2404F\"}, {\"id\": \"6314\"}, {\"id\": \"2336G\"}, {\"id\": \"6162\"}]"},{"content": "[{\"text\": [{\"en\": \"T81-T97 operate normally againBAREEL and JANSON\", \"fr\": \"T81-T97 circulent \u00e0 nouveau entre BARRIERE et JANSON\", \"nl\": \"T81-T97 worden weer bediend tussen BAREEL en JANSON\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"97\"}]", "priority": 3, "points": "[{\"id\": \"5164F\"}]"},{"content": "[{\"text\": [{\"en\": \"T81-T97 operate normally againBAREEL and JANSON\", \"fr\": \"T81-T97 circulent \u00e0 nouveau entre BARRIERE et JANSON\", \"nl\": \"T81-T97 worden weer bediend tussen BAREEL en JANSON\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"97\"}]", "priority": 3, "points": "[{\"id\": \"5722F\"}]"},{"content": "[{\"text\": [{\"en\": \"T81-T97 operate normally againBAREEL and JANSON\", \"fr\": \"T81-T97 circulent \u00e0 nouveau entre BARRIERE et JANSON\", \"nl\": \"T81-T97 worden weer bediend tussen BAREEL en JANSON\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"97\"}]", "priority": 3, "points": "[{\"id\": \"5916F\"}]"},{"content": "[{\"text\": [{\"en\": \"T81-T97 operate normally againBAREEL and JANSON\", \"fr\": \"T81-T97 circulent \u00e0 nouveau entre BARRIERE et JANSON\", \"nl\": \"T81-T97 worden weer bediend tussen BAREEL en JANSON\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"97\"}]", "priority": 3, "points": "[{\"id\": \"2708G\"}, {\"id\": \"5952F\"}, {\"id\": \"2709F\"}, {\"id\": \"2710G\"}, {\"id\": \"1984G\"}]"},{"content": "[{\"text\": [{\"en\": \"T81-T97 operate normally againBAREEL and JANSON\", \"fr\": \"T81-T97 circulent \u00e0 nouveau entre BARRIERE et JANSON\", \"nl\": \"T81-T97 worden weer bediend tussen BAREEL en JANSON\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"97\"}]", "priority": 3, "points": "[{\"id\": \"5121F\"}]"},{"content": "[{\"text\": [{\"en\": \"T81-T97 operate normally againBAREEL and JANSON\", \"fr\": \"T81-T97 circulent \u00e0 nouveau entre BARRIERE et JANSON\", \"nl\": \"T81-T97 worden weer bediend tussen BAREEL en JANSON\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"97\"}]", "priority": 3, "points": "[{\"id\": \"5151\"}, {\"id\": \"2668\"}, {\"id\": \"5155\"}, {\"id\": \"2667F\"}]"},{"content": "[{\"text\": [{\"en\": \"T81-T97 operate normally againBAREEL and JANSON\", \"fr\": \"T81-T97 circulent \u00e0 nouveau entre BARRIERE et JANSON\", \"nl\": \"T81-T97 worden weer bediend tussen BAREEL en JANSON\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"97\"}]", "priority": 3, "points": "[{\"id\": \"1985G\"}]"},{"content": "[{\"text\": [{\"en\": \"T81-T97 operate normally againBAREEL and JANSON\", \"fr\": \"T81-T97 circulent \u00e0 nouveau entre BARRIERE et JANSON\", \"nl\": \"T81-T97 worden weer bediend tussen BAREEL en JANSON\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"97\"}]", "priority": 3, "points": "[{\"id\": \"5161F\"}]"},{"content": "[{\"text\": [{\"en\": \"Until 2026, works. T-bus 82/97 diverted between BEMPT and FOREST CENTRE/VORST CENTRUM.\", \"fr\": \"Jusqu'en 2026, travaux. T-bus 82/97 d\u00e9vi\u00e9 entre BEMPT et FOREST CENTRE.\", \"nl\": \"Tot 2026, werken. Bus T-bus 82/97 omgeleid tussen BEMPT en VORST CENTRUM.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"T82\"}]", "priority": 5, "points": "[{\"id\": \"3405\"}, {\"id\": \"7472\"}, {\"id\": \"7474\"}, {\"id\": \"7465\"}, {\"id\": \"3255\"}, {\"id\": \"5755\"}, {\"id\": \"5756\"}]"},{"content": "[{\"text\": [{\"en\": \"Until 2026, works. Bus 50 and T-bus diverted between FOREST CENTRE / VORST CENTRUM and BEMPT.\", \"fr\": \"Jusqu'en 2026, travaux. Bus 50 et T-bus d\u00e9vi\u00e9s entre FOREST CENTRE et BEMPT.\", \"nl\": \"Tot 2026, werken. Bus 50 en T-bus omgeleid tussen VORST CENTRUM en BEMPT.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"T82\"}]", "priority": 5, "points": "[{\"id\": \"3196\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. As of Apr 15, STOP NOT SERVED. Stop of bus 12: rue Archim\u00e8de / Archimedesstraat 16.\", \"fr\": \"Travaux. D\u00e8s le 15/4, ARRET NON DESSERVI. Arr\u00eat du bus 12: rue Archim\u00e8de 16.\", \"nl\": \"Werken. Vanaf 15/4, HALTE NIET BEDIEND. Halte van bus 12: Archimedesstraat 16.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"12\"}]", "priority": 4, "points": "[{\"id\": \"1418B\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. From Apr 23 until Jun 2, bus 13 and 88 diverted. Take bus 13 or 88 at the stop of bus 820 to UZ Brussel.\", \"fr\": \"Travaux; Du 23/4 au 2/6, bus 13 et 88 d\u00e9vi\u00e9s. Prenez le bus 13 ou 88 \u00e0 l'arr\u00eat du bus 820 vers UZ Brussel.\", \"nl\": \"Werken. Van 23/4 tot en met 2/6, bus 13 en 88 omgeleid. Neem bus 13 of 88 aan de halte van bus 820 naar UZ Brussel.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"13\"}]", "priority": 4, "points": "[{\"id\": \"1721\"}, {\"id\": \"1328\"}]"},{"content": "[{\"text\": [{\"en\": \"From Sep 5 6AM, works. STOP NOT SERVED. Temporary stop: rue du Brillant (across stop towards Heiligenborre)\", \"fr\": \"D\u00e8s le 5/9 6h, travaux. ARRET NON DESSERVI. Arr\u00eat provisoire: rue du Brillant (face \u00e0 l'arr\u00eat vers Heiligenborre)\", \"nl\": \"Vanaf 5/9 6u, werken. HALTE NIET BEDIEND. Tijdelijke halte: Briljantstraat (tgnover halte > Heiligenborre)\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"17\"}]", "priority": 4, "points": "[{\"id\": \"4293\"}]"},{"content": "[{\"text\": [{\"en\": \"From Sep 5 6AM, works. STOP NOT SERVED. Bus 17 diverted between BRILLANT and BEAULIEU via Michiels\", \"fr\": \"D\u00e8s le 5/9 6h, travaux. ARRET NON DESSERVI. Bus 17 d\u00e9vi\u00e9 entre BRILLANT et BEAULIEU via Michiels\", \"nl\": \"Vanaf 5/9 6u, werken. HALTE NIET BEDIEND. Bus 17 omgeleid tussen BRILJANT en BEAULIEU via Michiels\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"17\"}]", "priority": 4, "points": "[{\"id\": \"4295\"}, {\"id\": \"4296\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. Until mid-2024, T19 interrupted at MIROIR. Stop of T-bus 19: av. Jette 126 (next to this stop)\", \"fr\": \"Travaux. Jusque mi-2024, T19 interrompu \u00e0 MIROIR. Arr\u00eat du T-bus 19: av. de Jette, 126 (\u00e0 c\u00f4t\u00e9 de cet arr\u00eat).\", \"nl\": \"Werken. Tot midden 2024, T19 onderbroken aan SPIEGEL. Halte van T-bus 19: Jetselaan 126 (naast deze halte)\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"19\"}]", "priority": 4, "points": "[{\"id\": \"6864F\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. Until mid-2024, T19 replaced by T-bus btw MIROIR and CIMETIERE DE JETTE. T-bus at stop of bus 13 to UZ-VUB.\", \"fr\": \"Travaux. Jsq mi-2024, T19 remplac\u00e9 par T-bus entre MIROIR et CIM. JETTE. T-bus \u00e0 l'arr\u00eat du bus 13 vers UZ-VUB.\", \"nl\": \"Werken. Tot midden 2024, T19 vervangen door T-bus tss SPIEGEL en KERKH. JETTE.  T-bus aan halte van B13 naar UZ-VUB.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"19\"}]", "priority": 4, "points": "[{\"id\": \"0471\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. Until mid-2024, stop not served. Take tram 19 at CIMETIERE DE JETTE / KERKHOF VAN JETTE.\", \"fr\": \"Travaux. Jusque mi-2024, arr\u00eat non desservi. Prenez le tram 19 \u00e0 CIMETIERE DE JETTE.\", \"nl\": \"Werken. Tot midden 2024, halte niet bediend. Neem tram 19 aan KERKHOF VAN JETTE.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"19\"}]", "priority": 4, "points": "[{\"id\": \"6869G\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. As of April 29th, STOP NOT SERVED. Take tram 19 at the next stop, STUYVENBERGH.\", \"fr\": \"Travaux. D\u00e8s le 29/4, ARRET NON DESSERVI. Prenez le tram 19 \u00e0 l'arr\u00eat suivant, STUYVENBERGH.\", \"nl\": \"Werken. Vanaf 29/4, HALTE NIET BEDIEND. Neem tram 19 aan de volgende halte, STUYVENBERGH.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"19\"}]", "priority": 4, "points": "[{\"id\": \"5082\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. Until mid-2024, T19 replaced by T-bus between MIROIR and CIMETIERE DE JETTE.\", \"fr\": \"Travaux. Jusque mi-2024, tram 19 remplac\u00e9 par des T-bus entre MIROIR et CIMETIERE DE JETTE.\", \"nl\": \"Werken. Tot midden 2024, tram 19 vervangen door T-bus tussen SPIEGEL en KERKHOF VAN JETTE.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"19\"}]", "priority": 5, "points": "[{\"id\": \"1306F\"}, {\"id\": \"5105F\"}, {\"id\": \"1094F\"}, {\"id\": \"1111\"}, {\"id\": \"5104F\"}, {\"id\": \"5103\"}, {\"id\": \"5102F\"}, {\"id\": \"1064\"}, {\"id\": \"5108\"}, {\"id\": \"5109\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. Until mid-2024, stop not served. T-bus at VERBEYST (bd de Smet de Naeyer 211, stop of bus 14 to GARE DU NORD).\", \"fr\": \"Travaux, jusque mi-2024, arr\u00eat non desservi.T-bus \u00e0 VERBEYST (bd de Smet de Naeyer 211, arr\u00eat B14 vers GARE DU NORD).\", \"nl\": \"Werken. Tot midden 2024, halte niet bediend. T-bus aan VERBEYST (de Smet de Naeyerlaan 211, halte B14 naar NOORDST.)\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"19\"}]", "priority": 4, "points": "[{\"id\": \"6803F\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. As of Apr 15, STOP NOT SERVED. Stop of bus 21: rue Franklinstraat 2a.\", \"fr\": \"Travaux. D\u00e8s le 15/4, ARRET NON DESSERVI. Arr\u00eat du bus 21: rue Franklin, 2a.\", \"nl\": \"Werken. Vanaf 15/4, HALTE NIET BEDIEND. Halte van bus 21: Franklinstraat 2a.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"21\"}]", "priority": 4, "points": "[{\"id\": \"1270B\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. As of Apr 15, bus 21 diverted. Take bus 21 at the stop of bus 64 to BORDET STATION.\", \"fr\": \"Travaux. D\u00e8s le 15/4, bus 21 d\u00e9vi\u00e9. Prenez le bus 21 \u00e0 l'arr\u00eat du bus 64 vers BORDET STATION.\", \"nl\": \"Werken. Vanaf 15/4, bus 21 omgeleid. Neem bus 21 aan de halte van bus 64 naar BORDET STATION.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"21\"}]", "priority": 4, "points": "[{\"id\": \"1133\"}]"},{"content": "[{\"text\": [{\"en\": \"From Apr 29 at 7AM, works. STOP NOT SERVED. Take bus 21 at the next stop, DIAMANT.\", \"fr\": \"D\u00e8s le 29/4 \u00e0 7h, travaux. ARRET NON DESSERVI. Prenez le bus 21 \u00e0 l'arr\u00eat suivant DIAMANT.\", \"nl\": \"Vanaf 29/4, 7u, werken. HALTE NIET BEDIEND. Neem bus 21 aan de volgende halte, DIAMANT.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"21\"}]", "priority": 4, "points": "[{\"id\": \"6451\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. As of Apr 15, bus 21 diverted btw MICHEL- ANGE and TOULOUSE via MAELBEEK. Stop SCHUMAN moved rue Franklin.\", \"fr\": \"Travaux. D\u00e8s le 15/4,bus 21 d\u00e9vi\u00e9 entre MICHEL- ANGE et TOULOUSE via MAELBEEK. Arr\u00eat SCHUMAN d\u00e9plac\u00e9 rue Franklin.\", \"nl\": \"Werken. Vanaf 15/4, bus 21 omgeleid tss MICHELANGELO en TOULOUSE via MAALBEEK. SCHUMAN verplaatst Franklinstr.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"21\"}]", "priority": 6, "points": "[{\"id\": \"1464\"}, {\"id\": \"1463\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. As of Apr 15, STOP NOT SERVED. Take bus 21 at MAELBEEK / MAALBEEK (stop of bus 64 to BORDET STATION).\", \"fr\": \"Travaux. D\u00e8s le 15/4, ARRET NON DESSERVI. Prenez le bus 21 \u00e0 MAELBEEK (halte van bus 64 naar BORDET STATION).\", \"nl\": \"Werken. Vanaf 15/4, HALTE NIET BEDIEND. Neem bus 21 aan MAALBEEK (arr\u00eat du bus 64 vers BORDET STATION).\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"21\"}]", "priority": 4, "points": "[{\"id\": \"1416\"}]"},{"content": "[{\"text\": [{\"en\": \"From Apr 29 at 7AM, works. STOP NOT SERVED. Take bus 29 at the stop DIAMANT of bus 21 to MAES.\", \"fr\": \"D\u00e8s le 29/4,7h, travaux. ARRET NON DESSERVI. Prenez le bus 29 \u00e0 l'arr\u00eat DIAMANT du bus 21 vers MAES.\", \"nl\": \"Vanaf 29/4, 7u, werken. HALTE NIET BEDIEND. Neem bus 29 aan de halte DIAMANT van bus 21 naar MAES.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"29\"}]", "priority": 4, "points": "[{\"id\": \"6454\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. As of Apr 29, stop moved to avenue de Mai / Meilaan, next to numbers 65-67\", \"fr\": \"Travaux. D\u00e8s le 29/4, arr\u00eat d\u00e9plac\u00e9 avenue de Mai, \u00e0 hauteur des num\u00e9ros 65-67.\", \"nl\": \"Werken. Vanaf 29/4, halte verplaatst naar de Meilaan, ter hoogte van huisnummers 65-67.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"29\"}]", "priority": 4, "points": "[{\"id\": \"1521\"}]"},{"content": "[{\"text\": [{\"en\": \"Jan 7, 9PM-Jun 28,works. Tram 3 interrupted btw ESPLANADE and DOCKS BRUXSEL. Stop of the T-bus: next to this stop\", \"fr\": \"7/1, 21h-28/6, travaux. Tram 3 interrompu entre ESPLANADE et DOCKS BRUXSEL. Arr\u00eat du T-bus: \u00e0 c\u00f4t\u00e9 de cet arr\u00eat.\", \"nl\": \"7/1, 21u-28/6, werken. Tram 3 onderbroken tss ESPLANADE en DOCKS BRUXSEL. Halte van de T-bus: naast deze halte.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"3\"}]", "priority": 4, "points": "[{\"id\": \"5705\"}]"},{"content": "[{\"text\": [{\"en\": \"From Jan 7 at 9PM to Jun 28, works. Terminus not served. Stop of the T-bus: av. de Meysse, in front of number 125.\", \"fr\": \"Du 7/1 \u00e0 21h au 28/6, travaux. Terminus non desservi. Arr\u00eat du T-bus: avenue de Meysse, en face du num\u00e9ro 125.\", \"nl\": \"7/1, 21u-28/6, werken. Eindpunt niet bediend. Halte van de T-bus: Meiseselaan, tegenover nummer 125.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"3\"}]", "priority": 4, "points": "[{\"id\": \"5701\"}]"},{"content": "[{\"text\": [{\"en\": \"Jan 7, 9PM-Jun 28, works. Stop not served. T-bus to ESPLANADE at the stop of bus 56 to BUDA.\", \"fr\": \"7/1, 21h-28/6, travaux. Arr\u00eat non desservi. T-bus vers ESPLANADE \u00e0 l'arr\u00eat du bus 56 vers BUDA.\", \"nl\": \"7/1, 21u-28/6, werken. Halte niet bediend. T-bus naar ESPLANADE aan de halte van bus 56 naar BUDA.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"3\"}]", "priority": 4, "points": "[{\"id\": \"5770F\"}]"},{"content": "[{\"text\": [{\"en\": \"Jan 7, 9PM-Jun 28,works. Tram 3 interrupted btw ESPLANADE and DOCKS BRUXSEL. T-bus at stop of bus 83 to VAL MARIA\", \"fr\": \"7/1, 21h-28/6, travaux. Tram 3 interrompu entre ESPLANADE et DOCKS BRUXSEL. T-bus \u00e0 l'arr\u00eat du bus 83 vers VAL MARIA\", \"nl\": \"7/1, 21u-28/6, werken. Tram 3 onderbroken tss ESPLANADE en DOCKS BRUXSEL. T-bus halte van bus 83 naar MARI\u00cbNDAAL.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"3\"}]", "priority": 4, "points": "[{\"id\": \"5700G\"}]"},{"content": "[{\"text\": [{\"en\": \"Jan 7, 9PM-Jun 28, works. Tram 3 replaced by T-bus between DOCKS BRUXSEL and ESPLANADE. Info: stib-mivb.brussels\", \"fr\": \"7/1, 21h-28/6, travaux. Tram 3 remplac\u00e9 par des T-bus entre DOCKS BRUXSEL et ESPLANADE. Info: stib.brussels.\", \"nl\": \"7/1, 21u-28/6, werken. Tram 3 vervangen door T-bus tussen DOCKS BRUXSEL en ESPLANADE. info: mivb.brussels.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"3\"}]", "priority": 5, "points": "[{\"id\": \"5219F\"}, {\"id\": \"6179\"}, {\"id\": \"2537F\"}, {\"id\": \"0722\"}, {\"id\": \"9986F\"}, {\"id\": \"6424F\"}, {\"id\": \"0606\"}, {\"id\": \"6177F\"}, {\"id\": \"0626\"}, {\"id\": \"0516\"}, {\"id\": \"6209\"}, {\"id\": \"0725\"}, {\"id\": \"0726\"}, {\"id\": \"0616\"}, {\"id\": \"0506\"}, {\"id\": \"2200F\"}, {\"id\": \"0723\"}, {\"id\": \"0526\"}, {\"id\": \"0724\"}]"},{"content": "[{\"text\": [{\"en\": \"From Jan 15, works. Bus 34 diverted between HANKAR and BERGOJE via DEMEY.\", \"fr\": \"D\u00e8s le 15/1, travaux. Bus 34 d\u00e9vi\u00e9 entre HANKAR et BERGOJE via DEMEY.\", \"nl\": \"Vanaf 15/1, werken. Bus 34 omgeleid tussen HANKAR en BERGOJE via DEMEY.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"34\"}]", "priority": 5, "points": "[{\"id\": \"6433\"}, {\"id\": \"1712\"}, {\"id\": \"1733\"}, {\"id\": \"2291B\"}, {\"id\": \"1233\"}, {\"id\": \"1729\"}, {\"id\": \"1728\"}, {\"id\": \"1706\"}, {\"id\": \"1716\"}, {\"id\": \"1715\"}, {\"id\": \"1714\"}, {\"id\": \"1824\"}, {\"id\": \"1713\"}]"},{"content": "[{\"text\": [{\"en\": \"From Jan 15, works. STOP NOT SERVED. Take bus 34 at the stop RO(O)DENBERG of bus 72 to ADEPS.\", \"fr\": \"D\u00e8s le 15/1, travaux. ARRET NON DESSERVI. Prenez le bus 34 \u00e0 l'arr\u00eat ROODENBERG du bus 72 vers ADEPS.\", \"nl\": \"Vanaf 15/1, werken. HALTE NIET BEDIEND. Neem bus 34 aan de halte RODENBERG van bus 72 naar ADEPS.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"34\"}]", "priority": 4, "points": "[{\"id\": \"1720B\"}]"},{"content": "[{\"text\": [{\"en\": \"From Jan 15, works. STOP NOT SERVED. Stop of bus 34: boulevard du Souverain / Vorstlaan 159.\", \"fr\": \"D\u00e8s le 15/1, travaux. ARRET NON DESSERVI. Arr\u00eat du bus 34: boulevard du Souverain 159.\", \"nl\": \"Vanaf 15/1, werken. HALTE NIET BEDIEND. Halte van bus 34: Vorstlaan 159.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"34\"}]", "priority": 4, "points": "[{\"id\": \"1731\"}]"},{"content": "[{\"text\": [{\"en\": \"From Apr 3 at 6AM, works. STOP NOT SERVED. Take bus 38 and 41 at the previous stop, HOUZEAU.\", \"fr\": \"D\u00e8s le 3/4 \u00e0 6h, travaux. ARRET NON DESSERVI. Prenez les bus 38 et 41 \u00e0 l'arr\u00eat pr\u00e9c\u00e9dent, HOUZEAU.\", \"nl\": \"Vanaf 3/4 om 6u, werken. HALTE NIET BEDIEND. Neem bus 38 en 41 aan de vorige halte, HOUZEAU.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"38\"}]", "priority": 4, "points": "[{\"id\": \"1970\"}]"},{"content": "[{\"text\": [{\"en\": \"From Apr 3 at 6AM, works. Bus 38 diverted between LONGCHAMP and HOUZEAU via rue Edith Cavellstraat.\", \"fr\": \"D\u00e8s le 3/4 \u00e0 6h, travaux. Bus 38 d\u00e9vi\u00e9 entre LONGCHAMP et HOUZEAU via rue Edith Cavell.\", \"nl\": \"Vanaf 3/4 om 6u, werken. Bus 38 omgeleid tussen LONGCHAMP en HOUZEAU via Edith Cavellstraat.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"38\"}]", "priority": 5, "points": "[{\"id\": \"1916\"}, {\"id\": \"1915\"}]"},{"content": "[{\"text\": [{\"en\": \"From Apr 3 at 6AM, works. STOP NOT SERVED. Bus 38 at GOSSART (avenue Winston Churchilllaan 202).\", \"fr\": \"D\u00e8s le 3/4 \u00e0 6h, travaux. ARRET NON DESSERVI. Bus 38 \u00e0 GOSSART (avenue Winston Churchill 202).\", \"nl\": \"Vanaf 3/4 om 6u, werken. HALTE NIET BEDIEND. Bus 38 aan GOSSART (Winston Churchilllaan 202).\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"38\"}]", "priority": 4, "points": "[{\"id\": \"1918\"}]"},{"content": "[{\"text\": [{\"en\": \"From Apr 3 at 6AM, works. STOP NOT SERVED. Bus 38 at GOSSART (avenue Winston Churchilllaan 187).\", \"fr\": \"D\u00e8s le 3/4 \u00e0 6h, travaux. ARRET NON DESSERVI. Bus 38 \u00e0 GOSSART (avenue Winston Churchill 187).\", \"nl\": \"Vanaf 3/4 om 6u, werken. HALTE NIET BEDIEND. Bus 38 aan GOSSART (Winston Churchilllaan 187).\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"38\"}]", "priority": 4, "points": "[{\"id\": \"1972\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. As of April 7th, bus 38 diverted. Take bus 38 at the next stop, ROYALE / KONING.\", \"fr\": \"Travaux. D\u00e8s le 7/4, bus 38 d\u00e9vi\u00e9. Prenez le bus 38 \u00e0 l'arr\u00eat suivant, ROYALE.\", \"nl\": \"Werken. Vanaf 7/4, bus 38 omgeleid. Neem bus 38 aan de volgende halte, KONING.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"38\"}]", "priority": 4, "points": "[{\"id\": \"3502\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. As of Apr 29, STOP NOT SERVED. Stop of bus 38: WASHINGTON (stop of bus 60 to UCCLE CALEVOET).\", \"fr\": \"Travaux. D\u00e8s le 29/4, ARRET NON DESSERVI. Arr\u00eat du bus 38: WASHINGTON (arr\u00eat du bus 60 vers UCCLE CALEVOET)\", \"nl\": \"Werken. Vanaf 29/4,HALTE NIET BEDIEND. Halte van bus 38: WASHINGTON (halte van bus 60 naar UKKEL KALEVOET)\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"38\"}]", "priority": 4, "points": "[{\"id\": \"1913\"}]"},{"content": "[{\"text\": [{\"en\": \"Obstacle on the road: B41 diverted between BOONDAAL STATION and MONTANA direction HELDEN\", \"fr\": \"Obstacle sur la route: B41 d\u00e9vi\u00e9 entre BOONDAEL GARE et MONTANA direction HEROS\", \"nl\": \"Hindernis op de weg: B41 omgeleid tussen BOONDAAL STATION en MONTANA richting HELDEN\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"41\"}]", "priority": 2, "points": "[{\"id\": \"2763\"}]"},{"content": "[{\"text\": [{\"en\": \"From Mar 4, works. Bus 43 and N11 diverted. Weekdays before 8PM: B43 at BRAVES. Otherwise: bus at GRIOTTES.\", \"fr\": \"D\u00e8s le 4/3, travaux. Bus 43 et N11 d\u00e9vi\u00e9s. En semaine avant 20h: B43 \u00e0 BRAVES. Autres moments: bus \u00e0 GRIOTTES.\", \"nl\": \"Vanaf 4/3, werken. Bus 43 en N11 omgeleid. Weekdagen voor 20u: B43 aan DAPPEREN. Anders: bus aan NOORDKRIEKEN.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"43\"}]", "priority": 4, "points": "[{\"id\": \"1963\"}]"},{"content": "[{\"text\": [{\"en\": \"Enjoy your trip on our lines !\", \"fr\": \"Bon voyage sur nos lignes !\", \"nl\": \"Geniet van uw reis op onze lijnen !\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"44\"}]", "priority": 9, "points": "[{\"id\": \"9552\"}]"},{"content": "[{\"text\": [{\"en\": \"Until end of August 2024, works. Stop not served. Walk to WTC-GLIBERT.\", \"fr\": \"Jusque fin ao\u00fbt 2024, travaux. Arr\u00eat non desservi. Continuez \u00e0 pied pour WTC-GLIBERT.\", \"nl\": \"Tot einde augustus 2024, werken. halte niet bediend. Ga te voet verder om naar WTC-GLIBERT te gaan.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"46\"}]", "priority": 4, "points": "[{\"id\": \"1894\"}]"},{"content": "[{\"text\": [{\"en\": \"Until end of August, works. Bus 46 interrupted. Take bus 46 at ANNEESSENS (via bus 33).\", \"fr\": \"Jusque fin ao\u00fbt, travaux. Bus 46 interrompu. Prenez le bus 46 \u00e0 ANNEESSENS (via bus 33).\", \"nl\": \"Tot einde augustus, werken. Bus 46 onderbroken. Neem bus 46 aan ANNEESSENS (via bus 33).\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"46\"}]", "priority": 4, "points": "[{\"id\": \"1895\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. Until end of August, B46 not operated btw WTC-GLIBERT and PTE ANDERLECHT. For the center, bus 88 at WTC.\", \"fr\": \"Travaux. Jsq fin ao\u00fbt, B46 ne circule pas entre WTC-GLIBERT et PORTE D'ANDERLECHT. Pour le centre, bus 88 \u00e0 WTC.\", \"nl\": \"Werken. Tot einde augustus rijdt bus 46 niet tss WTC-GLIBERT en ANDERLECHTSEPT. Voor het centrum,neem B88 aan WTC\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"46\"}]", "priority": 5, "points": "[{\"id\": \"9025\"}, {\"id\": \"1896\"}, {\"id\": \"2209\"}]"},{"content": "[{\"text\": [{\"en\": \"Until Summer of 2024, works. As of Mar 4, stop of bus 47: Military Area, stop of bus 57 to GARE DU NORD.\", \"fr\": \"Jsq \u00e9t\u00e9 2024, travaux. D\u00e8s le 4/3, arr\u00eat du bus 47 : Domaine Militaire, arr\u00eat du bus 57 vers GARE DU NORD.\", \"nl\": \"Tot zomer 2024, werken. Vanaf 4/3, halte van bus 47: Militair Domein, halte van bus 57 naar NOORDSTATION..\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"47\"}]", "priority": 4, "points": "[{\"id\": \"3068\"}]"},{"content": "[{\"text\": [{\"en\": \"Until Summer of 2024, works. Stop not served. Take bus 47 or 57 at ANTOON VAN OSS (stop of bus 56 to BUDA).\", \"fr\": \"Jsq \u00e9t\u00e9 2024, travaux. Arr\u00eat non desservi. Prenez le bus 47 ou 57 \u00e0 ANTOON VAN OSS (arr\u00eat du bus 56 vers BUDA).\", \"nl\": \"Tot zomer 2024, werken. Halte niet bediend. Neem bus 47 of 57 aan ANTOON VAN OSS (halte van bus 56 naar BUDA).\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"47\"}]", "priority": 4, "points": "[{\"id\": \"1837\"}]"},{"content": "[{\"text\": [{\"en\": \"Until Summer of 2024, works. Bus 47 diverted btw VTM and RAMIER. As of Mar 18, stop HOPITAL MILITAIRE in rue Bruyn.\", \"fr\": \"Jsq \u00e9t\u00e9 2024, travaux. Bus 47 d\u00e9vi\u00e9 entre VTM et RAMIER. D\u00e8s le 18/3, arr\u00eat HOPITAL MILITAIRE rue Bruyn.\", \"nl\": \"Tot zomer 2024, werken. Bus 47 omgeleid tussen VTM en BOSDUIF. Vanaf 18/3,halte MILITAIR HOSP in de Bruynstraat.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"47\"}]", "priority": 5, "points": "[{\"id\": \"9784B\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. STOP NOT SERVED. B47: at the stop CROIX DE GUERRE of B56 (av. des Croix de Guerre)\", \"fr\": \"Travaux. ARRET NON DESSERVI. B47 : \u00e0 l'arr\u00eat CROIX DE GUERRE du B56 (av. des Croix de Guerre)\", \"nl\": \"Werken. HALTE NIET BEDIEND. B47: aan de halte OORLOGSKRUISEN van B56 (Oorlogskruisenlaan)\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"47\"}]", "priority": 4, "points": "[{\"id\": \"2362B\"}]"},{"content": "[{\"text\": [{\"en\": \"Until Summer of 2024, works. Stop of bus 47: rue de Ransbeekstraat 201.\", \"fr\": \"Jusqu'\u00e0 l'\u00e9t\u00e9 2024, travaux. Arr\u00eat du bus 47: rue de Ransbeek 201.\", \"nl\": \"Tot zomer 2024, werken. Halte van bus 47: Ransbeekstraat 201.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"47\"}]", "priority": 4, "points": "[{\"id\": \"2360\"}]"},{"content": "[{\"text\": [{\"en\": \"Until Summer of 2024, works. Stop not served. Take bus 47 at the stop of bus 56 to BUDA.\", \"fr\": \"Jusqu'\u00e0 l'\u00e9t\u00e9 2024, travaux. Arr\u00eat non desservi. Prenez le bus 47 \u00e0 l'arr\u00eat du bus 56 vers BUDA.\", \"nl\": \"Tot zomer 2024, werken. Halte niet bediend. Neem bus 47 aan de halte van bus 56 naar BUDA.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"47\"}]", "priority": 4, "points": "[{\"id\": \"2358\"}]"},{"content": "[{\"text\": [{\"en\": \"From Oct 18 9.30AM, stop not served. Go to the previous stop : HELDENPLEIN.\", \"fr\": \"A partir du 18/10 9h30, arr\u00eat non desservi. Rejoignez l'arr\u00eat pr\u00e9c\u00e9dent : HELDENPLEIN.\", \"nl\": \"Vanaf 18/10 9u30, halte niet bediend. Ga naar de vorige halte HELDENPLEIN.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"47\"}]", "priority": 4, "points": "[{\"id\": \"9787\"}]"},{"content": "[{\"text\": [{\"en\": \"Until Summer of 2024, works. Bus 47 diverted btw VTM and RAMIER. As of Mar 18, stop HOPITAL MILITAIRE in rue Bruyn.\", \"fr\": \"Jsq \u00e9t\u00e9 2024, travaux. Bus 47 d\u00e9vi\u00e9 entre VTM et RAMIER. D\u00e8s le 18/3, arr\u00eat HOPITAL MILITAIRE rue Bruyn.\", \"nl\": \"Tot zomer 2024, werken. Bus 47 omgeleid tussen VTM en BOSDUIF. Vanaf 18/3,halte MILITAIR HOSP in de Bruynstraat.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"47\"}]", "priority": 5, "points": "[{\"id\": \"9634\"}, {\"id\": \"9632\"}, {\"id\": \"9606\"}]"},{"content": "[{\"text\": [{\"en\": \"End of the works. As of Monday Apr 15, stop served by bus 49 to GARE DU MIDI / ZUIDSTATION. Bus 90 withdrawn.\", \"fr\": \"Fin des travaux. D\u00e8s le lundi 15/4, arr\u00eat desservi par les bus 49 vers GARE DU MIDI. Bus 90 supprim\u00e9\", \"nl\": \"Einde van de werken. Vanaf maandag 15/4 wordt deze halte bediend door bus 49 naar ZUIDSTATION. Bus 90 geschrapt.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"49\"}]", "priority": 4, "points": "[{\"id\": \"1207\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. Until 2026, tram 82 and 97 interrupted. Stop of the T-bus and of bus 50: ch. de Neerstalsestwg 236.\", \"fr\": \"Travaux. Jsq 2026, tram 82 et 97 interrompus. Arr\u00eat du T-bus et du bus 50: chauss\u00e9e de Neerstalle 236\", \"nl\": \"Werken. Tot 2026, tram 82 en 97 onderbroken. Halte van de T-bus en van bus 50: Neerstalsesteenweg 236\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"50\"}]", "priority": 4, "points": "[{\"id\": \"3604\"}]"},{"content": "[{\"text\": [{\"en\": \"Until 2026, works. Bus 50 diverted. Stop bus 50: bd 2e Arm\u00e9e Britannique / Britse Tweedelegerlaan.\", \"fr\": \"Jsq 2026, travaux. Bus 50 d\u00e9vi\u00e9. Arr\u00eat bus 50: bd 2e Arm\u00e9e Britannique, carrefour rue de la Station.\", \"nl\": \"Tot 2026, werken. Bus 50 omgeleid. Halte bus 50: Britse Tweedelegerlaan, kruispunt Stationstraat.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"50\"}]", "priority": 4, "points": "[{\"id\": \"5719\"}]"},{"content": "[{\"text\": [{\"en\": \"Until 2026, works. Bus 50 and T-bus diverted between FOREST CENTRE / VORST CENTRUM and BEMPT.\", \"fr\": \"Jusqu'en 2026, travaux. Bus 50 et T-bus d\u00e9vi\u00e9s entre FOREST CENTRE et BEMPT.\", \"nl\": \"Tot 2026, werken. Bus 50 en T-bus omgeleid tussen VORST CENTRUM en BEMPT.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"50\"}]", "priority": 5, "points": "[{\"id\": \"5915\"}, {\"id\": \"2548\"}, {\"id\": \"2546\"}, {\"id\": \"2544\"}, {\"id\": \"2555\"}, {\"id\": \"1015\"}, {\"id\": \"2553\"}, {\"id\": \"3211\"}, {\"id\": \"2539\"}]"},{"content": "[{\"text\": [{\"en\": \"From May 18, 5AM, works. STOP NOT SERVED. Stop of bus 52: avenue du Parc / Parklaan 26, in front of number 26.\", \"fr\": \"D\u00e8s le 18/5, 5h, travaux. ARRET NON DESSERVI. Arr\u00eat du bus 52: avenue du Parc, en face du num\u00e9ro 26.\", \"nl\": \"Vanaf 18/5, 5u, werken. HALTE NIET BEDIEND. Halte van bus 52: Parklaan, tegenover nummer 26.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"52\"}]", "priority": 4, "points": "[{\"id\": \"2334B\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. As of Apr 15 at 6AM, STOP NOT SERVED. Take bus 53 at BEYSEGHEM / BEIZEGEM.\", \"fr\": \"Travaux. D\u00e8s le 15/4 \u00e0 6h, ARRET NON DESSERVI. Prenez le bus 53 \u00e0 BEYSEGHEM.\", \"nl\": \"Werken. Vanaf 15/4 om 6u, HALTE NIET BEDIEND. Neem bus 53 aan BEIZEGEM.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"53\"}]", "priority": 4, "points": "[{\"id\": \"2852\"}]"},{"content": "[{\"text\": [{\"en\": \"Until Summer of 2024, works. Stop not served. Stop of bus 53: place Peter Benoitplein 3\", \"fr\": \"Jusqu'\u00e0 l'\u00e9t\u00e9 2024, travaux. Arr\u00eat non desservi. Arr\u00eat du bus 53 : place Peter Benoit 3\", \"nl\": \"Tot zomer 2024, werken. Halte niet bediend. Halte van bus 53: Peter Benoitplein 3\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"53\"}]", "priority": 4, "points": "[{\"id\": \"2362B\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. As of Apr 15 at 6AM, STOP NOT SERVED. Take bus 53 at BEYSEGHEM / BEIZEGEM.\", \"fr\": \"Travaux. D\u00e8s le 15/4 \u00e0 6h, ARRET NON DESSERVI. Prenez le bus 53 \u00e0 BEYSEGHEM.\", \"nl\": \"Werken. Vanaf 15/4 om 6u, HALTE NIET BEDIEND. Neem bus 53 aan BEIZEGEM.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"53\"}]", "priority": 4, "points": "[{\"id\": \"2819\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. As of Apr 15 at 6AM, bus 53 diverted between BEYSEGHEM / BEIZEGEM and PETER BENOIT.\", \"fr\": \"Travaux. D\u00e8s le 15/4 \u00e0 6h, bus 53 d\u00e9vi\u00e9 entre BEYSEGHEM et PETER BENOIT.\", \"nl\": \"Werken. Vanaf 15/4 om 6u, bus 53 omgeleid tussen BEIZEGEM en PETER BENOIT.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"53\"}]", "priority": 5, "points": "[{\"id\": \"2813B\"}, {\"id\": \"2815B\"}, {\"id\": \"2566B\"}, {\"id\": \"2572\"}, {\"id\": \"2571\"}, {\"id\": \"2570\"}, {\"id\": \"3085\"}, {\"id\": \"2171\"}, {\"id\": \"2647\"}, {\"id\": \"2569\"}, {\"id\": \"2547\"}, {\"id\": \"2568\"}, {\"id\": \"2567\"}, {\"id\": \"4132B\"}, {\"id\": \"2565\"}, {\"id\": \"2564\"}, {\"id\": \"2809\"}, {\"id\": \"2573B\"}, {\"id\": \"2648\"}, {\"id\": \"2824\"}, {\"id\": \"3637\"}, {\"id\": \"1767\"}, {\"id\": \"2811\"}, {\"id\": \"1204\"}, {\"id\": \"2810\"}, {\"id\": \"2575\"}, {\"id\": \"2817\"}, {\"id\": \"2816\"}, {\"id\": \"2814\"}, {\"id\": \"3605\"}]"},{"content": "[{\"text\": [{\"en\": \"Apr 2, 2024-June 2025, works. Bus 54 diverted btw FOREST CENTRE and FOREST NATIONAL. Info: stib-mivb.brussels.\", \"fr\": \"Du 2/4/2024 \u00e0 juin 2025, travaux. Bus 54 d\u00e9vi\u00e9 entre FOREST CENTRE et FOREST NATIONAL. Info: stib.brussels.\", \"nl\": \"2/4/2024-juni 2025, werken. Bus 54 omgeleid tussen VORST CENTRUM en VORST NATIONAAL. Info: mivb.brussels.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"54\"}]", "priority": 5, "points": "[{\"id\": \"5915\"}, {\"id\": \"1015\"}]"},{"content": "[{\"text\": [{\"en\": \"From Apr 2, 2024 to June 2025, works. STOP NOT SERVED. Stop of bus 54 and 74: avenue du Globelaan 8.\", \"fr\": \"Du 2/4/2024 \u00e0 juin 2025, travaux. ARRET NON DESSERVI. Arr\u00eat des bus 54 et 74: avenue du Globe 8.\", \"nl\": \"Van 2/4/2024 tot juni 2025, werken. HALTE NIET BEDIEND. Halte van bus 54 en 74: Globelaan 8.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"54\"}]", "priority": 4, "points": "[{\"id\": \"2616B\"}]"},{"content": "[{\"text\": [{\"en\": \"From Apr 2, 2024 to June 2025, works. STOP NOT SERVED. Take bus 54 at the next stop, FOREST NATIONAL.\", \"fr\": \"Du 2/4/2024 \u00e0 juin 2025, travaux. ARRET NON DESSERVI. Prenez le bus 54 \u00e0 l'arr\u00eat suivant, FOREST NATIONAL.\", \"nl\": \"Van 2/4/2024 tot juni 2025, werken. HALTE NIET BEDIEND. Neem bus 54 aan de volgende halte, VORST NATIONAAL.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"54\"}]", "priority": 4, "points": "[{\"id\": \"2952B\"}]"},{"content": "[{\"text\": [{\"en\": \"Apr 2, 2024-June 2025, works. Bus 54 diverted btw FOREST CENTRE and FOREST NATIONAL. Info: stib-mivb.brussels.\", \"fr\": \"Du 2/4/2024 \u00e0 juin 2025, travaux. Bus 54 d\u00e9vi\u00e9 entre FOREST CENTRE et FOREST NATIONAL. Info: stib.brussels.\", \"nl\": \"2/4/2024-juni 2025, werken. Bus 54 omgeleid tussen VORST CENTRUM en VORST NATIONAAL. Info: mivb.brussels.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"54\"}]", "priority": 5, "points": "[{\"id\": \"3243\"}]"},{"content": "[{\"text\": [{\"en\": \"As of Nov 14, stop moved to avenue Van Praetlaan, after Van Praet bridge.\", \"fr\": \"D\u00e8s le 14/11, arr\u00eat d\u00e9plac\u00e9 avenue Van Praet, apr\u00e8s le pont Van Praet.\", \"nl\": \"Vanaf 14/11, halte verplaatst naar de Van Praetlaan, na het Van Praetbrug.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"56\"}]", "priority": 4, "points": "[{\"id\": \"6370\"}]"},{"content": "[{\"text\": [{\"en\": \"Until Summer of 2024, works. As of March 18, buses 56 and 57 serve this stop normally.\", \"fr\": \"Jusqu'\u00e0 l'\u00e9t\u00e9 2024, travaux. D\u00e8s le 18/3, les bus 56 et 57 desservent \u00e0 nouveau cet arr\u00eat.\", \"nl\": \"Tot zomer 2024, werken. Vanaf 18/3 bedienen bus 56 en 57 opnieuw deze halte.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"56\"}]", "priority": 5, "points": "[{\"id\": \"1839\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. As of Apr 15, bus 56 diverted. Take bus 56 at the previous stop, at the St-Cyr house.\", \"fr\": \"Travaux. D\u00e8s le 15/4, bus 56 d\u00e9vi\u00e9. Prenez le bus 56 \u00e0 l'arr\u00eat pr\u00e9c\u00e9dent, devant la maison Saint-Cyr.\", \"nl\": \"Werken. Vanaf 15/4, bus 56 omgeleid. Neem bus 56 aan de vorige halte, voor het St-Cyr-huis.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"56\"}]", "priority": 4, "points": "[{\"id\": \"1273\"}]"},{"content": "[{\"text\": [{\"en\": \"Until Summer of 2024, works. Stop not served. Take bus 47 or 56 at ANTOON VAN OSS. For HOP MILITAIRE , walk.\", \"fr\": \"Jsq \u00e9t\u00e9 2024, travaux. Arr\u00eat non desservi. Bus 47 ou 56 \u00e0 ANTOON VAN OSS. Pour HOPITAL MILITAIRE, \u00e0 pied.\", \"nl\": \"Tot zomer 2024, werken. Halte niet bediend. Neem bus 47 of 56 aan ANTOON VAN OSS. Voor MILITAIR HOSPITAAL, ga te voet.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"56\"}]", "priority": 4, "points": "[{\"id\": \"1838\"}]"},{"content": "[{\"text\": [{\"en\": \"Until Summer of 2024, works. As of Mar 18, stop served normally by bus 56.\", \"fr\": \"Jusqu'\u00e0 l'\u00e9t\u00e9 2024, travaux. D\u00e8s le 18/3, arr\u00eat \u00e0 nouveau desservi par les bus 56.\", \"nl\": \"Tot zomer 2024, werken. Vanaf 18/3, halte opnieuw bediend door bus 56.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"56\"}]", "priority": 4, "points": "[{\"id\": \"2352\"}]"},{"content": "[{\"text\": [{\"en\": \"Until Summer of 2024, works. Stop not served. Take bus 57 at the stop of bus 56 to SCHUMAN.\", \"fr\": \"Jusqu'\u00e0 l'\u00e9t\u00e9 2024, travaux. Arr\u00eat non desservi. Prenez le bus 57 \u00e0 l'arr\u00eat du bus 56 vers SCHUMAN.\", \"nl\": \"Tot zomer 2024, werken. Halte niet bediend. Neem bus 57 aan de halte van bus 56 naar SCHUMAN.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"57\"}]", "priority": 4, "points": "[{\"id\": \"2317\"}]"},{"content": "[{\"text\": [{\"en\": \"Until Summer of 2024, works. Stop not served. Take bus 57 at the stop of bus 56 to BUDA.\", \"fr\": \"Jusqu'\u00e0 l'\u00e9t\u00e9 2024, travaux. Arr\u00eat non desservi. Prenez le bus 57 \u00e0 l'arr\u00eat du bus 56 vers BUDA.\", \"nl\": \"Tot zomer 2024, werken. Halte niet bediend. Neem bus 57 aan de halte van bus 56 naar BUDA.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"57\"}]", "priority": 4, "points": "[{\"id\": \"2358\"}]"},{"content": "[{\"text\": [{\"en\": \"Until Summer of 2024, works. Bus 57 diverted. Take bus 57 at ANTOON VAN OSS (stop of bus 56 to BUDA)\", \"fr\": \"Jusqu'\u00e0 l'\u00e9t\u00e9 2024, travaux. Bus 57 d\u00e9vi\u00e9. Prenez le bus 57 \u00e0 ANTOON VAN OSS (arr\u00eat du bus 56 vers BUDA).\", \"nl\": \"Tot zomer 2024, werken. Bus 57 omgeleid. Neem bus 57 aan ANTOON VAN OSS (halte van bus 56 naar BUDA).\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"57\"}]", "priority": 4, "points": "[{\"id\": \"1827\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. As of Apr 24 at 6.30AM, STOP NOT SERVED. Take bus 59 at the next stop, COTEAUX / WIJNHEUVELEN.\", \"fr\": \"Travaux. D\u00e8s le 24/4 \u00e0 6h30, ARRET NON DESSERVI. Prenez le bus 59 \u00e0 l'arr\u00eat suivant, COTEAUX.\", \"nl\": \"Werken. Vanaf 24/4 om 6. 30u, HALTE NIET BEDIEND. Neem bus 59 aan de volgende halte, WIJNHEUVELEN.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"59\"}]", "priority": 4, "points": "[{\"id\": \"3163\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. As of Apr 24 at 6.30AM, STOP NOT SERVED. Stop of bus 59: ST-JOSSE / ST-JOOST (rue Willemsstraat 9).\", \"fr\": \"Travaux. D\u00e8s le 24/4 \u00e0 6h30, ARRET NON DESSERVI. Arr\u00eat du bus 59: SAINT-JOSSE (rue Willems, 9).\", \"nl\": \"Werken. Vanaf 24/4 om 6. 30u, HALTE NIET BEDIEND. Halte van bus 59: SINT-JOOST (Willemsstraat 9).\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"59\"}]", "priority": 4, "points": "[{\"id\": \"3162\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. As of Apr 24 at 6.30AM, bus 59 diverted. Stop bus 59: GUTENBERG (rue des Eburons / Eburonenstraat 10)\", \"fr\": \"Travaux. D\u00e8s le 24/4 \u00e0 6h30, bus 59 d\u00e9vi\u00e9. Arr\u00eat du bus 59: GUTENBERG (rue des Eburons, 10).\", \"nl\": \"Werken. Vanaf 24/4 om 6. 30u, bus 59 omgeleid. Halte van bus 59: GUTENBERG (Eburonenstraat, 10).\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"59\"}]", "priority": 4, "points": "[{\"id\": \"3118\"}, {\"id\": \"3114\"}, {\"id\": \"6017\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. As of Apr 24 at 6.30AM, STOP NOT SERVED. Stop of bus 59: rue des Coteaux / Wijnheuvelenstraat 213.\", \"fr\": \"Travaux. D\u00e8s le 24/4 \u00e0 6h30, ARRET NON DESSERVI. Arr\u00eat du bus 59, rue des Coteaux, 213.\", \"nl\": \"Werken. Vanaf 24/4 om 6. 30u, HALTE NIET BEDIEND. Halte van bus 59: Wijnheuvelenstraat, 213.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"59\"}]", "priority": 4, "points": "[{\"id\": \"3112\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. As of Apr 15, bus 60 diverted between JOURDAN and AMBIORIX via MAELBEEK. Connection metro at MAELBEEK.\", \"fr\": \"Travaux. D\u00e8s le 15/4, bus 60 d\u00e9vi\u00e9 entre JOURDAN et AMBIORIX via MAELBEEK. Correspondance m\u00e9tro \u00e0 MAELBEEK.\", \"nl\": \"Werken. Vanaf 15/4, bus 60 omgeleid tussen JOURDAN en AMBIORIX via MAALBEEK. Aansluiting metro aan MAALBEEK.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"60\"}]", "priority": 6, "points": "[{\"id\": \"3158B\"}, {\"id\": \"6453\"}, {\"id\": \"6112\"}, {\"id\": \"2133\"}, {\"id\": \"2132\"}, {\"id\": \"2131\"}, {\"id\": \"1250\"}, {\"id\": \"4857B\"}, {\"id\": \"4804B\"}, {\"id\": \"6956B\"}, {\"id\": \"3160\"}, {\"id\": \"1976\"}, {\"id\": \"1986\"}, {\"id\": \"1884\"}, {\"id\": \"1653\"}, {\"id\": \"1883\"}, {\"id\": \"1980\"}, {\"id\": \"2134\"}, {\"id\": \"1739\"}, {\"id\": \"6406\"}, {\"id\": \"2847\"}, {\"id\": \"1977\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. As of Apr 15, STOP NOT SERVED. Take bus 60 at PARC LEOPOLD (ch. Etterbeek, in front of number 166).\", \"fr\": \"Travaux. D\u00e8s le 15/4, ARRET NON DESSERVI. Bus 60 \u00e0 PARC LEOPOLD (chauss\u00e9e d'Etterbeek, en face du num\u00e9ro 166).\", \"nl\": \"Werken. Vanaf 15/4, HALTE NIET BEDIEND. Neem bus 60 aan LEOPOLDSPARK (Etterbeeksesteenweg, tegenover nummer 166)\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"60\"}]", "priority": 4, "points": "[{\"id\": \"1271B\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. As of Apr 15, STOP NOT SERVED. Take bus 60 at MAELBEEK / MAALBEEK.\", \"fr\": \"Travaux. D\u00e8s le 15/4, ARRET NON DESSERVI. Prenez le bus 60 \u00e0 MAELBEEK.\", \"nl\": \"Werken. Vanaf 15/4, HALTE NIET BEDIEND. Neem bus 60 aan MAALBEEK.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"60\"}]", "priority": 4, "points": "[{\"id\": \"1270B\"}]"},{"content": "[{\"text\": [{\"en\": \"From Apr 24 at 6AM, works. STOP NOT SERVED. Temporary stop: rue Guillaume Kennisstraat 8.\", \"fr\": \"D\u00e8s le 24/4 \u00e0 6h, travaux. ARRET NON DESSERVI. Arr\u00eat provisoire: rue Guillaume Kennis 8.\", \"nl\": \"Vanaf 24/4 om 6u, werken. HALTE NIET BEDIEND. Tijdelijke halte: Guillaume Kennisstraat 8.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"66\"}]", "priority": 4, "points": "[{\"id\": \"2346\"}]"},{"content": "[{\"text\": [{\"en\": \"Risk of subsidence. Stop of bus 65, 66 and N04 moved to chauss\u00e9e de Haecht/Haachtsesteenweg, next to number 162\", \"fr\": \"Risque d'effondrement. Arr\u00eat des bus 65, 66 et N04 d\u00e9plac\u00e9 chauss\u00e9e de Haecht, \u00e0 hauteur du num\u00e9ro 162.\", \"nl\": \"Risico op instorting. Halte van bus 65, 66 en N04 verplaatst naar de Haachtsesteenweg, ter hoogte van nummer 162.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"66\"}]", "priority": 4, "points": "[{\"id\": \"6418\"}]"},{"content": "[{\"text\": [{\"en\": \"From Jan 7 at 9PM to Jun 28, works. Tram 7 does not serve this stop. Take tram 3 to go to VANDERKINDERE.\", \"fr\": \"Du 7/1 \u00e0 21h au 28/6, travaux. Tram 7 ne dessert pas cet arr\u00eat. Prenez le tram 3 pour rejoindre VANDERKINDERE.\", \"nl\": \"Van 7/1 om 21u tot en met 28/6, werken. Tram 7 bedient deze halte niet. Neem tram 3 om naar VANDERKINDERE te gaan.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"7\"}]", "priority": 4, "points": "[{\"id\": \"5219F\"}]"},{"content": "[{\"text\": [{\"en\": \"From Jan 8 to Jun 28, works. Tram 7 interrupted to HEEMBEEK. T-bus at the stop of bus 56 to BUDA.\", \"fr\": \"Du 8/1 au 28/6, travaux. Tram 7 interrompu jusqu'\u00e0 HEEMBEEK. T-bus \u00e0 l'arr\u00eat du bus 56 vers BUDA.\", \"nl\": \"8/1-28/6, werken. Tram 7 onderbroken tot HEEMBEEK. T-bus aan de halte van bus 56 naar BUDA.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"7\"}]", "priority": 5, "points": "[{\"id\": \"5759F\"}]"},{"content": "[{\"text\": [{\"en\": \"Jan 8-Jun 28, works. Tram 7 replaced by T-bus between DOCKS BRUXSEL and HEEMBEEK. Info: stib-mivb.brussels\", \"fr\": \"8/1-28/6, travaux. Tram 7 remplac\u00e9 par des T-bus entre DOCKS BRUXSEL et HEEMBEEK. Info: stib. brussels.\", \"nl\": \"8/1-28/6, werken. Tram 7 vervangen door T-bus tussen DOCKS BRUXSEL en HEEMBEEK. info: mivb. brussels.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"7\"}]", "priority": 5, "points": "[{\"id\": \"2636F\"}, {\"id\": \"9056F\"}]"},{"content": "[{\"text\": [{\"en\": \"From Mar 18, works. STOP NOT SERVED. stop of bus 71: avenue de l'Universit\u00e9 / Hogeschoollaan 4-10.\", \"fr\": \"D\u00e8s le 18/3, travaux. ARRET NON DESSERVI. Arr\u00eat du bus 71: avenue de l'Universit\u00e9 4-10.\", \"nl\": \"Vanaf 18/3, werken. HALTE NIET BEDIEND. Halte van bus 71: Hogeschoollaan 4-10.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"71\"}]", "priority": 4, "points": "[{\"id\": \"3514\"}]"},{"content": "[{\"text\": [{\"en\": \"Apr 2, 2024-June 2025, works. Bus 74 diverted btw FOREST CENTRE and FOREST NATIONAL. Info: stib-mivb.brussels.\", \"fr\": \"Du 2/4/2024 \u00e0 juin 2025, travaux. Bus 74 d\u00e9vi\u00e9 entre FOREST CENTRE et FOREST NATIONAL. Info: stib.brussels.\", \"nl\": \"2/4/2024-juni 2025, werken. Bus 74 omgeleid tussen VORST CENTRUM en VORST NATIONAAL. Info: mivb.brussels.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"74\"}]", "priority": 5, "points": "[{\"id\": \"3682\"}, {\"id\": \"3074\"}, {\"id\": \"5915\"}, {\"id\": \"2614\"}, {\"id\": \"2602\"}, {\"id\": \"2601\"}, {\"id\": \"2600\"}, {\"id\": \"2226\"}, {\"id\": \"2523\"}, {\"id\": \"2555\"}, {\"id\": \"2599\"}, {\"id\": \"1015\"}, {\"id\": \"2598\"}, {\"id\": \"2607\"}, {\"id\": \"2606\"}, {\"id\": \"2605\"}]"},{"content": "[{\"text\": [{\"en\": \"From Apr 2, 2024 to June 2025, works. STOP NOT SERVED. Stop of bus 54 and 74: avenue du Globelaan 8.\", \"fr\": \"Du 2/4/2024 \u00e0 juin 2025, travaux. ARRET NON DESSERVI. Arr\u00eat des bus 54 et 74: avenue du Globe 8.\", \"nl\": \"Van 2/4/2024 tot juni 2025, werken. HALTE NIET BEDIEND. Halte van bus 54 en 74: Globelaan 8.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"74\"}]", "priority": 4, "points": "[{\"id\": \"2616B\"}]"},{"content": "[{\"text\": [{\"en\": \"From Jan 18, works. STOP NOT SERVED. Temporary stop: Avenue de Roodebeeklaan 45.\", \"fr\": \"D\u00e8s le 18/1, travaux. ARRET NON DESSERVI. Arr\u00eat provisoire: Avenue de Roodebeek 45.\", \"nl\": \"Vanaf 18/1, werken. HALTE NIET BEDIEND. Tijdelijke halte: Roodebeeklaan 45.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"79\"}]", "priority": 4, "points": "[{\"id\": \"1404\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. As of Apr 15, STOP NOT SERVED. Stop of bus 79: rue Archim\u00e8de / Archimedesstraat 16.\", \"fr\": \"Travaux. D\u00e8s le 15/4, ARRET NON DESSERVI. Arr\u00eat du bus 79: rue Archim\u00e8de 16.\", \"nl\": \"Werken. Vanaf 15/4, HALTE NIET BEDIEND. Halte van bus 79: Archimedesstraat 16.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"79\"}]", "priority": 4, "points": "[{\"id\": \"1474B\"}, {\"id\": \"2083\"}]"},{"content": "[{\"text\": [{\"en\": \"Works.From Apr 29 at 7AM until May 3 at 5PM, bus 80 diverted. Stop B80: av. L. Grosjeanl, before the highway bridge.\", \"fr\": \"Travaux. Du 29/4 \u00e0 7h au 3/5 \u00e0 17h, bus 80 d\u00e9vi\u00e9. Arr\u00eat du bus 80: av. L\u00e9on Grosjean, avant le pont de l'autoroute\", \"nl\": \"Werken. Van 29/4 om 7u tot 3/5 om 17u, bus 80 omgeleid. Halte van bus 80: L\u00e9on Grosjeanlaan, voor brug autostrade\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"80\"}]", "priority": 4, "points": "[{\"id\": \"3904\"}]"},{"content": "[{\"text\": [{\"en\": \"Works.From Apr 29 at 7AM until May 3 at 5PM, bus 80 diverted. Stop B80: ch. Roodebeeksestwg 493.\", \"fr\": \"Travaux. Du 29/4 \u00e0 7h au 3/5 \u00e0 17h, bus 80 d\u00e9vi\u00e9. Arr\u00eat du bus 80: chauss\u00e9e de Roodebeek 493\", \"nl\": \"Werken. Van 29/4 om 7u tot 3/5 om 17u, bus 80 omgeleid. Halte van bus 80: Roodebeeksesteenweg 493\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"80\"}]", "priority": 4, "points": "[{\"id\": \"3905\"}, {\"id\": \"3906\"}]"},{"content": "[{\"text\": [{\"en\": \"T81-T97 operate normally againBAREEL and JANSON\", \"fr\": \"T81-T97 circulent \u00e0 nouveau entre BARRIERE et JANSON\", \"nl\": \"T81-T97 worden weer bediend tussen BAREEL en JANSON\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"81\"}]", "priority": 3, "points": "[{\"id\": \"6463F\"}]"},{"content": "[{\"text\": [{\"en\": \"T81-T97 operate normally againBAREEL and JANSON\", \"fr\": \"T81-T97 circulent \u00e0 nouveau entre BARRIERE et JANSON\", \"nl\": \"T81-T97 worden weer bediend tussen BAREEL en JANSON\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"81\"}]", "priority": 3, "points": "[{\"id\": \"2286G\"}]"},{"content": "[{\"text\": [{\"en\": \"Until 2026, works. Stop not served. Take tram 82 at FOREST CENTRE / VORST CENTRUM (stop to Drogenbos).\", \"fr\": \"Jusqu'en 2026, travaux. Arr\u00eat non desservi. Prenez le tram 82 \u00e0 FOREST CENTRE (arr\u00eat vers Drogenbos).\", \"nl\": \"Tot 2026, werken. Halte niet bediend. Neem tram 82 aan VORST CENTRUM (halte naar Drogenbos).\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"82\"}]", "priority": 4, "points": "[{\"id\": \"5152G\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. Until 2026, stop not served. Walk to DROGENBOS.\", \"fr\": \"Travaux. Jusqu'en 2026, arr\u00eat non desservi. Pour rejoindre DROGENBOS, continuez \u00e0 pied.\", \"nl\": \"Werken. Tot 2026, halte niet bediend. Ga te voet verder om naar DROGENBOS te gaan.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"82\"}]", "priority": 4, "points": "[{\"id\": \"5729\"}, {\"id\": \"5725\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. Until 2026, stop not served. T-bus 82 to DROGENBOS at the previous stop, CARREFOUR STALLE.\", \"fr\": \"Travaux. Jusqu'en 2026, arr\u00eat non desservi. T-bus 82 vers DROGENBOS \u00e0 l'arr\u00eat pr\u00e9c\u00e9dent, CARREFOUR STALLE.\", \"nl\": \"Werken. Tot 2026, halte niet bediend. T-bus 82 naar DROGENBOS aan de vorige halte, KRUISPUNT STALLE.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"82\"}]", "priority": 4, "points": "[{\"id\": \"5724\"}]"},{"content": "[{\"text\": [{\"en\": \"Jan 22, 6AM-end of June, works. B86 diverted. Stop of B86:ch.De Gand/ Gentsestwg, in front of number 219 (Stop B13).\", \"fr\": \"Du 22/1 \u00e0 6h jusqu'\u00e0 fin juin, travaux. Bus 86 d\u00e9vi\u00e9. Arr\u00eat du B86: ch. de Gand, en face du num\u00e9ro 219 (arr\u00eat B13).\", \"nl\": \"Van 22/1 om 6u tot eind juni, werken. Bus 86 omgeleid. Halte van B86: Gentsesteenweg,tegenover nr. 219 (halte bus 13).\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"86\"}]", "priority": 4, "points": "[{\"id\": \"6754\"}]"},{"content": "[{\"text\": [{\"en\": \"Jan 22, 6AM-end of June, works. Bus 86 diverted. Bus 86 at stop MERCHTEM of bus 20 to GARE DU NORD / NOORDSTATION.\", \"fr\": \"Du 22/1 \u00e0 6h jusqu'\u00e0 fin juin, travaux. Bus 86 d\u00e9vi\u00e9. Bus 86 \u00e0 l'arr\u00eat MERCHTEM du bus 20 vers GARE DU NORD.\", \"nl\": \"Van 22/1 om 6u tot eind juni, werken. Bus 86 omgeleid. B86 aan halte MERCHTEM van bus 20 naar NOORDSTATION.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"86\"}]", "priority": 4, "points": "[{\"id\": \"6755\"}]"},{"content": "[{\"text\": [{\"en\": \"From Mar 3 at 7AM, works. STOP NOT SERVED. Take bus 86 at the next stop DUCHESSE BRABANT / HERTOGIN BRABANT.\", \"fr\": \"D\u00e8s le 3/3 \u00e0 7h, travaux. ARRET NON DESSERVI. Prenez le bus 86 \u00e0 l'arr\u00eat suivant, DUCHESSE BRABANT.\", \"nl\": \"Vanaf 3/3 om 7u, werken. HALTE NIET BEDIEND. Neem bus 86 aan de volgende halte HERTOGIN BRABANT.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"86\"}]", "priority": 4, "points": "[{\"id\": \"6706\"}]"},{"content": "[{\"text\": [{\"en\": \"From Jan 22 at 6AM to end of June, works. Bus 86 diverted. Stop of bus 86: rue A. Vandenpeereboomstraat 44\", \"fr\": \"Du 22/1 \u00e0 6h jusqu'\u00e0 fin juin, travaux. Bus 86 d\u00e9vi\u00e9. Arr\u00eat du bus 86: rue  A. Vandenpeereboom 44.\", \"nl\": \"Van 22/1 om 6u tot eind juni, werken. Bus 86 omgeleid. Halte van bus 86: A. Vandenpeereboomstraat 44\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"86\"}]", "priority": 4, "points": "[{\"id\": \"4595\"}, {\"id\": \"1242\"}]"},{"content": "[{\"text\": [{\"en\": \"From Dec 4, works. STOP NOT SERVED. Stop of bus 88: rue du Progr\u00e8s / Vooruitgangstraat 64.\", \"fr\": \"D\u00e8s le 4/12, travaux. ARRET NON DESSERVI. Arr\u00eat du bus 88: rue du Progr\u00e8s 64.\", \"nl\": \"Vanaf 4/12, werken. HALTE NIET BEDIEND. Halte van bus 88: Vooruitgangstraat 64.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"88\"}]", "priority": 4, "points": "[{\"id\": \"3400\"}]"},{"content": "[{\"text\": [{\"en\": \"As of Nov 16 at 6AM, works. Stop moved to av. Port / Havenln, in front of number 100 (moved backward of +/- 120m)\", \"fr\": \"D\u00e8s le 16/11 \u00e0 6h, travaux. Arr\u00eat d\u00e9plac\u00e9 avenue du Port, en face du num\u00e9ro 100 (recul\u00e9 de +/- 120m).\", \"nl\": \"Vanaf 16/11 om 6u,werken Halte verplaatst naar de Havenlaan, tegenover nr 100 (achteruitgebracht van +/- 120m)\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"88\"}]", "priority": 4, "points": "[{\"id\": \"2305\"}]"},{"content": "[{\"text\": [{\"en\": \"From Dec 4, works. STOP NOT SERVED. Stop of bus 58 and 88 : rue du Progr\u00e8s, after crossing rue des Charbonniers.\", \"fr\": \"D\u00e8s le 4/12, travaux. ARRET NON DESSERVI. Arr\u00eat des bus 58 et 88 : rue du Progr\u00e8s, apr\u00e8s rue des Charbonniers.\", \"nl\": \"Vanaf 4/12, werken. HALTE NIET BEDIEND. Halte bus 58 en 88 : Vooruitgangstraat, na Koolbrandersstraat.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"88\"}]", "priority": 4, "points": "[{\"id\": \"1083\"}]"},{"content": "[{\"text\": [{\"en\": \"Until end of August, works. Bus 89 diverted btw PTE DE NINOVE and BOURSE, and interrupted bt BOURSE and CENTRAL ST\", \"fr\": \"Jsq fin ao\u00fbt, travaux. Bus 89 d\u00e9vi\u00e9 entre PORTE DE NINOVE et BOURSE, et interrompu entre BOURSE et GARE CENTRALE.\", \"nl\": \"Tot einde augustus, werken. Bus 89 omgeleid tss NINOOFSEPOORT en BEURS, en onderbroken tss BEURS en CENTR ST\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"89\"}]", "priority": 5, "points": "[{\"id\": \"2754\"}, {\"id\": \"2776\"}, {\"id\": \"2748B\"}, {\"id\": \"4595\"}, {\"id\": \"1178\"}, {\"id\": \"2784\"}, {\"id\": \"2782\"}, {\"id\": \"6648\"}]"},{"content": "[{\"text\": [{\"en\": \"Until end of August 2024, works. Stop not served. Take bus 29 or 71 at DE BROUCKERE to go to CENTRAL STATION.\", \"fr\": \"Jsq fin ao\u00fbt 2024, travaux. Arr\u00eat non desservi. Prenez le bus 29 ou 71 \u00e0 DE BROUCKERE pour GARE CENTRALE.\", \"nl\": \"Tot einde augustus 2024, werken. halte niet bediend. Neem bus 29 of 71 aan DE BROUCKERE om naar CENTR. ST. te gaan\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"89\"}]", "priority": 4, "points": "[{\"id\": \"1894\"}]"},{"content": "[{\"text\": [{\"en\": \"Until end of August, works. Bus 89 diverted. For the city center, take metro 1 or 5 at STE-CATHERINE.\", \"fr\": \"Jusque fin ao\u00fbt, travaux. Bus 89 d\u00e9vi\u00e9. Pour le centre-ville, prenez le m\u00e9tro 1 ou 5 \u00e0 SAINTE-CATHERINE.\", \"nl\": \"Tot einde augustus, werken. Bus 89 omgeleid. Om naar het stadscentrum te gaan, neem M 1 5 aan SINT-KATELIJNE.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"89\"}]", "priority": 4, "points": "[{\"id\": \"3261\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. From Apr 26 at 9PM until May 12, stop not served. Walk to ROI BAUDOUIN / KONING BOUDEWIJN.\", \"fr\": \"Travaux. Du 26/4 \u00e0 21h au 12/5, arr\u00eat non desservi. Pour rejoindre ROI BAUDOUIN, continuez \u00e0 pied.\", \"nl\": \"Werken. Van 26/4 om 21u tot en met 12/5, halte niet bediend. Ga te voet verder naar KONING BOUDEWIJN.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"9\"}]", "priority": 4, "points": "[{\"id\": \"1693F\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. From Apr 26 at 9PM until May 12, stop not served. T-bus to UZ BRUSSEL at the stop of bus 820 to UZ BRUSSEL.\", \"fr\": \"Travaux. Du 26/4 \u00e0 21h au 12/5, arr\u00eat non desservi. T-bus vers UZ BRUSSEL \u00e0 l'arr\u00eat du bus 820 vers UZ BRUSSEL.\", \"nl\": \"Werken. 26/4, 21u-12/5, halte niet bediend. T-bus naar UZ BRUSSEL aan de halte van bus 820 naar UZ BRUSSEL.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"9\"}]", "priority": 4, "points": "[{\"id\": \"1686F\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. From Apr 26 at 9PM until May 12, stop not served. T-bus to ROI BAUDOUIN at the stop of bus 820 to ZAVENTEM.\", \"fr\": \"Travaux. Du 26/4 \u00e0 21h au 12/5, arr\u00eat non desservi. T-bus vers ROI BAUDOUIN \u00e0 l'arr\u00eat du bus 820 vers ZAVENTEM.\", \"nl\": \"Werken. 26/4, 21u-12/5, halte niet bediend.T-bus naar KONING BOUDEWIJN aan de halte van bus 820 naar ZAVENTEM.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"9\"}]", "priority": 4, "points": "[{\"id\": \"1687F\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. From Apr 26 at 9PM until May 12, stop not served. Stop of the T-bus: av. Arbre Ballon / Dikke Beuklaan 117\", \"fr\": \"Travaux. Du 26/4 \u00e0 21h au 12/5, arr\u00eat non desservi. Arr\u00eat du T-bus: avenue de l'Arbre Ballon 117.\", \"nl\": \"Werken. Van 26/4 om 21u tot en met 12/5, halte niet bediend. Halte van de T-bus: Dikke Beuklaan 117.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"9\"}]", "priority": 4, "points": "[{\"id\": \"4223F\"}]"},{"content": "[{\"text\": [{\"en\": \"From Mar 5 at 9AM, works. STOP NOT SERVED. Temporary stop: avenue Jean & Pierre Carsoellaan 4.\", \"fr\": \"D\u00e8s le 5/3 \u00e0 9h, travaux. ARRET NON DESSERVI. Arr\u00eat provisoire: avenue Jean et Pierre Carsoel 4.\", \"nl\": \"Vanaf 5/3 om 9u, werken. HALTE NIET BEDIEND. Tijdelijke halte: Jean en Pierre Carsoellaan 4.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"92\"}]", "priority": 4, "points": "[{\"id\": \"6931H\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. As of Mar 27, STOP MOVED. Stop of bus 95: rue des Thuyas / Thujastraat 13.\", \"fr\": \"Travaux. D\u00e8s le 27/3, ARRET DEPLACE. Arr\u00eat du bus 95: rue des Thuyas, 13.\", \"nl\": \"Werken. Vanaf 27/3, HALTE VERPLAATST. Halte van bus 95: Thujastraat 13.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"95\"}]", "priority": 4, "points": "[{\"id\": \"4310\"}]"},{"content": "[{\"text\": [{\"en\": \"From Mar 25 until Jun 30, works. STOP NOT SERVED. Stop of bus 95: bd. Gen. Jacqueslaan 235.\", \"fr\": \"Du 25/3 au 30/6, travaux. ARRET NON DESSERVI. Arr\u00eat du bus 95: boulevard G\u00e9n\u00e9ral Jacques, 235.\", \"nl\": \"Van 25/3 tot en met 30/6, werken. HALTE NIET BEDIEND. Halte van bus 95:  Generaal Jacqueslaan 235.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"95\"}]", "priority": 4, "points": "[{\"id\": \"4363\"}]"},{"content": "[{\"text\": [{\"en\": \"From Mar 18, works. STOP NOT SERVED. stop of bus 95: chauss\u00e9e de Boondael / Boondaalsesteenweg, before roundabout.\", \"fr\": \"D\u00e8s le 18/3, travaux. ARRET NON DESSERVI. Arr\u00eat du bus 95: chauss\u00e9e de Boondael, avant le rond-point.\", \"nl\": \"Vanaf 18/3, werken. HALTE NIET BEDIEND. Halte van bus 95: Boondaalsesteenweg, voor rondpunt.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"95\"}]", "priority": 4, "points": "[{\"id\": \"3514\"}]"},{"content": "[{\"text\": [{\"en\": \"From Mar 18, works. STOP NOT SERVED. Temporary stop: avenue de la Couronne / Kroonlaan 439-443.\", \"fr\": \"D\u00e8s le 18/3, travaux. ARRET NON DESSERVI. Arr\u00eat provisoire: avenue de la Couronne 439-443.\", \"nl\": \"Vanaf 18/3, werken. HALTE NIET BEDIEND. Tijdelijke halte: Kroonlaan 439-443.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"95\"}]", "priority": 4, "points": "[{\"id\": \"3558\"}]"},{"content": "[{\"text\": [{\"en\": \"T81-T97 operate normally againBAREEL and JANSON\", \"fr\": \"T81-T97 circulent \u00e0 nouveau entre BARRIERE et JANSON\", \"nl\": \"T81-T97 worden weer bediend tussen BAREEL en JANSON\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"97\"}]", "priority": 3, "points": "[{\"id\": \"5917F\"}]"},{"content": "[{\"text\": [{\"en\": \"T81-T97 operate normally againBAREEL and JANSON\", \"fr\": \"T81-T97 circulent \u00e0 nouveau entre BARRIERE et JANSON\", \"nl\": \"T81-T97 worden weer bediend tussen BAREEL en JANSON\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"97\"}]", "priority": 3, "points": "[{\"id\": \"5163F\"}]"},{"content": "[{\"text\": [{\"en\": \"T81-T97 operate normally againBAREEL and JANSON\", \"fr\": \"T81-T97 circulent \u00e0 nouveau entre BARRIERE et JANSON\", \"nl\": \"T81-T97 worden weer bediend tussen BAREEL en JANSON\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"97\"}]", "priority": 3, "points": "[{\"id\": \"5719H\"}]"},{"content": "[{\"text\": [{\"en\": \"T81-T97 operate normally againBAREEL and JANSON\", \"fr\": \"T81-T97 circulent \u00e0 nouveau entre BARRIERE et JANSON\", \"nl\": \"T81-T97 worden weer bediend tussen BAREEL en JANSON\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"97\"}]", "priority": 3, "points": "[{\"id\": \"5953F\"}, {\"id\": \"6361\"}, {\"id\": \"5120\"}, {\"id\": \"5175\"}, {\"id\": \"6077F\"}, {\"id\": \"5123\"}, {\"id\": \"2604F\"}, {\"id\": \"5158\"}, {\"id\": \"5068F\"}, {\"id\": \"5066F\"}, {\"id\": \"2603\"}, {\"id\": \"2462F\"}, {\"id\": \"6427F\"}, {\"id\": \"9972F\"}, {\"id\": \"6430F\"}, {\"id\": \"5119\"}, {\"id\": \"6109\"}, {\"id\": \"2333F\"}, {\"id\": \"2463F\"}]"},{"content": "[{\"text\": [{\"en\": \"T81-T97 operate normally againBAREEL and JANSON\", \"fr\": \"T81-T97 circulent \u00e0 nouveau entre BARRIERE et JANSON\", \"nl\": \"T81-T97 worden weer bediend tussen BAREEL en JANSON\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"97\"}]", "priority": 3, "points": "[{\"id\": \"2765\"}, {\"id\": \"2764G\"}]"}]
+[
+    {
+        "content": "[{\"text\": [{\"en\": \"Obstacle on the tracks: T81-T97 are not operated between BAREEL and JANSON\", \"fr\": \"Obstacle sur les voies: T81-T97 Trafic interrompu entre BARRIERE et JANSON\", \"nl\": \"Obstakel op de sporen: T81-T97 Geen verkeer tussen BAREEL en JANSON\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"81\"}]",
+        "priority": 2,
+        "points": "[{\"id\": \"6462F\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Obstacle on the tracks: T81-T97 are not operated between BAREEL and JANSON\", \"fr\": \"Obstacle sur les voies: T81-T97 Trafic interrompu entre BARRIERE et JANSON\", \"nl\": \"Obstakel op de sporen: T81-T97 Geen verkeer tussen BAREEL en JANSON\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"81\"}]",
+        "priority": 2,
+        "points": "[{\"id\": \"6099\"}, {\"id\": \"6121F\"}, {\"id\": \"3611F\"}, {\"id\": \"6113F\"}, {\"id\": \"3613F\"}, {\"id\": \"3123\"}, {\"id\": \"6858G\"}, {\"id\": \"6705F\"}, {\"id\": \"2260F\"}, {\"id\": \"1805F\"}, {\"id\": \"6799F\"}, {\"id\": \"6860G\"}, {\"id\": \"6106\"}, {\"id\": \"6008\"}, {\"id\": \"6109\"}, {\"id\": \"2971F\"}, {\"id\": \"2331F\"}, {\"id\": \"6120\"}, {\"id\": \"6077F\"}, {\"id\": \"2539F\"}, {\"id\": \"3612F\"}, {\"id\": \"6114F\"}, {\"id\": \"3371F\"}, {\"id\": \"0631\"}, {\"id\": \"6427F\"}, {\"id\": \"6117\"}, {\"id\": \"2259F\"}, {\"id\": \"6856\"}, {\"id\": \"3508F\"}, {\"id\": \"2257G\"}, {\"id\": \"6857\"}, {\"id\": \"2960F\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Obstacle on the tracks: T81-T97 are not operated between BAREEL and JANSON\", \"fr\": \"Obstacle sur les voies: T81-T97 Trafic interrompu entre BARRIERE et JANSON\", \"nl\": \"Obstakel op de sporen: T81-T97 Geen verkeer tussen BAREEL en JANSON\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"81\"}]",
+        "priority": 2,
+        "points": "[{\"id\": \"6153\"}, {\"id\": \"6175\"}, {\"id\": \"6078\"}, {\"id\": \"6809F\"}, {\"id\": \"1042\"}, {\"id\": \"3370F\"}, {\"id\": \"3572F\"}, {\"id\": \"2220F\"}, {\"id\": \"6157F\"}, {\"id\": \"2931F\"}, {\"id\": \"6009\"}, {\"id\": \"6155F\"}, {\"id\": \"6166\"}, {\"id\": \"6165\"}, {\"id\": \"3610F\"}, {\"id\": \"6068\"}, {\"id\": \"2218F\"}, {\"id\": \"6808G\"}, {\"id\": \"6162\"}, {\"id\": \"2671F\"}, {\"id\": \"2285G\"}, {\"id\": \"6425F\"}, {\"id\": \"2380F\"}, {\"id\": \"2217F\"}, {\"id\": \"6810\"}, {\"id\": \"6156F\"}, {\"id\": \"6158H\"}, {\"id\": \"6811\"}, {\"id\": \"2336G\"}, {\"id\": \"3608\"}, {\"id\": \"3609F\"}, {\"id\": \"6792F\"}, {\"id\": \"2972F\"}, {\"id\": \"0636\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Obstacle on the tracks: T81-T97 are not operated between BAREEL and JANSON\", \"fr\": \"Obstacle sur les voies: T81-T97 Trafic interrompu entre BARRIERE et JANSON\", \"nl\": \"Obstakel op de sporen: T81-T97 Geen verkeer tussen BAREEL en JANSON\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"81\"}]",
+        "priority": 2,
+        "points": "[{\"id\": \"2286G\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Obstacle on the tracks: T81-T97 are not operated between BAREEL and JANSON\", \"fr\": \"Obstacle sur les voies: T81-T97 Trafic interrompu entre BARRIERE et JANSON\", \"nl\": \"Obstakel op de sporen: T81-T97 Geen verkeer tussen BAREEL en JANSON\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"97\"}]",
+        "priority": 2,
+        "points": "[{\"id\": \"5152G\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Obstacle on the tracks: T81-T97 are not operated between BAREEL and JANSON\", \"fr\": \"Obstacle sur les voies: T81-T97 Trafic interrompu entre BARRIERE et JANSON\", \"nl\": \"Obstakel op de sporen: T81-T97 Geen verkeer tussen BAREEL en JANSON\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"97\"}]",
+        "priority": 2,
+        "points": "[{\"id\": \"2334F\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Obstacle on the tracks: T81-T97 are not operated between BAREEL and JANSON\", \"fr\": \"Obstacle sur les voies: T81-T97 Trafic interrompu entre BARRIERE et JANSON\", \"nl\": \"Obstakel op de sporen: T81-T97 Geen verkeer tussen BAREEL en JANSON\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"97\"}]",
+        "priority": 2,
+        "points": "[{\"id\": \"5154F\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Obstacle on the tracks: T81-T97 are not operated between BAREEL and JANSON\", \"fr\": \"Obstacle sur les voies: T81-T97 Trafic interrompu entre BARRIERE et JANSON\", \"nl\": \"Obstakel op de sporen: T81-T97 Geen verkeer tussen BAREEL en JANSON\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"97\"}]",
+        "priority": 2,
+        "points": "[{\"id\": \"5151\"}, {\"id\": \"2668\"}, {\"id\": \"5155\"}, {\"id\": \"2667F\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Obstacle on the tracks: T81-T97 are not operated between BAREEL and JANSON\", \"fr\": \"Obstacle sur les voies: T81-T97 Trafic interrompu entre BARRIERE et JANSON\", \"nl\": \"Obstakel op de sporen: T81-T97 Geen verkeer tussen BAREEL en JANSON\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"97\"}]",
+        "priority": 2,
+        "points": "[{\"id\": \"5917F\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Obstacle on the tracks: T81-T97 are not operated between BAREEL and JANSON\", \"fr\": \"Obstacle sur les voies: T81-T97 Trafic interrompu entre BARRIERE et JANSON\", \"nl\": \"Obstakel op de sporen: T81-T97 Geen verkeer tussen BAREEL en JANSON\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"97\"}]",
+        "priority": 2,
+        "points": "[{\"id\": \"5953F\"}, {\"id\": \"6361\"}, {\"id\": \"5120\"}, {\"id\": \"5175\"}, {\"id\": \"6077F\"}, {\"id\": \"5123\"}, {\"id\": \"2604F\"}, {\"id\": \"5158\"}, {\"id\": \"5068F\"}, {\"id\": \"5066F\"}, {\"id\": \"2603\"}, {\"id\": \"2462F\"}, {\"id\": \"6427F\"}, {\"id\": \"9972F\"}, {\"id\": \"6430F\"}, {\"id\": \"5119\"}, {\"id\": \"6109\"}, {\"id\": \"2333F\"}, {\"id\": \"2463F\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Obstacle on the tracks: T81-T97 are not operated between BAREEL and JANSON\", \"fr\": \"Obstacle sur les voies: T81-T97 Trafic interrompu entre BARRIERE et JANSON\", \"nl\": \"Obstakel op de sporen: T81-T97 Geen verkeer tussen BAREEL en JANSON\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"97\"}]",
+        "priority": 2,
+        "points": "[{\"id\": \"5156F\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Obstacle on the tracks: T81-T97 are not operated between BAREEL and JANSON\", \"fr\": \"Obstacle sur les voies: T81-T97 Trafic interrompu entre BARRIERE et JANSON\", \"nl\": \"Obstakel op de sporen: T81-T97 Geen verkeer tussen BAREEL en JANSON\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"97\"}]",
+        "priority": 2,
+        "points": "[{\"id\": \"5116\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Obstacle on the tracks: T81-T97 are not operated between BAREEL and JANSON\", \"fr\": \"Obstacle sur les voies: T81-T97 Trafic interrompu entre BARRIERE et JANSON\", \"nl\": \"Obstakel op de sporen: T81-T97 Geen verkeer tussen BAREEL en JANSON\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"81\"}]",
+        "priority": 2,
+        "points": "[{\"id\": \"6463F\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Obstacle on the tracks: T81-T97 are not operated between BAREEL and JANSON\", \"fr\": \"Obstacle sur les voies: T81-T97 Trafic interrompu entre BARRIERE et JANSON\", \"nl\": \"Obstakel op de sporen: T81-T97 Geen verkeer tussen BAREEL en JANSON\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"97\"}]",
+        "priority": 2,
+        "points": "[{\"id\": \"6078\"}, {\"id\": \"6428F\"}, {\"id\": \"5018F\"}, {\"id\": \"5016F\"}, {\"id\": \"2404F\"}, {\"id\": \"6314\"}, {\"id\": \"2336G\"}, {\"id\": \"6162\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Obstacle on the tracks: T81-T97 are not operated between BAREEL and JANSON\", \"fr\": \"Obstacle sur les voies: T81-T97 Trafic interrompu entre BARRIERE et JANSON\", \"nl\": \"Obstakel op de sporen: T81-T97 Geen verkeer tussen BAREEL en JANSON\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"97\"}]",
+        "priority": 2,
+        "points": "[{\"id\": \"5161F\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Obstacle on the tracks: T81-T97 are not operated between BAREEL and JANSON\", \"fr\": \"Obstacle sur les voies: T81-T97 Trafic interrompu entre BARRIERE et JANSON\", \"nl\": \"Obstakel op de sporen: T81-T97 Geen verkeer tussen BAREEL en JANSON\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"97\"}]",
+        "priority": 2,
+        "points": "[{\"id\": \"5121F\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Obstacle on the tracks: T81-T97 are not operated between BAREEL and JANSON\", \"fr\": \"Obstacle sur les voies: T81-T97 Trafic interrompu entre BARRIERE et JANSON\", \"nl\": \"Obstakel op de sporen: T81-T97 Geen verkeer tussen BAREEL en JANSON\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"97\"}]",
+        "priority": 2,
+        "points": "[{\"id\": \"2765\"}, {\"id\": \"2764G\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Obstacle on the tracks: T81-T97 are not operated between BAREEL and JANSON\", \"fr\": \"Obstacle sur les voies: T81-T97 Trafic interrompu entre BARRIERE et JANSON\", \"nl\": \"Obstakel op de sporen: T81-T97 Geen verkeer tussen BAREEL en JANSON\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"97\"}]",
+        "priority": 2,
+        "points": "[{\"id\": \"5115F\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Obstacle on the tracks: T81-T97 are not operated between BAREEL and JANSON\", \"fr\": \"Obstacle sur les voies: T81-T97 Trafic interrompu entre BARRIERE et JANSON\", \"nl\": \"Obstakel op de sporen: T81-T97 Geen verkeer tussen BAREEL en JANSON\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"97\"}]",
+        "priority": 2,
+        "points": "[{\"id\": \"5756F\"}, {\"id\": \"1258G\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Obstacle on the tracks: T81-T97 are not operated between BAREEL and JANSON\", \"fr\": \"Obstacle sur les voies: T81-T97 Trafic interrompu entre BARRIERE et JANSON\", \"nl\": \"Obstakel op de sporen: T81-T97 Geen verkeer tussen BAREEL en JANSON\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"97\"}]",
+        "priority": 2,
+        "points": "[{\"id\": \"5916F\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Obstacle on the tracks: T81-T97 are not operated between BAREEL and JANSON\", \"fr\": \"Obstacle sur les voies: T81-T97 Trafic interrompu entre BARRIERE et JANSON\", \"nl\": \"Obstakel op de sporen: T81-T97 Geen verkeer tussen BAREEL en JANSON\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"97\"}]",
+        "priority": 2,
+        "points": "[{\"id\": \"2708G\"}, {\"id\": \"5952F\"}, {\"id\": \"2709F\"}, {\"id\": \"2710G\"}, {\"id\": \"1984G\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Obstacle on the tracks: T81-T97 are not operated between BAREEL and JANSON\", \"fr\": \"Obstacle sur les voies: T81-T97 Trafic interrompu entre BARRIERE et JANSON\", \"nl\": \"Obstakel op de sporen: T81-T97 Geen verkeer tussen BAREEL en JANSON\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"97\"}]",
+        "priority": 2,
+        "points": "[{\"id\": \"1985G\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Obstacle on the tracks: T81-T97 are not operated between BAREEL and JANSON\", \"fr\": \"Obstacle sur les voies: T81-T97 Trafic interrompu entre BARRIERE et JANSON\", \"nl\": \"Obstakel op de sporen: T81-T97 Geen verkeer tussen BAREEL en JANSON\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"97\"}]",
+        "priority": 2,
+        "points": "[{\"id\": \"5722F\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Obstacle on the tracks: T81-T97 are not operated between BAREEL and JANSON\", \"fr\": \"Obstacle sur les voies: T81-T97 Trafic interrompu entre BARRIERE et JANSON\", \"nl\": \"Obstakel op de sporen: T81-T97 Geen verkeer tussen BAREEL en JANSON\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"97\"}]",
+        "priority": 2,
+        "points": "[{\"id\": \"5723G\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Obstacle on the tracks: T81-T97 are not operated between BAREEL and JANSON\", \"fr\": \"Obstacle sur les voies: T81-T97 Trafic interrompu entre BARRIERE et JANSON\", \"nl\": \"Obstakel op de sporen: T81-T97 Geen verkeer tussen BAREEL en JANSON\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"97\"}]",
+        "priority": 2,
+        "points": "[{\"id\": \"5719H\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Obstacle on the tracks: T81-T97 are not operated between BAREEL and JANSON\", \"fr\": \"Obstacle sur les voies: T81-T97 Trafic interrompu entre BARRIERE et JANSON\", \"nl\": \"Obstakel op de sporen: T81-T97 Geen verkeer tussen BAREEL en JANSON\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"97\"}]",
+        "priority": 2,
+        "points": "[{\"id\": \"5163F\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Obstacle on the tracks: T81-T97 are not operated between BAREEL and JANSON\", \"fr\": \"Obstacle sur les voies: T81-T97 Trafic interrompu entre BARRIERE et JANSON\", \"nl\": \"Obstakel op de sporen: T81-T97 Geen verkeer tussen BAREEL en JANSON\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"97\"}]",
+        "priority": 2,
+        "points": "[{\"id\": \"5164F\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. As of Apr 15, bus 12 diverted btw MEISER and LUXEMBOURG via MAELBEEK. Stop SCHUMAN moved rue Franklinstr.\", \"fr\": \"Travaux. D\u00e8s le 15/4, bus 12 d\u00e9vi\u00e9 entre MEISER et LUXEMBOURG via MAELBEEK. Arr\u00eat SCHUMAN d\u00e9plac\u00e9 rue Franklin.\", \"nl\": \"Werken. Vanaf 15/4, bus 12 omgeleid tss MEISER en LUXEMBURG via MAALBEEK. Halte SCHUMAN verplaatst Franklinstr.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"12\"}]",
+        "priority": 6,
+        "points": "[{\"id\": \"3017\"}, {\"id\": \"2695\"}, {\"id\": \"5048\"}, {\"id\": \"9600B\"}, {\"id\": \"2250\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Bus 17: From Sep 5 6AM, works. Diversion between BRILLANT/BRILJANT and BEAULIEU via Michiels\", \"fr\": \"Bus 17: D\u00e8s le 5/9 6h, travaux. D\u00e9viation entre BRILLANT et BEAULIEU via Michiels\", \"nl\": \"Bus 17: Vanaf 5/9 6u, werken. Omleiding tussen BRILJANT en BEAULIEU via Michiels\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"17\"}]",
+        "priority": 6,
+        "points": "[{\"id\": \"9059\"}, {\"id\": \"4351\"}, {\"id\": \"4341\"}, {\"id\": \"1455\"}, {\"id\": \"4287\"}, {\"id\": \"4355\"}, {\"id\": \"4357\"}, {\"id\": \"4358\"}, {\"id\": \"4348\"}, {\"id\": \"4292\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. Until mid-2024, T19 interrupted at this stop. Stop of T-bus 19: av. Jette 232 (next to this stop)\", \"fr\": \"Travaux. Jusque mi-2024, T19 interrompu \u00e0 cet arr\u00eat. Arr\u00eat du T-bus 19: av. de Jette, 232 (\u00e0 c\u00f4t\u00e9 de cet arr\u00eat).\", \"nl\": \"Werken. Tot midden 2024, T19 onderbroken aan deze halte. Halte van T-bus 19: Jetselaan 232 (naast deze halte)\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"19\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"6865F\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. Until mid-2024, stop not served. T-bus at VERBEYST (bd de Smet de Naeyer 234, stop of bus 14 to UZ-VUB).\", \"fr\": \"Travaux. Jusque mi-2024, arr\u00eat non desservi. T-bus \u00e0 VERBEYST (bd de Smet de Naeyer 234, arr\u00eat B14 vers UZ-VUB).\", \"nl\": \"Werken. Tot midden 2024, halte niet bediend. T-bus aan VERBEYST (de Smet de Naeyerlaan 234, halte B14 naar UZ-VUB).\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"19\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"6867F\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. Until mid-2024, tram 19 replaced by T-bus btw DE WAND and MIROIR / SPIEGEL. Take T-bus at CIM. DE JETTE.\", \"fr\": \"Travaux. Jusque mi-2024, tram 19 remplac\u00e9 par des T-bus entre DE WAND et MIROIR. Prenez le T-bus \u00e0 CIMETIERE DE JETTE.\", \"nl\": \"Werken. Tot midden 2024, tram 19 vervangen door T-bus tss DE WAND en SPIEGEL. Neem de T-bus aan KERKHOF VAN JETTE\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"19\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"6800F\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. Until mid-2024, stop not served. T-bus at LEOPOLD I (bd de Smet de Naeyer 59), or T19 at MIROIR.\", \"fr\": \"Travaux, jusque mi-2024, arr\u00eat non desservi. T-bus \u00e0 LEOPOLD I (bd de Smet de Naeyer 59), ou T19 \u00e0 MIROIR.\", \"nl\": \"Werken. Tot midden 2024, halte niet bediend. T-bus aan LEOPOLD I (de Smet de Naeyerlaan 59), of T19 aan SPIEGEL.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"19\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"6804F\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Dec 4, works. STOP NOT SERVED. Take bus 20 at the previous stop, GARE DU NORD / NOORDSTATION.\", \"fr\": \"D\u00e8s le 4/12, travaux. ARRET NON DESSERVI. Prenez le bus 20 \u00e0 l'arr\u00eat pr\u00e9c\u00e9dent, GARE DU NORD.\", \"nl\": \"Vanaf 4/12, werken. HALTE NIET BEDIEND. Neem bus 20 aan de vorige halte, NOORDSTATION.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"20\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"3400\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Apr 29 at 7AM, works. STOP NOT SERVED. Take bus 21 at the stop DIAMANT of bus 28 to BRABANCONNE.\", \"fr\": \"D\u00e8s le 29/4,7h, travaux. ARRET NON DESSERVI. Prenez le bus 21 \u00e0 l'arr\u00eat DIAMANT du bus 28 vers BRABANCONNE.\", \"nl\": \"Vanaf 29/4, 7u, werken. HALTE NIET BEDIEND. Neem bus 21 aan de halte DIAMANT van bus 28 naar BRABANCONNE.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"21\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"6454\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. As of Apr 15, STOP NOT SERVED. Stop of bus 21: rue Archim\u00e8de / Archimedesstraat 16.\", \"fr\": \"Travaux. D\u00e8s le 15/4, ARRET NON DESSERVI. Arr\u00eat du bus 21: rue Archim\u00e8de 16.\", \"nl\": \"Werken. Vanaf 15/4, HALTE NIET BEDIEND. Halte van bus 21: Archimedesstraat 16.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"21\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"2083\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. As of Apr 15, bus 21 diverted btw TREVES and MICHEL-ANGE via MAELBEEK. Stop SCHUMAN moved rue Archim\u00e8de.\", \"fr\": \"Travaux. D\u00e8s le 15/4,bus 21 d\u00e9vi\u00e9 entre TREVES et MICHEL-ANGE via MAELBEEK. Arr\u00eat SCHUMAN d\u00e9plac\u00e9 rue Archim\u00e8de.\", \"nl\": \"Werken. Vanaf 15/4, bus 21 omgeleid tss TRIER en MICHELANGELO via MAALBEEK. Halte SCHUMAN verplaatst Archimedesstr\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"21\"}]",
+        "priority": 6,
+        "points": "[{\"id\": \"1132\"}, {\"id\": \"1262B\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Apr 29, 7AM,works. Bus 21 N05 diverted. Take the bus at the stop of bus 28 to BRABANCONNE.\", \"fr\": \"D\u00e8s le 29/4,7h, travaux. BUS 21 N05 DEVIES. Prenez le bus \u00e0 l'arr\u00eat du bus 28 vers BRABANCONNE.\", \"nl\": \"Vanaf 29/4, 7u, werken. Bus 21 N05 omgeleid. Neem de bus aan de halte van bus 28 naar BRABANCONNE.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"21\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"3707\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Apr 29, works. Bus 28 diverted. Bus 28 at STADE FALLON: chemin du Struykbekenweg.\", \"fr\": \"D\u00e8s le 29/4, travaux. Bus 28 d\u00e9vi\u00e9.. Bus 28 \u00e0 STADE FALLON: chemin du Struykbeken.\", \"nl\": \"Vanaf 29/4, werken. Bus 28 omgeleid. Bus 28 aan FALLON STADION: Struykbekenweg.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"28\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"1832\"}, {\"id\": \"1830\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Apr 29, works. STOP NOT SERVED. Go to KONKEL on foot.\", \"fr\": \"D\u00e8s le 29/4, travaux. ARRET NON DESSERVI. Continuez \u00e0 pied jusqu'\u00e0 KONKEL.\", \"nl\": \"Vanaf 29/4, werken. HALTE NIET BEDIEND. Ga te voet tot KONKEL.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"28\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"1415\"}, {\"id\": \"1831\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Jan 18, works. STOP NOT SERVED. Temporary stop: Avenue de Roodebeeklaan 45.\", \"fr\": \"D\u00e8s le 18/1, travaux. ARRET NON DESSERVI. Arr\u00eat provisoire: Avenue de Roodebeek 45.\", \"nl\": \"Vanaf 18/1, werken. HALTE NIET BEDIEND. Tijdelijke halte: Roodebeeklaan 45.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"28\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"1404\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From FEB 2, works. Stop SAINT-JOSSE moved, go to the temporary stop: chauss\u00e9e de Louvain 73.\", \"fr\": \"D\u00e8s le 26/2, travaux. Arr\u00eat SAINT-JOSSE d\u00e9plac\u00e9, allez \u00e0 l'arr\u00eat provisoire : chauss\u00e9e de Louvain 73.\", \"nl\": \"Vanaf 26/2, werken. Halte SINT-JOOST verplaatst, ga naar de tijdelijke halte: Leuvensesteenweg 73.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"29\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"1570\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Apr 29, 7AM,works. STOP NOT SERVED. Take bus 29 at the stop PLASKY of bus 63 to GARE CENTRALE.\", \"fr\": \"D\u00e8s le 29/4,7h, travaux. ARRET NON DESSERVI. Prenez le bus 29 \u00e0 l'arr\u00eat PLASKY du bus 63 vers GARE CENTRALE.\", \"nl\": \"Vanaf 29/4, 7u, werken. HALTE NIET BEDIEND. Neem bus 29 aan de halte PLASKY van bus 63 naar CENTRAAL STATION.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"29\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"3367\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. As of April 7th, stop served only by bus 66. Take bus 29, 63 or 65 at the stop of bus 71 to DELTA.\", \"fr\": \"Travaux. D\u00e8s le 7/4, arr\u00eat uniquement desservi par bus 66. Bus 29, 63 ou 65 \u00e0 l'arr\u00eat du bus 71 vers DELTA.\", \"nl\": \"Werken. Vanaf 7/4, halte enkel bediend door bus 66. Neem bus 29, 63 of 65 aan de halte van bus 71 naar DELTA.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"29\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"6445\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Apr 29, 7AM, works. STOP NOT SERVED. Temporary stop: B29: avenue E. Plaskylaan 76.\", \"fr\": \"D\u00e8s 29/4 \u00e0 7h, travaux. ARRET NON DESSERVI. Arr\u00eat provisoire: avenue E. Plasky 76.\", \"nl\": \"Vanaf 29/4, 7u, werken. HALTE NIET BEDIEND. Tijdelijke halte: E. Plaskylaan 76.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"29\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"3366\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. STOP NOT OPERATED. Temporary stop: rue de Pavie / Paviastraat 53.\", \"fr\": \"Travaux. ARRET NON DESSERVI. Arr\u00eat provisoire: rue de Pavie 53.\", \"nl\": \"Werken. HALTE NIET BEDIEND. Tijdelijke halte: Paviastraat 53.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"29\"}]",
+        "priority": 5,
+        "points": "[{\"id\": \"1568\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Jan 7, 9PM-Jun 28, works.Tram 3 diverted to the stop DOCKS BRUXSEL of tram 7 and replaced by T-bus to ESPLANADE.\", \"fr\": \"7/1, 21h-28/6, travaux. Tram 3 d\u00e9vi\u00e9 vers l'arr\u00eat DOCKS BRUXSEL du tram 7 et remplac\u00e9 par des T-bus jsq ESPLANADE.\", \"nl\": \"7/1, 21u-28/6, werken. Tram 3 omgeleid naar de halte DOCKS BRUXSEL van tram 7 en vervangen door T-bus tot ESPLANADE.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"3\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"2337F\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Jan 7, 9PM-Jun 28, works. Stop not served. Stop  T-bus to ESPLANADE : av. Croix du Feu, crossing r. Heembeek.\", \"fr\": \"7/1, 21h-28/6, travaux. Arr\u00eat non desservi.Arr\u00eat T-bus vers ESPLANADE:av. Croix du Feu, carrefour rue de Heembeek.\", \"nl\": \"7/1, 21u-28/6, werken. Halte niet bediend.Halte T-bus naar ESPLANADE : Vuurkruisenlaan, kruispunt Heembeeklaan.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"3\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"5771\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Jan 7, 9PM-Jun 28,works. Tram 3 interrupted btw ESPLANADE and DOCKS BRUXSEL. Stop of the T-bus: av. Araucarialn.\", \"fr\": \"7/1, 21h-28/6, travaux. Tram 3 interrompu entre ESPLANADE et DOCKS BRUXSEL. Arr\u00eat du T-bus: avenue de l'Araucaria.\", \"nl\": \"7/1, 21u-28/6, werken. Tram 3 onderbroken tss ESPLANADE en DOCKS BRUXSEL. Halte van de T-bus: Araucarialaan.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"3\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"5704F\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Jan 7, 9PM-Jun 28,works. Tram 3 and 7 replaced by T-bus to DOCKS BRUXSEL. T-bus at this stop.\", \"fr\": \"7/1, 21h-28/6, travaux. Tram 3 et 7 remplac\u00e9s par des T-bus jusqu'\u00e0 DOCKS BRUXSEL. T-bus \u00e0 cet arr\u00eat.\", \"nl\": \"7/1, 21u-28/6, werken. Tram 3 en 7 vervangen door T-bus tot DOCKS BRUXSEL. T-bus aan deze halte.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"3\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"5707\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Jan 7 at 9PM to Jun 28, works. Tram 3 replaced by T-bus. Stop T-bus: av. Croix du Feu / Vuurkruisenln, 211-213\", \"fr\": \"Du 7/1 \u00e0 21h au 28/6, travaux. Tram 3 remplac\u00e9 par des T-bus. Arr\u00eat du T-bus: avenue des Croix du Feu, 211-213\", \"nl\": \"Van 7/1 om 21u tot en met 28/6, werken. Tram 3 vervangen door T-bus. Halte T-bus: Vuurkruisenlaan, 211-213\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"3\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"5773\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From jan 15, works. STOP NOT SERVED. Take bus 34 at the stop CLESSE of bus 72 to ADEPS.\", \"fr\": \"D\u00e8s le 15/1, travaux. ARRET NON DESSERVI. Prenez le bus 34 \u00e0 l'arr\u00eat CLESSE du bus 72 vers ADEPS.\", \"nl\": \"Vanaf 15/1, werken. HALTE NIET BEDIEND. Neem bus 34 aan de halte CLESSE van bus 72 naar ADEPS.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"34\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"1719\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Apr 3 at 6AM, works. STOP NOT SERVED. Bus 38 at the stop LANGEVELD of bus 60 to AMBIORIX.\", \"fr\": \"D\u00e8s le 3/4 \u00e0 6h, travaux. ARRET NON DESSERVI. Bus 38 \u00e0 l'arr\u00eat LANGEVELD du bus 60 vers AMBIORIX.\", \"nl\": \"Vanaf 3/4 om 6u, werken. HALTE NIET BEDIEND. Bus 38 aan halte LANGEVELD van bus 60 naar AMBIORIX.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"38\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"1919\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Apr 3 at 6AM, works. STOP NOT SERVED. Bus 38 at the stop LANGEVELD of bus 60 to UCCLE CALEVOET.\", \"fr\": \"D\u00e8s le 3/4 \u00e0 6h, travaux. ARRET NON DESSERVI. Bus 38 \u00e0 l'arr\u00eat LANGEVELD du bus 60 vers UCCLE CALEVOET.\", \"nl\": \"Vanaf 3/4 om 6u, werken. HALTE NIET BEDIEND. Bus 38 aan halte LANGEVELD van bus 60 naar UKKEL KALEVOET.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"38\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"1971\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Apr 3 at 6AM, works. Bus 38 diverted between LONGCHAMP and HOUZEAU via rue Edith Cavellstraat.\", \"fr\": \"D\u00e8s le 3/4 \u00e0 6h, travaux. Bus 38 d\u00e9vi\u00e9 entre LONGCHAMP et HOUZEAU via rue Edith Cavell.\", \"nl\": \"Vanaf 3/4 om 6u, werken. Bus 38 omgeleid tussen LONGCHAMP en HOUZEAU via Edith Cavellstraat.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"38\"}]",
+        "priority": 5,
+        "points": "[{\"id\": \"1910\"}, {\"id\": \"3503\"}, {\"id\": \"1909\"}, {\"id\": \"1233\"}, {\"id\": \"6433\"}, {\"id\": \"3122\"}, {\"id\": \"1906\"}, {\"id\": \"1729\"}, {\"id\": \"1903\"}, {\"id\": \"1912\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"fr\": \"Bon voyage sur nos lignes !\", \"nl\": \"Een goede reis op onze lijnen gewenst!\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"39\"}]",
+        "priority": 9,
+        "points": "[{\"id\": \"5519\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Obstacle on the road: B41 diverted between BOONDAAL STATION and MONTANA direction HELDEN\", \"fr\": \"Obstacle sur la route: B41 d\u00e9vi\u00e9 entre BOONDAEL GARE et MONTANA direction HEROS\", \"nl\": \"Hindernis op de weg: B41 omgeleid tussen BOONDAAL STATION en MONTANA richting HELDEN\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"41\"}]",
+        "priority": 2,
+        "points": "[{\"id\": \"4310\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Obstacle on the road: B41 diverted between BOONDAAL STATION and MONTANA direction HELDEN\", \"fr\": \"Obstacle sur la route: B41 d\u00e9vi\u00e9 entre BOONDAEL GARE et MONTANA direction HEROS\", \"nl\": \"Hindernis op de weg: B41 omgeleid tussen BOONDAAL STATION en MONTANA richting HELDEN\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"41\"}]",
+        "priority": 2,
+        "points": "[{\"id\": \"2080\"}, {\"id\": \"6440\"}, {\"id\": \"2076\"}, {\"id\": \"2074\"}, {\"id\": \"1921\"}, {\"id\": \"4408\"}, {\"id\": \"3549\"}, {\"id\": \"1942\"}, {\"id\": \"2721\"}, {\"id\": \"2115\"}, {\"id\": \"1723B\"}, {\"id\": \"2046\"}, {\"id\": \"6469\"}, {\"id\": \"4401\"}, {\"id\": \"4402\"}, {\"id\": \"4403\"}, {\"id\": \"5415\"}, {\"id\": \"5416\"}, {\"id\": \"4405\"}, {\"id\": \"2715\"}, {\"id\": \"1724\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Obstacle on the road: B41 diverted between BOONDAAL STATION and MONTANA direction HELDEN\", \"fr\": \"Obstacle sur la route: B41 d\u00e9vi\u00e9 entre BOONDAEL GARE et MONTANA direction HEROS\", \"nl\": \"Hindernis op de weg: B41 omgeleid tussen BOONDAAL STATION en MONTANA richting HELDEN\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"41\"}]",
+        "priority": 2,
+        "points": "[{\"id\": \"1920\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Mar 4, works. Bus 43 and N11 diverted. Take the bus at GRIOTTES / NOORDKRIEKEN.\", \"fr\": \"D\u00e8s le 4/3, travaux. Bus 43 et N11 d\u00e9vi\u00e9s. Prenez le bus \u00e0 GRIOTTES.\", \"nl\": \"Vanaf 4/3, werken. Bus 43 en N11 omgeleid. Neem de bus aan NOORDKRIEKEN.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"43\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"1957B\"}, {\"id\": \"1933B\"}, {\"id\": \"1939\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"As from 21 Sept, works. Stop moved +-60m forwards.\", \"fr\": \"D\u00e8s le 21/9, travaux. Arr\u00eat avanc\u00e9 de +-60m.\", \"nl\": \"Vanaf 21/9, werken. Halte +-60m vooruitgebracht.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"45\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"3462\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. Until end of August, bus 46 not operated btw WTC-GLIBERT and CENTRAL STATION. Walk to the center.\", \"fr\": \"Travaux. Jsq fin ao\u00fbt, bus 46 ne circule pas entre WTC-GLIBERT et GARE CENTRALE.Pour le centre, continuez \u00e0 pied\", \"nl\": \"Werken. Tot einde augustus rijdt bus 46 niet tss WTC-GLIBERT en CENTRAAL STATION. Voor het centrum, ga te voet.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"46\"}]",
+        "priority": 5,
+        "points": "[{\"id\": \"2835\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Jan 22 at 7AM, works. STOP NOT SERVED. Stop of bus 46: rue de Laeken / Lakensestraat 34.\", \"fr\": \"D\u00e8s le 22/1 \u00e0 7h, travaux. ARRET NON DESSERVI. Arr\u00eat du bus 46: rue de Laeken 34.\", \"nl\": \"Van 22/1 om 7u, werken. HALTE NIET BEDIEND. Halte van bus 46: Lakensestraat 34.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"46\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"3469\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Feb 7, works. STOP NOT SERVED. Temporary stop: Vlierkensstraat 174.\", \"fr\": \"D\u00e8s le 7/2, travaux. ARRET NON DESSERVI. Arr\u00eat provisoire: Vlierkensstraat 174.\", \"nl\": \"Vanaf 7/2, werken. HALTE NIET BEDIEND. Tijdelijke halte: Vlierkensstraat 174.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"47\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"9605\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Jan 9th at 6AM, works. STOP UNSERVED. Go to the stop HOP. MILITAIR(E) HOSP. from B53.\", \"fr\": \"D\u00e8s le 9/1 \u00e0 6h, travaux. ARRET NON DESSERVI. Aller \u00e0 l'arr\u00eat HOP. MILITAIRE du B53.\", \"nl\": \"Vanaf 9/1 om 6u, werken. HALTE NIET BEDIEND. Ga naar de halte MILITAIR HOSP. van B53.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"47\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"3067\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Until Summer of 2024, works. As of Mar 3, STOP NOT SERVED. Stop of bus 47 57: ANTOON VAN OSS.\", \"fr\": \"Jusqu'\u00e0 l'\u00e9t\u00e9 2024, travaux. D\u00e8s le 4/3, ARRET NON DESSERVI. Arr\u00eat des bus 47 57 : ANTOON VAN OSS.\", \"nl\": \"Tot zomer 2024, werken. Vanaf 4/3, HALTE NIET BEDIEND. Halte van bus 47 57: ANTOON VAN OSS\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"47\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"1827\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Until Summer of 2024, works. Bus 47 diverted btw VTM and RAMIER. As of Mar 18, stop HOPITAL MILITAIRE in rue Bruyn.\", \"fr\": \"Jsq \u00e9t\u00e9 2024, travaux. Bus 47 d\u00e9vi\u00e9 entre VTM et RAMIER. D\u00e8s le 18/3, arr\u00eat HOPITAL MILITAIRE rue Bruyn.\", \"nl\": \"Tot zomer 2024, werken. Bus 47 omgeleid tussen VTM en BOSDUIF. Vanaf 18/3,halte MILITAIR HOSP in de Bruynstraat.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"47\"}]",
+        "priority": 5,
+        "points": "[{\"id\": \"9786\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Oct 7, works. STOP NOT OPERATED. Temporary stop: David Terniersstraat 115\", \"fr\": \"D\u00e8s le 7/10, travaux. ARRET NON DESSERVI. Arr\u00eat provisoire : David Terniersstraat 115\", \"nl\": \"Vanaf 7/10, werken. HALTE NIET BEDIEND. Tijdelijke halte: David Terniersstraat 115\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"47\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"9627\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Until Summer of 2024, works. B47 diverted btw CHEMIN VERT and ANT VAN OSS. As of Mar 3, diverted to H. MILITAIRE\", \"fr\": \"Jsq \u00e9t\u00e9 2024, travaux. B47 d\u00e9vi\u00e9 entre CHEMIN VERT et ANTOON VAN OSS. D\u00e8s le 4/3, d\u00e9vi\u00e9 jsq HOPITAL MILITAIRE.\", \"nl\": \"Tot zomer 2024, werken. Bus 47 omgeleid tss GROENWEG en ANTOON VAN OSS. Vanaf 4/3, omgeleid tot MILITAIR HOSPITAAL\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"47\"}]",
+        "priority": 5,
+        "points": "[{\"id\": \"2314\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Until Summer of 2024, works. Stop not served. Stop of bus 47: CROIX DE GUERRE / OORLOGSKRUISEN.\", \"fr\": \"Jusqu'\u00e0 l'\u00e9t\u00e9 2024, travaux. Arr\u00eat non desservi. Arr\u00eat du bus 47 : CROIX DE GUERRE.\", \"nl\": \"Tot zomer 2024, werken. Halte niet bediend. Halte van bus 47: OORLOGSKRUISEN.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"47\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"1987\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Until Summer of 2024, works. Stop not served. Take bus 47 or 56 at ANTOON VAN OSS. For HOP MILITAIRE , walk.\", \"fr\": \"Jsq \u00e9t\u00e9 2024, travaux. Arr\u00eat non desservi. Bus 47 ou 56 \u00e0 ANTOON VAN OSS. Pour HOPITAL MILITAIRE, \u00e0 pied.\", \"nl\": \"Tot zomer 2024, werken. Halte niet bediend. Neem bus 47 of 56 aan ANTOON VAN OSS. Voor MILITAIR HOSPITAAL, ga te voet.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"47\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"1838\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Until Summer of 2024, works. Stop not served. Stop of bus 47: VERGER / BOOMGAARD (av. Croix de Guerre/Oorlogskruisenln)\", \"fr\": \"Jusqu'\u00e0 l'\u00e9t\u00e9 2024, travaux. Arr\u00eat non desservi. Arr\u00eat du bus 47 : VERGER (avenue des Croix de Guerre).\", \"nl\": \"Tot zomer 2024, werken. Halte niet bediend. Halte van bus 47: BOOMGAARD (Oorlogskruisenlaan).\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"47\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"2312\"}, {\"id\": \"2363\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Apr 23 at 7AM, works. STOP NOT SERVED. Temporary stop: avenue Besmelaan 77.\", \"fr\": \"D\u00e8s le 23/4 \u00e0 7h, travaux. ARRET NON DESSERVI. Arr\u00eat provisoire: avenue Besme 77.\", \"nl\": \"Vanaf 23/4 om 7u, werken. HALTE NIET BEDIEND. Tijdelijke halte: Besmelaan 77.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"48\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"2408\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. From Apr 17 at 7AM, until May 10 at 5PM, stop moved av. Victor Besmelaan, before the roundabout.\", \"fr\": \"Travaux. Du 17/4 \u00e0 7h au 10/5 \u00e0 17h, arr\u00eat d\u00e9plac\u00e9 avenue Victor Besme, avant le rond-point\", \"nl\": \"Werken. Van 17/4 om 7u tot 10/5 om 17u, halte verplaatst naar de Victor Besmelaan, voor de rotonde.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"48\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"2459\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Apr 20, works. Stop not served. Take B49 next to number 26 (100m before this stop).\", \"fr\": \"D\u00e8s le 20/4, travaux. Arr\u00eat non desservi. Arr\u00eat du B49 \u00e0  hauteur du num\u00e9ro 26 (100 m avant cet arr\u00eat).\", \"nl\": \"Vanaf 20/4, werken. Halte niet bediend. Neem B49 ter hoogte van nummer 26 (100m voor deze halte).\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"49\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"2225\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Until 2026, works. Bus 50 diverted to FOREST CENTRE / VORST CENTRUM. Stop of bus 50: r. Abbesses / Abdissenstr.\", \"fr\": \"Jusqu'en 2026, travaux. Bus 50 d\u00e9vi\u00e9 jusqu'\u00e0 FOREST CENTRE. Arr\u00eat du bus 50: rue des Abbesses.\", \"nl\": \"Tot 2026, werken. Bus 50 omgeleid tot VORST CENTRUM. Halte van bus 50: Abdissenstraat.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"50\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"5152\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Apr 22 at 12PM, works. STOP NOT SERVED. Stop of bus 50: avenue Paul Gilsonlaan, just before this stop.\", \"fr\": \"D\u00e8s 22/4 \u00e0 12h, travaux. ARRET NON DESSERVI. Arr\u00eat du bus 50: avenue Paul Gilson, peu avant cet arr\u00eat.\", \"nl\": \"Vanaf 22/4 om 12u, werken. HALTE NIET BEDIEND. Halte van bus 50: Paul Gilsonlaan, net voor deze halte.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"50\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"2609\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Until Summer of 2024, works. Stop not served. Stop of bus 53: KRUIPWEG (rue du Paturage / Weilandstraat).\", \"fr\": \"Jusqu'\u00e0 l'\u00e9t\u00e9 2024, travaux. Arr\u00eat non desservi. Arr\u00eat du bus 53 : KRUIPWEG (rue du Paturage)\", \"nl\": \"Tot zomer 2024, werken. Halte niet bediend. Halte van bus 53: KRUIPWEG (Weilandstraat)\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"53\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"2312\"}, {\"id\": \"2363\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. From Apr 29 until May 8 at 7PM, STOP NOT SERVED. Stop of bus 54: avenue du Globelaan 43.\", \"fr\": \"Travaux. Du 29/4 au 8/5 \u00e0 19h, ARRET NON DESSERVI. Arr\u00eat du bus 54: avenue du Globe, 43.\", \"nl\": \"Werken. Van 29/4 tot 8/5 om 19u, HALTE NIET BEDIEND. Halte van bus 54: Globelaan 43.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"54\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"2953\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Apr 2, 2024 to June 2025, works. STOP NOT SERVED. To go to BERVOETS, take bus 50 or T-bus(stop: r. Abbesses)\", \"fr\": \"Du 2/4/2024 \u00e0 juin 2025, travaux. ARRET NON DESSERVI. Pour rejoindre BERVOETS,bus 50 ou T-bus (arr\u00eat: r. des Abbesses)\", \"nl\": \"Van 2/4/2024 tot juni 2025, werken. HALTE NIET BEDIEND. Voor BERVOETS, neem bus 50 of de T-bus (halte: Abdissenstraat)\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"54\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"5161\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Apr 2, 2024 to June 2025, works. STOP NOT SERVED. To go to BERVOETS, take bus 50 or T-bus at FOREST CENTRE.\", \"fr\": \"Du 2/4/2024 \u00e0 juin 2025, travaux. ARRET NON DESSERVI. Pour rejoindre BERVOETS, bus 50 ou T-bus \u00e0 FOREST CENTRE.\", \"nl\": \"Van 2/4/2024 tot juni 2025, werken. HALTE NIET BEDIEND. Voor BERVOETS, neem bus 50 of de T-bus aan VORST CENTRUM.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"54\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"5152\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. From Apr 2 until June 2025, STOP NOT SERVED. Take bus 54 at the previous stop, FOREST CENTRE.\", \"fr\": \"Travaux. Du 2/4 \u00e0 juin 2025, ARRET NON DESSERVI. Prenez le bus 54 \u00e0 l'arr\u00eat pr\u00e9c\u00e9dent, FOREST CENTRE.\", \"nl\": \"Werken. Vanaf 2/4 tot juni 2025, HALTE NIET BEDIEND. Neem bus 54 aan de vorige halte, VORST CENTRUM.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"54\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"5719\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Apr 11 at 7AM, works. STOP NOT SERVED. Take the tram at the stop that is installed 25m further.\", \"fr\": \"D\u00e8s le 11/4 \u00e0 7h, travaux. ARRET NON DESSERVI. Prenez le tram \u00e0 l'arr\u00eat avanc\u00e9 de 25m.\", \"nl\": \"Vanaf 11/4 om 7u, werken. HALTE NIET BEDIEND. Neem de tram 25 meter verder.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"55\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"2902\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. STOP NOT SERVED. Temporary stop: avenue des Croix de Guerre 78\", \"fr\": \"Jusqu'\u00e0 l'\u00e9t\u00e9 2024, travaux. Arr\u00eat des bus 47 et 56 : avenue des Croix de Guerre 78.\", \"nl\": \"Tot zomer 2024, werken. Halte van bus 47 en 56: Oorlogskruisenlaan 78.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"56\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"2377\"}, {\"id\": \"2299\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. STOP NOT SERVED. Take bus 47 56 at the usual stop of trams 3 7 direction CHURCHILL / VANDERKINDERE.\", \"fr\": \"Travaux. ARRET NON DESSERVI. Prenez le bus 47 56 \u00e0 l'arr\u00eat habituel des trams 3 7 vers CHURCHILL/VANDERKINDERE.\", \"nl\": \"Werken. HALTE NIET BEDIEND. Neem bus 47 56 aan de gebruikelijke halte van tram 3 7 naar CHURCHILL/VANDERKINDERE.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"56\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"6368C\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Until Summer of 2024, works. Bus 56 diverted. Take bus 56 at ANTOON VAN OSS.\", \"fr\": \"Jusqu'\u00e0 l'\u00e9t\u00e9 2024, travaux. Bus 56 d\u00e9vi\u00e9. Prenez le bus 56 \u00e0 ANTOON VAN OSS.\", \"nl\": \"Tot zomer 2024, werken. Bus 56 omgeleid. Neem bus 56 aan ANTOON VAN OSS.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"56\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"1827\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. As of Apr 15, bus 56 diverted from AMBIORIX to MAELBEEK. Connection metro at MAELBEEK / MAALBEEK.\", \"fr\": \"Travaux. D\u00e8s le 15/4, bus 56 d\u00e9vi\u00e9 depuis AMBIORIX vers MAELBEEK. Correspondance m\u00e9tro \u00e0 MAELBEEK.\", \"nl\": \"Werken. Vanaf 15/4, bus 56 omgeleid vanaf AMBIORIX naar MAALBEEK. Aansluiting metro aan MAALBEEK.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"56\"}]",
+        "priority": 6,
+        "points": "[{\"id\": \"2092\"}, {\"id\": \"6461\"}, {\"id\": \"5740\"}, {\"id\": \"2100\"}, {\"id\": \"2067\"}, {\"id\": \"6191\"}, {\"id\": \"9291\"}, {\"id\": \"2097\"}, {\"id\": \"2096\"}, {\"id\": \"2094\"}, {\"id\": \"1007\"}, {\"id\": \"2920\"}, {\"id\": \"3414\"}, {\"id\": \"2105\"}, {\"id\": \"2102\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. As of March 18, bus 56 operates normally between HOP. MILITAIRE / MILITAIR HOSP. and ANTOON VAN OSS.\", \"fr\": \"Travaux. D\u00e8s le 18/3, bus 56 circule \u00e0 nouveau normalement entre HOPITAL MILITAIRE et ANTOON VAN OSS.\", \"nl\": \"Werken. Vanaf 18/3 rijdt B56 opnieuw langs zijn gebruikelijke reisweg tss MILITAIR HOSPITAAL en ANTOON VAN OSS.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"56\"}]",
+        "priority": 5,
+        "points": "[{\"id\": \"2365\"}, {\"id\": \"2827\"}, {\"id\": \"1989\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Until Summer of 2024, works. Bus 56 diverted. Stop of bus 56: avenue des Croix de l'Yser / IJzerkruisenlaan 36.\", \"fr\": \"Jusqu'\u00e0 l'\u00e9t\u00e9 2024, travaux. Bus 56 d\u00e9vi\u00e9. Arr\u00eat du bus 56 : avenue des Croix de l'Yser 36.\", \"nl\": \"Tot zomer 2024, werken. Bus 56 omgeleid. Halte van bus 56: IJzerkruisenlaan 36.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"56\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"2093\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. As of Apr 15, STOP NOT SERVED. Take bus 56 at AMBIORIX (stop of bus 64 to Bordet Station).\", \"fr\": \"Travaux. D\u00e8s le 15/4, ARRET NON DESSERVI. Prenez le bus 56 \u00e0 AMBIORIX (arr\u00eat du bus 64 vers Bordet Station).\", \"nl\": \"Werken. Vanaf 15/4, HALTE NIET BEDIEND. Neem bus 56 aan AMBIORIX (halte van bus 64 naar Bordet Station).\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"56\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"1474B\"}, {\"id\": \"2083\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Until Summer of 2024, works. Stop not served. Take bus 47 or 57 at ANTOON VAN OSS (stop of bus 56 to BUDA).\", \"fr\": \"Jsq \u00e9t\u00e9 2024, travaux. Arr\u00eat non desservi. Prenez le bus 47 ou 57 \u00e0 ANTOON VAN OSS (arr\u00eat du bus 56 vers BUDA).\", \"nl\": \"Tot zomer 2024, werken. Halte niet bediend. Neem bus 47 of 57 aan ANTOON VAN OSS (halte van bus 56 naar BUDA).\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"56\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"1837\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Until Summer 2024,works. B56 diverted btw P. BENOIT and VAN PRAET. As of Mar 18, bus 56 serves the stop MERCATOR.\", \"fr\": \"Jsq \u00e9t\u00e9 2024, travaux. Bus 56 d\u00e9vi\u00e9 entre P. BENOIT et VAN PRAET. D\u00e8s le 18/3, bus 56 dessert \u00e0 nouveau MERCATOR.\", \"nl\": \"Tot zomer 2024, werken. Bus 56 omgeleid tss P. BENOIT en VAN PRAET. Vanaf 18/3 bedient bus 56 opnieuw MERCATOR.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"56\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"2379\"}, {\"id\": \"1991\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. Bus 56 diverted between VERGER and VAN PRAET via avenue des Croix de Guerre\", \"fr\": \"Travaux. Bus 56 d\u00e9vi\u00e9 entre VERGER et VAN PRAET via avenue des Croix de Guerre\", \"nl\": \"Werken. Bus 56 omgeleid tussen BOOMGAARD en VAN PRAET via Oorlogskruisenlaan\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"56\"}]",
+        "priority": 5,
+        "points": "[{\"id\": \"2823B\"}, {\"id\": \"2766\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Until Summer of 2024, works. Stop not served. Stop of bus 57: chauss\u00e9e de Vilvorde, in front of number 150.\", \"fr\": \"Jusqu'\u00e0 l'\u00e9t\u00e9 2024, travaux. Arr\u00eat non desservi. Arr\u00eat du bus 57: ch\u00e9e de Vilvorde, en face du num\u00e9ro 150.\", \"nl\": \"Tot zomer 2024, werken. Halte niet bediend. Halte van bus 57: Vilvoordsesteenweg, tegenover nummer 150.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"57\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"3063\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Until Summer of 2024, works. Stop not served. Take bus 47 or 56 at ANTOON VAN OSS. For HOP MILITAIRE , walk.\", \"fr\": \"Jsq \u00e9t\u00e9 2024, travaux. Arr\u00eat non desservi. Bus 47 ou 56 \u00e0 ANTOON VAN OSS. Pour HOPITAL MILITAIRE, \u00e0 pied.\", \"nl\": \"Tot zomer 2024, werken. Halte niet bediend. Neem bus 47 of 56 aan ANTOON VAN OSS. Voor MILITAIR HOSPITAAL, ga te voet.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"57\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"1838\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Dec 4, works. STOP NOT SERVED. Take bus 14 and 57 under the CCN building, at the terminus of bus 61.\", \"fr\": \"D\u00e8s le 4/12, travaux. ARRET NON DESSERVI. Prenez le bus 14 et 57 sous le b\u00e2timent CCN, au terminus du bus 61.\", \"nl\": \"Vanaf 4/12, werken. HALTE NIET BEDIEND. Neem bus 14 en 57 onder het CCN-gebouw, aan eindhalte bus 61.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"57\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"1082\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Until Summer of 2024, works. As of Mar 18, stop served normally by bus 57.\", \"fr\": \"Jusqu'\u00e0 l'\u00e9t\u00e9 2024, travaux. D\u00e8s le 18/3, arr\u00eat \u00e0 nouveau desservi par les bus 57.\", \"nl\": \"Tot zomer 2024, werken. Vanaf 18/3, halte opnieuw bediend door bus 57.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"57\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"2352\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Until Summer of 2024, works. Stop not served. Stop of bus 57: MARLY.\", \"fr\": \"Jsq \u00e9t\u00e9 2024, travaux. Arr\u00eat non desservi. Arr\u00eat du bus 57 : MARLY.\", \"nl\": \"Tot zomer 2024, werken. Halte niet bediend. Halte van bus 57: MARLY.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"57\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"2360\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Dec 4, works. STOP NOT SERVED. Take bus 58 at the stop WTC of bus 14 direction UZ-VUB.\", \"fr\": \"D\u00e8s le 4/12, travaux. ARRET NON DESSERVI. Prenez le bus 58 \u00e0 l'arr\u00eat WTC du bus 14 direction UZ-VUB.\", \"nl\": \"Vanaf 4/12, werken. HALTE NIET BEDIEND. Neem bus 58 aan de halte WTC van bus 14 richting UZ-VUB.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"58\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"3400\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Dec 4, works. STOP NOT SERVED. Stop of bus 58 and 88 : rue du Progr\u00e8s, after crossing rue des Charbonniers.\", \"fr\": \"D\u00e8s le 4/12, travaux. ARRET NON DESSERVI. Arr\u00eat des bus 58 et 88 : rue du Progr\u00e8s, apr\u00e8s rue des Charbonniers.\", \"nl\": \"Vanaf 4/12, werken. HALTE NIET BEDIEND. Halte bus 58 en 88 : Vooruitgangstraat, na Koolbrandersstraat.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"58\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"1083\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Oct 22, works. The stop is moved : Rue du Pavillon, 86. (Moved 20m forwards).\", \"fr\": \"A partir du 22/10, travaux. Arr\u00eat d\u00e9plac\u00e9 : rue du Pavillon, 86. (Avanc\u00e9 de 20m).\", \"nl\": \"Vanaf 22/10, werken. De halte is verplaatst : Palvijoenstraat, 86. (20m vooruitgebracht).\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"58\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"5741\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. As of Apr 24 at 6.30AM, STOP NOT SERVED. Stop of bus 59: rue Willemsstraat 9.\", \"fr\": \"Travaux. D\u00e8s le 24/4 \u00e0 6h30, ARRET NON DESSERVI. Arr\u00eat du bus 59: rue Willems, 9.\", \"nl\": \"Werken. Vanaf 24/4 om 6. 30u, HALTE NIET BEDIEND. Halte van bus 59: Willemsstraat 9.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"59\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"1582\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. As of Apr 24 at 6.30AM, bus 59 diverted between COTEAUX / WIJNHEUVELEN and GUTENBERG via DAILLY.\", \"fr\": \"Travaux. D\u00e8s le 24/4 \u00e0 6h30, bus 59 d\u00e9vi\u00e9 entre COTEAUX et GUTENBERG via BREMER et DAILLY.\", \"nl\": \"Werken. Vanaf 24/4 om 6. 30u, bus 59 omgeleid tussen WIJNHEUVELEN en GUTENBERG via BREMER en DAILLY.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"59\"}]",
+        "priority": 5,
+        "points": "[{\"id\": \"6461\"}, {\"id\": \"5298\"}, {\"id\": \"5740\"}, {\"id\": \"3101\"}, {\"id\": \"3111\"}, {\"id\": \"3099\"}, {\"id\": \"3098\"}, {\"id\": \"3109\"}, {\"id\": \"3106\"}, {\"id\": \"3126\"}, {\"id\": \"3104\"}, {\"id\": \"3103\"}, {\"id\": \"3102\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. As of Apr 24 at 6.30AM, bus 59 diverted between ST-JOSSE / ST-JOOST and COTEAUX / WIJNHEUVELEN via DAILLY.\", \"fr\": \"Travaux. D\u00e8s le 24/4 \u00e0 6h30, bus 59 d\u00e9vi\u00e9 entre SAINT-JOSSE et COTEAUX via DAILLY et BREMER.\", \"nl\": \"Werken. Vanaf 24/4 om 6. 30u, bus 59 omgeleid tussen SINT-JOOST en WIJNHEUVELEN via DAILLY en BREMER.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"59\"}]",
+        "priority": 5,
+        "points": "[{\"id\": \"1569B\"}, {\"id\": \"3081\"}, {\"id\": \"1280B\"}, {\"id\": \"3158B\"}, {\"id\": \"6464\"}, {\"id\": \"1476\"}, {\"id\": \"3125\"}, {\"id\": \"6158\"}, {\"id\": \"3156\"}, {\"id\": \"3155\"}, {\"id\": \"3160\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. As of Apr 24 at 6.30AM, STOP NOT SERVED. Stop of bus 59: rue des Eburons / Eburonenstraat 10.\", \"fr\": \"Travaux. D\u00e8s le 24/4 \u00e0 6h30, ARRET NON DESSERVI. Arr\u00eat du bus 59: rue des Eburons, 10\", \"nl\": \"Werken. Vanaf 24/4 om 6. 30u, HALTE NIET BEDIEND. Halte van bus 59: Eburonenstraat 10.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"59\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"3100\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. As of Apr 15, bus 60 diverted. Take bus 60 at the previous stop, at the St-Cyr house.\", \"fr\": \"Travaux. D\u00e8s le 15/4,bus 60 d\u00e9vi\u00e9. Prenez le bus 60 \u00e0 l'arr\u00eat pr\u00e9c\u00e9dent, devant la maison Saint-Cyr.\", \"nl\": \"Werken. Vanaf 15/4, bus 60 omgeleid. Neem bus 60 aan de vorige halte, voor het St-Cyr-huis.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"60\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"1273\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. As of Apr 15, STOP NOT SERVED. Take bus 60 at the stop of bus 27 to LUXEMBOURG / LUXEMBURG.\", \"fr\": \"Travaux. D\u00e8s le 15/4, ARRET NON DESSERVI. Prenez le bus 60 \u00e0 l'arr\u00eat du bus 27 vers LUXEMBOURG.\", \"nl\": \"Werken. Vanaf 15/4, HALTE NIET BEDIEND. Neem bus 60 aan de halte van bus 27 naar LUXEMBURG.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"60\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"1416\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Mar 5 at 9AM, works. STOP NOT SERVED. Temporary stop: avenue Jean & Pierre Carsoellaan 4.\", \"fr\": \"D\u00e8s le 5/3 \u00e0 9h, travaux. ARRET NON DESSERVI. Arr\u00eat provisoire: avenue Jean et Pierre Carsoel 4.\", \"nl\": \"Vanaf 5/3 om 9u, werken. HALTE NIET BEDIEND. Tijdelijke halte: Jean en Pierre Carsoellaan 4.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"60\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"6931B\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Mar 11, works. Bus 60 diverted between GROELSTVELD and DE WANSIJN via DIEWEG.\", \"fr\": \"D\u00e8s le 11/3, travaux. Bus 60 d\u00e9vi\u00e9 entre GROELSTVELD et DE WANSIJN via DIEWEG.\", \"nl\": \"Vanaf 11/3, werken. Bus 60 omgeleid tussen GROELSTVELD en DE WANSIJN via DIEWEG.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"60\"}]",
+        "priority": 5,
+        "points": "[{\"id\": \"2702\"}, {\"id\": \"2701\"}, {\"id\": \"1929\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. As of April 7th, stop served only by bus 66. Take bus 29, 63 or 65 at the stop of bus 71 to DELTA.\", \"fr\": \"Travaux. D\u00e8s le 7/4, arr\u00eat uniquement desservi par bus 66. Bus 29, 63 ou 65 \u00e0 l'arr\u00eat du bus 71 vers DELTA.\", \"nl\": \"Werken. Vanaf 7/4, halte enkel bediend door bus 66. Neem bus 29, 63 of 65 aan de halte van bus 71 naar DELTA.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"65\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"6445\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Apr 14 at 7AM, works. STOP NOT SERVED. Take bus 66 at the drop off stop.\", \"fr\": \"D\u00e8s le 14/4 \u00e0 7h, travaux. ARRET NON DESSERVI. Prenez le bus 66 \u00e0 l'arr\u00eat de d\u00e9barquement.\", \"nl\": \"Vanaf 14/4 om 7u, werken. HALTE NIET BEDIEND. Neem bus 66 aan de afstaphalte.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"66\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"3284\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Jan 8 to Jun 28, works. After CHURCHILL, tram 7 continues on line 3 direction ESPLANADE.\", \"fr\": \"Du 8/1 au 28/6, travaux. Apr\u00e8s CHURCHILL, tram 7 continue sur la ligne 3 direction ESPLANADE.\", \"nl\": \"Van 8/1 tot en met 28/6, werken. Na CHURCHILL rijdt tram 7 verder op lijn 3 richting ESPLANADE.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"7\"}]",
+        "priority": 6,
+        "points": "[{\"id\": \"5307H\"}, {\"id\": \"5317G\"}, {\"id\": \"5305G\"}, {\"id\": \"5220F\"}, {\"id\": \"5200F\"}, {\"id\": \"5266F\"}, {\"id\": \"3481\"}, {\"id\": \"0821\"}, {\"id\": \"0901\"}, {\"id\": \"2246F\"}, {\"id\": \"0801\"}, {\"id\": \"5306G\"}, {\"id\": \"5308F\"}, {\"id\": \"5210\"}, {\"id\": \"5211\"}, {\"id\": \"5758F\"}, {\"id\": \"5311\"}, {\"id\": \"5212\"}, {\"id\": \"5213\"}, {\"id\": \"5312\"}, {\"id\": \"1049F\"}, {\"id\": \"6457F\"}, {\"id\": \"5303\"}, {\"id\": \"5205\"}, {\"id\": \"5208\"}, {\"id\": \"9969F\"}, {\"id\": \"0811\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Jan 8-Jun 28, works. Stop not served. Stop of tram 7: av. Croix du Feu in front of av. Pagodes.\", \"fr\": \"8/1-28/6, travaux. Arr\u00eat non desservi. Arr\u00eat du tram 7: avenue des Croix du Feu, \u00e0 hauteur de l'avenue des Pagodes.\", \"nl\": \"8/1-28/6, werken. Halte niet bediend. Halte van tram 7: Vuurkruisenlaan, ter hoogte van de Pagodenlaan.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"7\"}]",
+        "priority": 5,
+        "points": "[{\"id\": \"5771\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Jan 8-Jun 28, works. Tram 7 interrupted btw HEEMBEEK and DOCKS BXL. Stop of the T-bus to DOCKS BXL: av. Araucaria\", \"fr\": \"8/1-28/6, travaux. T7 interrompu de HEEMBEEK \u00e0 DOCKS BRUXSEL. Arr\u00eat du T-bus vers DOCKS BRUXSEL: av. Araucaria\", \"nl\": \"8/1-28/6, werken. T7 onderbroken tss HEEMBEEK en DOCKS BRUXSEL. Halte T-bus naar DOCKS BRUXSEL: Araucarialaan.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"7\"}]",
+        "priority": 5,
+        "points": "[{\"id\": \"5704F\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Jan 8-Jun 28, works. Stop not served. T-bus to HEEMBEEK and DE WAND at the stop of bus 56 to BUDA.\", \"fr\": \"8/1-28/6, travaux. Arr\u00eat non desservi. T-bus vers HEEMBEEK et DE WAND \u00e0 l'arr\u00eat du bus 56 vers BUDA.\", \"nl\": \"8/1-28/6, werken. Halte niet bediend. T-bus naar HEEMBEEK en DE WAND aan de halte van bus 56 naar BUDA.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"7\"}]",
+        "priority": 5,
+        "points": "[{\"id\": \"5770F\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Jan 8-Jun 28, works. Tram 7 interrupted btw HEEMBEEK and DOCKS BXL. Stop T-bus to DOCKS BXL: next to this stop.\", \"fr\": \"8/1-28/6, travaux. T7 interrompu de HEEMBEEK \u00e0 DOCKS BXL. Arr\u00eat du T-bus vers DOCKS BXL: \u00e0 c\u00f4t\u00e9 de cet arr\u00eat.\", \"nl\": \"8/1-28/6, werken. T7 onderbroken tss HEEMBEEK en DOCKS BXL. Halte T-bus naar DOCKS BXL: naast deze halte.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"7\"}]",
+        "priority": 5,
+        "points": "[{\"id\": \"5705\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Jan 8-Jun 28, works. Tram 7 replaced by T-bus between DOCKS BRUXSEL and HEEMBEEK. Info: stib-mivb.brussels\", \"fr\": \"8/1-28/6, travaux. Tram 7 remplac\u00e9 par des T-bus entre DOCKS BRUXSEL et HEEMBEEK. Info: stib. brussels.\", \"nl\": \"8/1-28/6, werken. Tram 7 vervangen door T-bus tussen DOCKS BRUXSEL en HEEMBEEK. info: mivb. brussels.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"7\"}]",
+        "priority": 6,
+        "points": "[{\"id\": \"5261\"}, {\"id\": \"5267\"}, {\"id\": \"5264F\"}, {\"id\": \"5256F\"}, {\"id\": \"5355F\"}, {\"id\": \"1048F\"}, {\"id\": \"5222F\"}, {\"id\": \"3480\"}, {\"id\": \"6456F\"}, {\"id\": \"5258\"}, {\"id\": \"0806\"}, {\"id\": \"5357\"}, {\"id\": \"0906\"}, {\"id\": \"5359\"}, {\"id\": \"0826\"}, {\"id\": \"5253\"}, {\"id\": \"5352\"}, {\"id\": \"5254\"}, {\"id\": \"5356\"}, {\"id\": \"5265F\"}, {\"id\": \"5221F\"}, {\"id\": \"5354H\"}, {\"id\": \"5255F\"}, {\"id\": \"5350G\"}, {\"id\": \"9963F\"}, {\"id\": \"0816\"}, {\"id\": \"2243F\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Jan 7, 9PM-Jun 28,works. Stop not served. Stop T-bus to DOCKS BRUXSEL: av. Croix du Feu, crossing av. Pagodes.\", \"fr\": \"7/1, 21h-28/6, travaux. Arr\u00eat non desservi.Arr\u00eat du T-bus vers DOCKS BRUXSEL: av. Croix du Feu, carr. av. Pagodes.\", \"nl\": \"7/1, 21u-28/6, werken. Halte niet bediend.Halte van de T-bus naar DOCKS BRUXSEL: Vuurkruisenln, kruispt Pagodenln.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"7\"}]",
+        "priority": 5,
+        "points": "[{\"id\": \"5706\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Mar 18, works. STOP NOT SERVED. Temporary stop: avenue de la Couronne / Kroonlaan 439-443.\", \"fr\": \"D\u00e8s le 18/3, travaux. ARRET NON DESSERVI. Arr\u00eat provisoire: avenue de la Couronne 439-443.\", \"nl\": \"Vanaf 18/3, werken. HALTE NIET BEDIEND. Tijdelijke halte: Kroonlaan 439-443.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"72\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"3558\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Apr 2, 2024 to June 2025, works. STOP NOT SERVED. Stop of bus 74: av. du Globelaan 43.\", \"fr\": \"Du 2/4/2024 \u00e0 juin 2025, travaux. ARRET NON DESSERVI. Arr\u00eat du bus 74: avenue du Globe 43.\", \"nl\": \"Van 2/4/2024 tot juni 2025, werken. HALTE NIET BEDIEND. Halte van bus 74: Globelaan 43.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"74\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"2732\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. From Apr 2 until June 2025, STOP NOT SERVED. Take bus 74 at the previous stop, FOREST CENTRE.\", \"fr\": \"Travaux. Du 2/4 \u00e0 juin 2025, ARRET NON DESSERVI. Prenez le bus 74 \u00e0 l'arr\u00eat pr\u00e9c\u00e9dent, FOREST CENTRE.\", \"nl\": \"Werken. Vanaf 2/4 tot juni 2025, HALTE NIET BEDIEND. Neem bus 74 aan de vorige halte, VORST CENTRUM.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"74\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"5719\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Apr 2, 2024 to June 2025, works. STOP NOT SERVED. Stop of bus 74: FOREST NATIONAL (av. du Globelaan 43)\", \"fr\": \"Du 2/4/2024 \u00e0 juin 2025, travaux. ARRET NON DESSERVI. Arr\u00eat du bus 74: FOREST NATIONAL (avenue du Globe 43).\", \"nl\": \"Van 2/4/2024 tot juni 2025, werken. HALTE NIET BEDIEND. Halte van bus 74: VORST NATIONAAL (Globelaan 43)\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"74\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"2952B\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Apr 2, 2024-June 2025, works. Bus 74 diverted between FOREST NATIONAL and FOREST CENTRE. Info: stib-mivb.brussels\", \"fr\": \"Du 2/4/2024 \u00e0 juin 2025, travaux. Bus 74 d\u00e9vi\u00e9 entre FOREST NATIONAL et FOREST CENTRE. Info: stib.brussels.\", \"nl\": \"2/4/2024-juni 2025, werken. Bus 74 omgeleid tussen VORST NATIONAAL en VORST CENTRUM. Info: mivb.brussels\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"74\"}]",
+        "priority": 5,
+        "points": "[{\"id\": \"2632\"}, {\"id\": \"2453\"}, {\"id\": \"2452\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Mar 18, works. Bus 74 limited to DECROLY. Walk to UCCLE-STALLE / UKKEL-STALLE.\", \"fr\": \"D\u00e8s le 18/3, travaux. Bus 74 limit\u00e9 \u00e0 DECROLY. Continuez \u00e0 pied jusqu'\u00e0 UCCLE-STALLE.\", \"nl\": \"Vanaf 18/3, werken. Bus 74 beperkt tot DECROLY. Ga te voet tot UKKEL-STALLE.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"74\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"2416\"}, {\"id\": \"2415\"}, {\"id\": \"2414\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Apr 2, 2024 to June 2025, works. STOP NOT SERVED. Stop of bus 74: FOREST NATIONAL (av. du Globelaan 8).\", \"fr\": \"Du 2/4/2024 \u00e0 juin 2025, travaux. ARRET NON DESSERVI. Arr\u00eat des bus 74: FOREST NATIONAL. (avenue du Globe 8).\", \"nl\": \"Van 2/4/2024 tot juni 2025, werken. HALTE NIET BEDIEND. Halte van bus 74: VORST NATIONAAL (Globelaan 8)\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"74\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"2939B\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. As of Apr 15, bus 79 diverted from MICHEL-ANGE to MAELBEEK. Stop SCHUMAN moved rue Franklin.\", \"fr\": \"Travaux. D\u00e8s le 15/4, bus 79 d\u00e9vi\u00e9 depuis MICHEL-ANGE vers MAELBEEK. Arr\u00eat SCHUMAN d\u00e9plac\u00e9 rue Franklin.\", \"nl\": \"Werken. Vanaf 15/4, bus 79 omgeleid vanaf MICHELANGELO naar MAALBEEK. Halte SCHUMAN verplaatst Franklinstr.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"79\"}]",
+        "priority": 6,
+        "points": "[{\"id\": \"6450\"}, {\"id\": \"6055\"}, {\"id\": \"9853\"}, {\"id\": \"1462\"}, {\"id\": \"2043\"}, {\"id\": \"2042\"}, {\"id\": \"2041\"}, {\"id\": \"3902\"}, {\"id\": \"3903\"}, {\"id\": \"3904\"}, {\"id\": \"2028\"}, {\"id\": \"3905\"}, {\"id\": \"1533\"}, {\"id\": \"1531\"}, {\"id\": \"1464\"}, {\"id\": \"1463\"}, {\"id\": \"1320\"}, {\"id\": \"3920\"}, {\"id\": \"3911\"}, {\"id\": \"1339\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. From Apr 29 at 7AM until May 3 at 5PM, bus 80 diverted between CARENE / CARINA and FEVRIER / FEBRUARI.\", \"fr\": \"Travaux. Du 29/4 \u00e0 7h au 3/5 \u00e0 17h, bus 80 d\u00e9vi\u00e9 entre CARENE et FEVRIER.\", \"nl\": \"Werken. Van 29/4 om 7u tot 3/5 om 17u, bus 80 omgeleid tussen CARINA en FEBRUARI.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"80\"}]",
+        "priority": 5,
+        "points": "[{\"id\": \"2988\"}, {\"id\": \"3207\"}, {\"id\": \"2292B\"}, {\"id\": \"5362\"}, {\"id\": \"3210B\"}, {\"id\": \"5045\"}, {\"id\": \"3401\"}, {\"id\": \"2895\"}, {\"id\": \"2908B\"}, {\"id\": \"3200\"}, {\"id\": \"3176\"}, {\"id\": \"3898\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"T81-T97 operate normally againBAREEL and JANSON\", \"fr\": \"T81-T97 circulent \u00e0 nouveau entre BARRIERE et JANSON\", \"nl\": \"T81-T97 worden weer bediend tussen BAREEL en JANSON\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"81\"}]",
+        "priority": 3,
+        "points": "[{\"id\": \"6153\"}, {\"id\": \"6175\"}, {\"id\": \"6078\"}, {\"id\": \"6809F\"}, {\"id\": \"1042\"}, {\"id\": \"3370F\"}, {\"id\": \"3572F\"}, {\"id\": \"2220F\"}, {\"id\": \"6157F\"}, {\"id\": \"2931F\"}, {\"id\": \"6009\"}, {\"id\": \"6155F\"}, {\"id\": \"6166\"}, {\"id\": \"6165\"}, {\"id\": \"3610F\"}, {\"id\": \"6068\"}, {\"id\": \"2218F\"}, {\"id\": \"6808G\"}, {\"id\": \"6162\"}, {\"id\": \"2671F\"}, {\"id\": \"2285G\"}, {\"id\": \"6425F\"}, {\"id\": \"2380F\"}, {\"id\": \"2217F\"}, {\"id\": \"6810\"}, {\"id\": \"6156F\"}, {\"id\": \"6158H\"}, {\"id\": \"6811\"}, {\"id\": \"2336G\"}, {\"id\": \"3608\"}, {\"id\": \"3609F\"}, {\"id\": \"6792F\"}, {\"id\": \"2972F\"}, {\"id\": \"0636\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Until 2026,works.Tram 82 replaced by T-bus btw FOREST CENTRE / VORST CENTRUM and DROGENBOS. More info: stib-mivb.be.\", \"fr\": \"Jusqu'en 2026, travaux. Tram 82 remplac\u00e9 par des T-bus entre FOREST CENTRE et DROGENBOS. Info: stib.brussels.\", \"nl\": \"Tot 2026, werken. Tram 82 wordt vervangen door T-bus tussen VORST CENTRUM en DROGENBOS. Info: mivb.brussels.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"82\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"5163F\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. Until 2026, stop not served. Stop of the T-bus: Grote Baan 227 (stop of De Lijn to Anderlecht).\", \"fr\": \"Travaux. Jsq 2026, arr\u00eat non desservi. Arr\u00eat du T-bus: Grand'Route 227 (arr\u00eat des bus De Lijn vers Anderlecht).\", \"nl\": \"Werken. Tot 2026, halte niet bediend. Halte van de T-bus: Grote Baan 227 (halte van De Lijn naar Anderlecht).\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"82\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"5732F\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. Until 2026, tram 82 and 97 interrupted. Stop of the T-bus and of bus 50: ch. de Neerstalsestwg 236.\", \"fr\": \"Travaux. Jsq 2026, tram 82 et 97 interrompus. Arr\u00eat du T-bus et du bus 50: chauss\u00e9e de Neerstalle 236\", \"nl\": \"Werken. Tot 2026, tram 82 en 97 onderbroken. Halte van de T-bus en van bus 50: Neerstalsesteenweg 236\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"82\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"5164F\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Until 2026, works. T-bus 82/97 diverted. Stop T-bus 82/97: bd 2e Arm\u00e9e Britannique / Britse Tweedelegerlaan.\", \"fr\": \"Jsq 2026, travaux. T-bus 82/97 d\u00e9vi\u00e9. Arr\u00eat T-bus 82/97: bd 2e Arm\u00e9e Britannique, carrefour rue de la Station.\", \"nl\": \"Tot 2026, werken. T-bus 82/97 omgeleid. Halte T-bus 82/97: Britse Tweedelegerlaan, kruispunt Stationstraat.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"82\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"5719H\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"As of Nov 16 at 6AM, works. Stop moved to av. Port / Havenln, in front of number 100 (moved backward of +/- 120m)\", \"fr\": \"D\u00e8s le 16/11 \u00e0 6h, travaux. Arr\u00eat d\u00e9plac\u00e9 avenue du Port, en face du num\u00e9ro 100 (recul\u00e9 de +/- 120m).\", \"nl\": \"Vanaf 16/11 om 6u,werken Halte verplaatst naar de Havenlaan, tegenover nr 100 (achteruitgebracht van +/- 120m)\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"86\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"2305\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Jan 22, 6AM-end of June, works. Bus 86 diverted between GARE DE L'OUEST/ WESTSTATION and SUZAN DANIEL via ETANGS NOIRS.\", \"fr\": \"Du 22/1 \u00e0 6h jusqu'\u00e0 fin juin, travaux. Bus 86 d\u00e9vi\u00e9 entre GARE DE L'OUEST et SUZAN DANIEL via ETANGS NOIRS.\", \"nl\": \"Van 22/1 om 6u tot eind juni, werken. Bus 86 omgeleid tussen WESTSTATION-SUZAN DANIEL via ZWARTE VIJVERS.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"86\"}]",
+        "priority": 5,
+        "points": "[{\"id\": \"3238\"}, {\"id\": \"3234\"}, {\"id\": \"3253\"}, {\"id\": \"3252\"}, {\"id\": \"3282\"}, {\"id\": \"3281\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. As of Apr 22 at 9.30AM, bus 89 diverted btw TRIANGLE and QUATRE- VENTS. For DUCHESSE, T82 at TRIANGLE.\", \"fr\": \"Travaux. D\u00e8s le 22/4 \u00e0 9h30, bus 89 d\u00e9vi\u00e9 entre TRIANGLE et QUATRE- VENTS. Pour DUCHESSE, tram 82 \u00e0 TRIANGLE.\", \"nl\": \"Werken. Vanaf 22/4 om 9. 30u, bus 89 omgeleid tussen DRIEHOEK en VIER WINDEN. Voor HERTOGIN, tram 82 aan DRIEHOEK.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"89\"}]",
+        "priority": 5,
+        "points": "[{\"id\": \"1895\"}, {\"id\": \"3223B\"}, {\"id\": \"3222\"}, {\"id\": \"3221\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. As of Apr 22 at 9.30AM, bus 89 diverted btw TRIANGLE and QUATRE- VENTS. For DUCHESSE, T82 at TRIANGLE.\", \"fr\": \"Travaux. D\u00e8s le 22/4 \u00e0 9h30, bus 89 d\u00e9vi\u00e9 entre TRIANGLE et QUATRE- VENTS. Pour DUCHESSE, tram 82 \u00e0 TRIANGLE.\", \"nl\": \"Werken. Vanaf 22/4 om 9. 30u, bus 89 omgeleid tussen DRIEHOEK en VIER WINDEN. Voor HERTOGIN, tram 82 aan DRIEHOEK.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"89\"}]",
+        "priority": 5,
+        "points": "[{\"id\": \"3347\"}, {\"id\": \"2301\"}, {\"id\": \"2595\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. From Apr 26 at 9PM until May 12, tram 9 replaced by T-bus btw UZ BRUSSEL and ROI BAUDOUIN / KONING BOUDEWIJN.\", \"fr\": \"Travaux. Du 26/4 \u00e0 21h au 12/5, tram 9 remplac\u00e9 par des T-bus entre UZ BRUSSEL et ROI BAUDOUIN.\", \"nl\": \"Werken. Van 26/4 om 21u tot en met 12/5, tram 9 vervangen door T-bus tussen UZ BRUSSEL en KONING BOUDEWIJN.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"9\"}]",
+        "priority": 5,
+        "points": "[{\"id\": \"1681F\"}, {\"id\": \"1679F\"}, {\"id\": \"0470F\"}, {\"id\": \"6864F\"}, {\"id\": \"6865F\"}, {\"id\": \"1675F\"}, {\"id\": \"1677F\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. From Apr 26 at 9PM until May 12, stop not served. T-bus to ROI BAUDOUIN at the stop of bus 83 to VAL MARIA.\", \"fr\": \"Travaux. Du 26/4 \u00e0 21h au 12/5, arr\u00eat non desservi. T-bus vers ROI BAUDOUIN \u00e0 l'arr\u00eat du bus 83 vers VAL MARIA.\", \"nl\": \"Werken. 26/4, 21u-12/5, halte niet bediend.T-bus naar KONING BOUDEWIJN aan de halte van bus 83 naar MARIENDAAL.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"9\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"1691F\"}, {\"id\": \"1689F\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. Apr 26, 9PM-May 12, stop not served. Stop of the T-bus: PALFIJN (stop of bus 83 to GARE DE BERCHEM).\", \"fr\": \"Travaux. 26/4, 21h-12/5, arr\u00eat non desservi. Arr\u00eat du T-bus: PALFIJN (arr\u00eat du bus 83 vers GARE DE BERCHEM).\", \"nl\": \"Werken. 26/4, 21u-12/5, halte niet bediend. Halte van de T-bus: PALFIJN (halte van bus 83 naar STATION BERCHEM)\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"9\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"1692F\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. Apr 26, 9PM-May 12, stop not served. T-bus to UZ BRUSSEL at the stop of bus 83 to GARE DE BERCHEM.\", \"fr\": \"Travaux. Du 26/4 \u00e0 21h au 12/5, arr\u00eat non desservi. T-bus vers UZ BRUSSEL \u00e0 l'arr\u00eat du bus 83 vers GARE DE BERCHEM.\", \"nl\": \"Werken. 26/4, 21u-12/5, halte niet bediend.T-bus naar UZ BRUSSEL aan de halte van bus 83 naar STATION BERCHEM.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"9\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"1690F\"}, {\"id\": \"1695F\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. From Apr 26 at 9PM until May 12, stop not served. Take tram 9 at the next stop, UZ BRUSSEL.\", \"fr\": \"Travaux. Du 26/4 \u00e0 21h au 12/5, arr\u00eat non desservi. Prenez le tram 9 \u00e0 l'arr\u00eat suivant, UZ BRUSSEL.\", \"nl\": \"Werken. Van 26/4 om 21u tot en met 12/5, halte niet bediend. Neem tram 9 aan de volgende halte, UZ BRUSSEL.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"9\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"1684F\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"T81-T97 operate normally againBAREEL and JANSON\", \"fr\": \"T81-T97 circulent \u00e0 nouveau entre BARRIERE et JANSON\", \"nl\": \"T81-T97 worden weer bediend tussen BAREEL en JANSON\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"97\"}]",
+        "priority": 3,
+        "points": "[{\"id\": \"5152G\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. As of Apr 15, STOP NOT SERVED. Stop of bus 12: rue Franklinstraat 2a.\", \"fr\": \"Travaux. D\u00e8s le 15/4, ARRET NON DESSERVI. Arr\u00eat du bus 12: rue Franklin, 2a.\", \"nl\": \"Werken. Vanaf 15/4, HALTE NIET BEDIEND. Halte van bus 12: Franklinstraat 2a.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"12\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"1270B\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"T81-T97 operate normally againBAREEL and JANSON\", \"fr\": \"T81-T97 circulent \u00e0 nouveau entre BARRIERE et JANSON\", \"nl\": \"T81-T97 worden weer bediend tussen BAREEL en JANSON\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"97\"}]",
+        "priority": 3,
+        "points": "[{\"id\": \"5154F\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. As of Apr 15, B12 diverted btw LUXEMBOURG and MEISER via MAELBEEK. Stop SCHUMAN moved rue Archim\u00e8destr. 16.\", \"fr\": \"Travaux. D\u00e8s le 15/4,B12 d\u00e9vi\u00e9 entre LUXEMBOURG et MEISER via MAELBEEK. Arr\u00eat SCHUMAN d\u00e9plac\u00e9 rue Archim\u00e8de 16.\", \"nl\": \"Werken. Vanaf 15/4, bus 12 omgeleid ts LUXEMBURG en MEISER via MAALBEEK. Halte SCHUMAN verplaatst Archimedesstraat 16.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"12\"}]",
+        "priority": 6,
+        "points": "[{\"id\": \"6433\"}, {\"id\": \"1780\"}, {\"id\": \"1131B\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"T81-T97 operate normally againBAREEL and JANSON\", \"fr\": \"T81-T97 circulent \u00e0 nouveau entre BARRIERE et JANSON\", \"nl\": \"T81-T97 worden weer bediend tussen BAREEL en JANSON\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"97\"}]",
+        "priority": 3,
+        "points": "[{\"id\": \"2334F\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Dec 4, works. STOP NOT SERVED. Take bus 14 and 57 under the CCN building, at the terminus of bus 61.\", \"fr\": \"D\u00e8s le 4/12, travaux. ARRET NON DESSERVI. Prenez le bus 14 et 57 sous le b\u00e2timent CCN, au terminus du bus 61.\", \"nl\": \"Vanaf 4/12, werken. HALTE NIET BEDIEND. Neem bus 14 en 57 onder het CCN-gebouw, aan eindhalte bus 61.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"14\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"1082\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"T81-T97 operate normally againBAREEL and JANSON\", \"fr\": \"T81-T97 circulent \u00e0 nouveau entre BARRIERE et JANSON\", \"nl\": \"T81-T97 worden weer bediend tussen BAREEL en JANSON\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"97\"}]",
+        "priority": 3,
+        "points": "[{\"id\": \"5756F\"}, {\"id\": \"1258G\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. As of Mar 27, STOP MOVED. Stop of bus 17: rue des Thuyas / Thujastraat 13.\", \"fr\": \"Travaux. D\u00e8s le 27/3, ARRET DEPLACE. Arr\u00eat du bus 17: rue des Thuyas, 13.\", \"nl\": \"Werken. Vanaf 27/3, HALTE VERPLAATST. Halte van bus 17: Thujastraat 13.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"17\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"4310\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"T81-T97 operate normally againBAREEL and JANSON\", \"fr\": \"T81-T97 circulent \u00e0 nouveau entre BARRIERE et JANSON\", \"nl\": \"T81-T97 worden weer bediend tussen BAREEL en JANSON\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"97\"}]",
+        "priority": 3,
+        "points": "[{\"id\": \"5116\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Sep 5 6AM, works. STOP NOT SERVED. Temporary stop: av. Charles Michiels across no. 205\", \"fr\": \"D\u00e8s le 5/9 6h, travaux. ARRET NON DESSERVI. Arr\u00eat provisoire : av. Charles Michiels face au num. 205\", \"nl\": \"Vanaf 5/9 6u, werken. HALTE NIET BEDIEND. Tijdelijke halte: Charles Michielslaan tegenover nr. 205\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"17\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"4294\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"T81-T97 operate normally againBAREEL and JANSON\", \"fr\": \"T81-T97 circulent \u00e0 nouveau entre BARRIERE et JANSON\", \"nl\": \"T81-T97 worden weer bediend tussen BAREEL en JANSON\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"97\"}]",
+        "priority": 3,
+        "points": "[{\"id\": \"5156F\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Wroks. Until mid-2024, stop not served. T-bus at LEOPOLD I (bd de Smet de Naeyer 54, stop of bus 14 to UZ-VUB).\", \"fr\": \"Travaux. Jusque mi-2024, arr\u00eat non desservi. T-bus \u00e0 LEOPOLD I (bd de Smet de Naeyer 54, arr\u00eat du bus 14 vers UZ-VUB).\", \"nl\": \"Werken. Tot midden 2024, halte niet bediend. T-bus aan LEOPOLD I (de Smet de Naeyerlaan 54, halte B14 naar UZ-VUB).\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"19\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"6866F\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"T81-T97 operate normally againBAREEL and JANSON\", \"fr\": \"T81-T97 circulent \u00e0 nouveau entre BARRIERE et JANSON\", \"nl\": \"T81-T97 worden weer bediend tussen BAREEL en JANSON\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"97\"}]",
+        "priority": 3,
+        "points": "[{\"id\": \"5115F\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Apr 29, 7AM,works. STOP NOT SERVED. Take bus 21 at the stop VICTOR HUGO of bus 28 to BRABANCONNE.\", \"fr\": \"D\u00e8s le 29/4,7h, travaux. ARRET NON DESSERVI. Prenez le bus 21 \u00e0 l'arr\u00eat VICTOR HUGO du bus 28 vers BRABANCONNE.\", \"nl\": \"Vanaf 29/4, 7u, werken. HALTE NIET BEDIEND. Neem bus 21 aan de halte VICTOR HUGO van bus 28 naar BRABANCONNE.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"21\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"3367\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Until 2026, works. Stop of T-bus 82/97: ch. de Neerstalsesteenweg in front of 348.\", \"fr\": \"Jusqu'en 2026, travaux. Arr\u00eat du T-bus 82/97: chauss\u00e9e de Neerstalle, en face du num\u00e9ro 348.\", \"nl\": \"Tot 2026, werken. Halte van T-bus 82/97: Neerstalsesteenweg, tegenover nummer 348.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"T82\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"3242\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Apr 29 at 7AM, works. Bus 21 diverted between DIVIN SAUVEUR / GODD. ZALIGMAKER and JAMBLINNE DE MEUX.\", \"fr\": \"D\u00e8s le 29/4 \u00e0 7h, travaux. Bus 21 d\u00e9vi\u00e9 entre DIVIN SAUVEUR et JAMBLINNE DE MEUX.\", \"nl\": \"Vanaf 29/4 om 7u, werken. Bus 21 omgeleid tussen GODD. ZALIGMAKER en JAMBLINNE DE MEUX.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"21\"}]",
+        "priority": 5,
+        "points": "[{\"id\": \"3199\"}, {\"id\": \"3361\"}, {\"id\": \"3904\"}, {\"id\": \"3905\"}, {\"id\": \"3425\"}, {\"id\": \"3458\"}, {\"id\": \"3204\"}, {\"id\": \"3468\"}, {\"id\": \"3203\"}, {\"id\": \"3214\"}, {\"id\": \"3466\"}, {\"id\": \"2695\"}, {\"id\": \"3201\"}, {\"id\": \"4500\"}, {\"id\": \"3911\"}, {\"id\": \"4505\"}, {\"id\": \"2924\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"As of Oct 25, stop moved +/- 50m behind, side square Lain\u00e9square.\", \"fr\": \"D\u00e8s le 25/10, arr\u00eat recul\u00e9 de +/- 50m, c\u00f4t\u00e9 square Lain\u00e9\", \"nl\": \"Vanaf 25/10, werken. Halte achteruitgebracht van +/- 50m, kant Lain\u00e9square.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"T82\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"2023\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. As of Apr 15, bus 21 diverted. Take bus 21 at MAELBEEK / MAALBEEK (stop of bus 64 to PORTE DE NAMUR / NAAMSEPOORT).\", \"fr\": \"Travaux. D\u00e8s le 15/4, bus 21 d\u00e9vi\u00e9. Prenez le bus 21 \u00e0 MAELBEEK (arr\u00eat du bus 64 vers PORTE DE NAMUR).\", \"nl\": \"Werken. Vanaf 15/4, bus 21 omgeleid. Neem bus 21 aan MAALBEEK (halte van bus 64 naar NAAMSEPOORT) .\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"21\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"1476\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Apr 29, 7AM, works. STOP NOT SERVED.Take bus 21 at the stop VICTOR HUGO of bus 28  to KONKEL.\", \"fr\": \"D\u00e8s 29/4 \u00e0 7h, travaux. ARRET NON DESSERVI. Prenez le bus 21 \u00e0 l'arr\u00eat VICTOR HUGO du bus 28 vers KONKEL.\", \"nl\": \"Vanaf 29/4, 7u, werken. HALTE NIET BEDIEND. Neem bus 21 aan halte VICTOR HUGO van bus 28 naar KONKEL.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"21\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"3366\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Apr 29, works. Bus 28 limited to the stop STADE FALLON STADION.\", \"fr\": \"D\u00e8s le 29/4, travaux. Bus 28 limit\u00e9 \u00e0 l'arr\u00eat STADE FALLON.\", \"nl\": \"Vanaf 29/4, werken. Bus 28 beperkt tot de halte FALLON STADION.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"28\"}]",
+        "priority": 5,
+        "points": "[{\"id\": \"6021\"}, {\"id\": \"6476\"}, {\"id\": \"1141\"}, {\"id\": \"1140\"}, {\"id\": \"1403\"}, {\"id\": \"1424\"}, {\"id\": \"1412\"}, {\"id\": \"1423\"}, {\"id\": \"1422\"}, {\"id\": \"1421\"}, {\"id\": \"1410\"}, {\"id\": \"2919\"}, {\"id\": \"6449\"}, {\"id\": \"1408\"}, {\"id\": \"1406\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Apr 29, works. STOP NOT SERVED. Temporary stop: chemin du Struykbekenweg.\", \"fr\": \"D\u00e8s le 29/4, travaux. ARRET NON DESSERVI. Arr\u00eat provisoire: chemin du Struykbeken.\", \"nl\": \"Vanaf 29/4, werken. HALTE NIET BEDIEND. Tijdelijke halte: Struykbekenweg.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"28\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"1833B\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Apr 29 at 7AM, works. STOP NOT SERVED. Take bus 29 at the stop DIAMANT of bus 28 to KONKEL.\", \"fr\": \"D\u00e8s le 29/4 \u00e0 7h, travaux. ARRET NON DESSERVI. Prenez le bus 29 \u00e0 l'arr\u00eat DIAMANT du bus 28 vers KONKEL.\", \"nl\": \"Vanaf 29/4, 7u, werken. HALTE NIET BEDIEND. Neem bus 29 aan de halte DIAMANT van bus 28 naar KONKEL.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"29\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"6451\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. As of April 7th, STOP NOT SERVED. To go to DE BROUCKERE, take metro lines 1 or 5.\", \"fr\": \"Travaux. D\u00e8s le 7/4, ARRET NON DESSERVI. Pour rejoindre DE BROUCKERE, prenez le m\u00e9tro 1 ou 5.\", \"nl\": \"Werken. Vanaf 7/4, HALTE NIET BEDIEND. Om naar DE BROUCKERE te gaan, neem metrolijn 1 of 5.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"29\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"6447\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Apr 29 at 5AM to May 3 at 5PM, works. Bus 29 diverted between SPEECKAERT and LEVIE.\", \"fr\": \"Du 29/4 \u00e0 5h au 3/5 \u00e0 17h, travaux. Bus 29 d\u00e9vi\u00e9 entre SPEECKAERT et LEVIE.\", \"nl\": \"Van 29/4 om 5u tot 3/5 om 17u, werken. Bus 29 omgeleid tussen SPEECKAERT en LEVIE.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"29\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"1558\"}, {\"id\": \"1557\"}, {\"id\": \"1578\"}, {\"id\": \"1554\"}, {\"id\": \"1553\"}, {\"id\": \"1552\"}, {\"id\": \"1550\"}, {\"id\": \"1385\"}, {\"id\": \"3910\"}, {\"id\": \"1528\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Bus 29: works. Stop CLOVIS not served. Temporary stop: rue de Pavie / Paviastraat 53.\", \"fr\": \"Bus 29 : travaux. Arr\u00eat CLOVIS non desservi. Arr\u00eat provisoire: rue de Pavie 53.\", \"nl\": \"Bus 29: werken. Halte CLOVIS niet bediend. Tijdelijke halte: Paviastraat 53.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"29\"}]",
+        "priority": 6,
+        "points": "[{\"id\": \"1567\"}, {\"id\": \"1566\"}, {\"id\": \"1565B\"}, {\"id\": \"1561\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Apr 29 at 5AM to May 3 at 5PM, works. STOP NOT SERVED. Temporary stop: avenue du Mai / Meilaan 208.\", \"fr\": \"Du 29/4 \u00e0 5h au 3/5 \u00e0 17h, travaux. ARRET NON DESSERVI. Arr\u00eat provisoire: avenue du Mai 208.\", \"nl\": \"Van 29/4 om 5u tot 3/5 om 17u, werken. HALTE NIET BEDIEND. Tijdelijke halte: Meilaan 208.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"29\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"1560\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Apr 29 at 5AM to May 3 at 5PM, works. STOP NOT SERVED. Temporary stop: avenue du Mai / Meilaan 148.\", \"fr\": \"Du 29/4 \u00e0 5h au 3/5 \u00e0 17h, travaux. ARRET NON DESSERVI. Arr\u00eat provisoire: avenue du Mai 148.\", \"nl\": \"Van 29/4 om 5u tot 3/5 om 17u, werken. HALTE NIET BEDIEND. Tijdelijke halte: Meilaan 148.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"29\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"1559\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Apr 29 at 7AM, works. Bus 29 diverted between RADIUM and LEVIE.\", \"fr\": \"D\u00e8s le 29/4 \u00e0 7h, travaux. Bus 29 d\u00e9vi\u00e9 entre RADIUM et LEVIE.\", \"nl\": \"Vanaf 29/4 om 7u, werken. Bus 29 omgeleid tussen RADIUM en LEVIE.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"29\"}]",
+        "priority": 5,
+        "points": "[{\"id\": \"1514B\"}, {\"id\": \"1513\"}, {\"id\": \"1820\"}, {\"id\": \"1512\"}, {\"id\": \"3354\"}, {\"id\": \"2594\"}, {\"id\": \"2296\"}, {\"id\": \"1509\"}, {\"id\": \"2680\"}, {\"id\": \"1508\"}, {\"id\": \"3150\"}, {\"id\": \"3072\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Jan 7, 9PM-Jun 28, works. Tram 3 replaced by T-bus. Stop T-bus: av. Croix du Feu, crossing av. Buissonnets\", \"fr\": \"7/1, 21h-28/6, travaux. Tram 3 remplac\u00e9 par des T-bus. Arr\u00eat du T-bus: av. Croix du Feu, carrefour av.Buissonnets\", \"nl\": \"7/1, 21u-28/6, werken. Tram 3 vervangen door T- bus. Halte T-bus: Vuurkruisenlaan, kruispunt Braambosjesln.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"3\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"5772\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Jan 7, 9PM-Jun 28, works. Tram 3 replaced by T-bus. Stop T-bus: av. Croix du Feu, after rue De Wandstraat.\", \"fr\": \"7/1, 21h-28/6, travaux. Tram 3 remplac\u00e9 par des T-bus. Arr\u00eat du T-bus: avenue des Croix du Feu, apr\u00e8s la rue De Wand.\", \"nl\": \"7/1, 21u-28/6, werken. Tram 3 vervangen door T-bus. Halte T-bus: Vuurkruisenlaan, na de De Wandstraat.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"3\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"5806\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Jan 8 to Jun 28, works. After CHURCHILL, tram 3 continues on line 7 direction HEYSEL / HEIZEL.\", \"fr\": \"Du 8/1 au 28/6, travaux. Apr\u00e8s CHURCHILL, tram 3 continue sur la ligne 7 direction HEYSEL.\", \"nl\": \"Van 8/1 tot en met 28/6, werken. Na CHURCHILL rijdt tram 3 verder op lijn 7 richting HEIZEL.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"3\"}]",
+        "priority": 6,
+        "points": "[{\"id\": \"6253\"}, {\"id\": \"6178\"}, {\"id\": \"2318G\"}, {\"id\": \"5221F\"}, {\"id\": \"0611\"}, {\"id\": \"0501\"}, {\"id\": \"0601\"}, {\"id\": \"0621\"}, {\"id\": \"0511\"}, {\"id\": \"0531\"}, {\"id\": \"2338F\"}, {\"id\": \"6422F\"}, {\"id\": \"0705\"}, {\"id\": \"0706\"}, {\"id\": \"0703\"}, {\"id\": \"5714\"}, {\"id\": \"2543F\"}, {\"id\": \"0704\"}, {\"id\": \"0702\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Jan 7, 9PM-Jun 28,works. Stop not served. Stop T-bus to DOCKS BRUXSEL: av. Croix du Feu, crossing av. Pagodes.\", \"fr\": \"7/1, 21h-28/6, travaux. Arr\u00eat non desservi.Arr\u00eat du T-bus vers DOCKS BRUXSEL: av. Croix du Feu, carr. av. Pagodes.\", \"nl\": \"7/1, 21u-28/6, werken. Halte niet bediend.Halte van de T-bus naar DOCKS BRUXSEL: Vuurkruisenln, kruispt Pagodenln.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"3\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"5706\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Jan 15, works. STOP NOT SERVED. Stop of bus 34: chauss\u00e9e de Wavre / Waversesteenweg 1303.\", \"fr\": \"D\u00e8s le 15/1, travaux. ARRET NON DESSERVI. Arr\u00eat du bus 34: chauss\u00e9e de Wavre 1303.\", \"nl\": \"Vanaf 15/1, werken. HALTE NIET BEDIEND. Halte van bus 34: Waversesteenweg 1303.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"34\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"1718B\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Mar 5 at 9AM, works. STOP NOT SERVED. Temporary stop: avenue Jean & Pierre Carsoellaan 4.\", \"fr\": \"D\u00e8s le 5/3 \u00e0 9h, travaux. ARRET NON DESSERVI. Arr\u00eat provisoire: avenue Jean et Pierre Carsoel 4.\", \"nl\": \"Vanaf 5/3 om 9u, werken. HALTE NIET BEDIEND. Tijdelijke halte: Jean en Pierre Carsoellaan 4.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"37\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"6931B\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. As of April 7th, stop of bus 38 moved to the Cantersteen, at the stop of bus 52 to FOREST / VORST (BERVOETS)\", \"fr\": \"Travaux. D\u00e8s le 7/4, arr\u00eat du bus 38 d\u00e9plac\u00e9 Cantersteen, \u00e0 l'arr\u00eat du bus 52 vers FOREST (BERVOETS).\", \"nl\": \"Werken. Vanaf 7/4, halte van bus 38 verplaatst naar de Kantersteen, aan de halte van bus 52 naar VORST (BERVOETS).\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"38\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"6443\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. As of Apr 29, STOP NOT SERVED. Take bus 38 at the next stop, BASCULE.\", \"fr\": \"Travaux. D\u00e8s le 29/4, ARRET NON DESSERVI. Prenez le bus 38 \u00e0 l'arr\u00eat suivant, BASCULE.\", \"nl\": \"Werken. Vanaf 29/4, HALTE NIET BEDIEND. Neem bus 38 aan de volgende halte, BASCULE.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"38\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"1914\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Apr 3 at 6AM, works. STOP NOT SERVED. Temporary stop: avenue Winston Churchilllaan 202.\", \"fr\": \"D\u00e8s le 3/4 \u00e0 6h, travaux. ARRET NON DESSERVI. Arr\u00eat provisoire: avenue Winston Churchill 202.\", \"nl\": \"Vanaf 3/4 om 6u, werken. HALTE NIET BEDIEND. Tijdelijke halte: Winston Churchilllaan 202.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"38\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"1973\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Apr 3 at 6AM, works. Bus 38 diverted between HOUZEAU and LONGCHAMP via rue Edith Cavellstraat.\", \"fr\": \"D\u00e8s le 3/4 \u00e0 6h, travaux. Bus 38 d\u00e9vi\u00e9 entre HOUZEAU et LONGCHAMP via rue Edith Cavell.\", \"nl\": \"Vanaf 3/4 om 6u, werken. Bus 38 omgeleid tussen HOUZEAU en LONGCHAMP via Edith Cavellstraat.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"38\"}]",
+        "priority": 5,
+        "points": "[{\"id\": \"1943\"}, {\"id\": \"4076\"}, {\"id\": \"1969\"}, {\"id\": \"1968\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Apr 3 at 6AM, works. STOP NOT SERVED. Take bus 38 and 41 at the next stop, HOUZEAU.\", \"fr\": \"D\u00e8s le 3/4 \u00e0 6h, travaux. ARRET NON DESSERVI. Prenez les bus 38 et 41 \u00e0 l'arr\u00eat suivant, HOUZEAU.\", \"nl\": \"Vanaf 3/4 om 6u, werken. HALTE NIET BEDIEND. Neem bus 38 en 41 aan de volgende halte, HOUZEAU.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"38\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"1920\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Obstacle on the road: B41 diverted between BOONDAAL STATION and MONTANA direction HELDEN\", \"fr\": \"Obstacle sur la route: B41 d\u00e9vi\u00e9 entre BOONDAEL GARE et MONTANA direction HEROS\", \"nl\": \"Hindernis op de weg: B41 omgeleid tussen BOONDAAL STATION en MONTANA richting HELDEN\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"41\"}]",
+        "priority": 2,
+        "points": "[{\"id\": \"2714\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Obstacle on the road: B41 diverted between BOONDAAL STATION and MONTANA direction HELDEN\", \"fr\": \"Obstacle sur la route: B41 d\u00e9vi\u00e9 entre BOONDAEL GARE et MONTANA direction HEROS\", \"nl\": \"Hindernis op de weg: B41 omgeleid tussen BOONDAAL STATION en MONTANA richting HELDEN\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"41\"}]",
+        "priority": 2,
+        "points": "[{\"id\": \"1970\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Obstacle on the road: B41 diverted between BOONDAAL STATION and MONTANA direction HELDEN\", \"fr\": \"Obstacle sur la route: B41 d\u00e9vi\u00e9 entre BOONDAEL GARE et MONTANA direction HEROS\", \"nl\": \"Hindernis op de weg: B41 omgeleid tussen BOONDAAL STATION en MONTANA richting HELDEN\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"41\"}]",
+        "priority": 2,
+        "points": "[{\"id\": \"5451\"}, {\"id\": \"4452\"}, {\"id\": \"4454\"}, {\"id\": \"2107\"}, {\"id\": \"2018\"}, {\"id\": \"1754\"}, {\"id\": \"1753\"}, {\"id\": \"2016\"}, {\"id\": \"1752\"}, {\"id\": \"2762\"}, {\"id\": \"2079\"}, {\"id\": \"4455\"}, {\"id\": \"4456\"}, {\"id\": \"6468\"}, {\"id\": \"5458\"}, {\"id\": \"4358\"}, {\"id\": \"5459\"}, {\"id\": \"6439\"}, {\"id\": \"4449\"}, {\"id\": \"1725\"}, {\"id\": \"4407\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Obstacle on the road: B41 diverted between BOONDAAL STATION and MONTANA direction HELDEN\", \"fr\": \"Obstacle sur la route: B41 d\u00e9vi\u00e9 entre BOONDAEL GARE et MONTANA direction HEROS\", \"nl\": \"Hindernis op de weg: B41 omgeleid tussen BOONDAAL STATION en MONTANA richting HELDEN\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"41\"}]",
+        "priority": 2,
+        "points": "[{\"id\": \"1943\"}, {\"id\": \"4076\"}, {\"id\": \"1969\"}, {\"id\": \"1968\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Mar 4, works. Bus 43 and N11 diverted. Take the bus at HOMBORCH (via B43 from this stop on weekdays or B37).\", \"fr\": \"D\u00e8s le 4/3, travaux. Bus 43 et N11 d\u00e9vi\u00e9s. Prenez le bus \u00e0 HOMBORCH (via B43 depuis cet arr\u00eat en semaine ou B37).\", \"nl\": \"Vanaf 4/3, werken. Bus 43 en N11 omgeleid. Neem de bus aan HOMBORCH (via B43 vanaf deze halte op weekdagen of B37).\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"43\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"1955\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Mar 4, works. Bus 43 diverted. Take the bus at HOMBORCH (via B43 from this stop on weekdays before 8PM).\", \"fr\": \"D\u00e8s le 4/3, travaux. Bus 43 d\u00e9vi\u00e9. Prenez le bus \u00e0 HOMBORCH (via B43 depuis cet arr\u00eat en semaine avant 20h).\", \"nl\": \"Vanaf 4/3, werken. Bus 43 omgeleid. Neem de bus aan HOMBORCH (via B43 vanaf deze halte op weekdagen voor 20u).\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"43\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"1944\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Mar 4, works. Bus 43 and N11 diverted. Take the bus at HOMBORCH (via B43 from this stop on weekdays or B37).\", \"fr\": \"D\u00e8s le 4/3, travaux. Bus 43 et N11 d\u00e9vi\u00e9s. Prenez le bus \u00e0 HOMBORCH (via B43 depuis cet arr\u00eat en semaine ou B37).\", \"nl\": \"Vanaf 4/3, werken. Bus 43 en N11 omgeleid. Neem de bus aan HOMBORCH (via B43 vanaf deze halte op weekdagen of B37).\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"43\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"1936\"}, {\"id\": \"1935\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Mar 4, works. Bus 43 diverted between CABRIS / GEITJES and GRIOTTES / NOORDKRIEKEN.\", \"fr\": \"D\u00e8s le 4/3, travaux. Bus 43 d\u00e9vi\u00e9 entre CABRIS et GRIOTTES.\", \"nl\": \"Vanaf 4/3, werken. Bus 43 omgeleid tussen GEITJES en NOORDKRIEKEN.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"43\"}]",
+        "priority": 5,
+        "points": "[{\"id\": \"2144\"}, {\"id\": \"2142\"}, {\"id\": \"2140\"}, {\"id\": \"2161\"}, {\"id\": \"2109B\"}, {\"id\": \"1953\"}, {\"id\": \"2143B\"}, {\"id\": \"2168\"}, {\"id\": \"2157\"}, {\"id\": \"2146\"}, {\"id\": \"2147B\"}, {\"id\": \"2156\"}, {\"id\": \"2167\"}, {\"id\": \"2145\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Mar 4, works. Bus 43 and N11 diverted. Take the bus at HOMBORCH (via B43 at stop B43 VIVIER D'OIE or B37).\", \"fr\": \"D\u00e8s le 4/3, travaux. Bus 43 et N11 d\u00e9vi\u00e9s. Prenez le bus \u00e0 HOMBORCH (via B43 \u00e0 l'arr\u00eat du B43 VIVIER D'OIE ou B37).\", \"nl\": \"Vanaf 4/3, werken. Bus 43 en N11 omgeleid. Neem de bus aan HOMBORCH (via B43 aan halte B43 DIESDELLE of B37).\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"43\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"1954\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Mar 4, works. Bus 43 diverted between GRIOTTES and HOMBORCH. B43 HOMBORCH extended to BRAVES.\", \"fr\": \"D\u00e8s le 4/3, travaux. Bus 43 d\u00e9vi\u00e9 entre GRIOTTES et HOMBORCH. B43 barr\u00e9 HOMBORCH prolong\u00e9 jusqu'\u00e0 BRAVES.\", \"nl\": \"Vanaf 4/3, werken. Bus 43 omgeleid tussen NOORDKRIEKEN en HOMBORCH. B43 HOMBORCH rijdt tot DAPPEREN.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"43\"}]",
+        "priority": 5,
+        "points": "[{\"id\": \"2165\"}, {\"id\": \"1250\"}, {\"id\": \"1921\"}, {\"id\": \"1932\"}, {\"id\": \"1931\"}, {\"id\": \"1942\"}, {\"id\": \"5817\"}, {\"id\": \"1984B\"}, {\"id\": \"2355\"}, {\"id\": \"4854C\"}, {\"id\": \"1929\"}, {\"id\": \"1926B\"}, {\"id\": \"1937\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Until end of August, works. Stop not served. Take bus 46 at the next stop, PORTE D'ANDERLECHT\", \"fr\": \"Jusque fin ao\u00fbt, travaux. Arr\u00eat non desservi. Prenez le bus 46 \u00e0 l'arr\u00eat suivant, PORTE D'ANDERLECHT.\", \"nl\": \"Tot einde augustus, werken. Halte niet bediend. Neem bus 46 aan de volgende halte, ANDERLECHTSEPOORT.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"46\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"2213\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"As of Sep 13 at 6AM, works. Stop moved to rue de Laeken / Lakensestraat, next to numbers 57-59.\", \"fr\": \"D\u00e8s le 13/9 \u00e0 6h, travaux. Arr\u00eat d\u00e9plac\u00e9 rue de Laeken, \u00e0 hauteur des num\u00e9ros 57-59.\", \"nl\": \"Vanaf 13/9 om 6u, werken. Halte verplaatst naar de Lakensestraat, ter hoogte van huisnummer 57-59.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"46\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"3465\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. Until end of August, bus 46 not operated btw WTC-GLIBERT and CENTRAL STATION. Walk to WTC-GLIBERT\", \"fr\": \"Travaux. Jsq fin ao\u00fbt, bus 46 ne circule pas entre WTC-GLIBERT et GARE CENTRALE. Allez \u00e0 pied \u00e0 WTC-GLIBERT\", \"nl\": \"Werken. Tot einde augustus rijdt bus 46 niet tss WTC- GLIBERT en CENTRAAL STATION. Ga te voet naar WTC-GLIBERT.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"46\"}]",
+        "priority": 5,
+        "points": "[{\"id\": \"2269\"}, {\"id\": \"2587\"}, {\"id\": \"3075\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Until end August 2024, works. B46 diverted to ANNEESSENS. Stops between BUANDERIE and WTC-GLIBERT not served.\", \"fr\": \"Jsq fin ao\u00fbt 2024, travaux. Bus 46 d\u00e9vi\u00e9 vers ANNEESSENS. Arr\u00eats entre BUANDERIE et WTC- GLIBERT non desservis.\", \"nl\": \"Tot einde augustus 2024, werken. Bus 46 omgeleid naar ANNEESSENS. Haltes tussen WASHUIS en WTC-GLIBERT niet bediend\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"46\"}]",
+        "priority": 5,
+        "points": "[{\"id\": \"2405\"}, {\"id\": \"2259\"}, {\"id\": \"2264\"}, {\"id\": \"2262\"}, {\"id\": \"2261\"}, {\"id\": \"2260\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. STOP NOT SERVED. Bus 47-56 at the stop VERGER (avenue des Croix de Guerre)\", \"fr\": \"Travaux. ARRET NON DESSERVI. Bus 47-56 \u00e0 l'arr\u00eat VERGER (avenue des Croix de Guerre)\", \"nl\": \"Werken. HALTE NIET BEDIEND. Bus 47-56 aan de halte BOOMGAARD (Oorlogskruisenlaan)\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"47\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"1974\"}, {\"id\": \"1967\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Until Summer of 2024, works. Stop of bus 47 and 56: avenue des Croix de Guerre / Oorlogskruisenlaan 78.\", \"fr\": \"Jusqu'\u00e0 l'\u00e9t\u00e9 2024, travaux. Arr\u00eat des bus 47 et 56 : avenue des Croix de Guerre 78.\", \"nl\": \"Tot zomer 2024, werken. Halte van bus 47 en 56: Oorlogskruisenlaan 78.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"47\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"2299\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Until Summer of 2024, works. Stop not served. Take bus 47 at the stop of bus 56 to SCHUMAN.\", \"fr\": \"Jusqu'\u00e0 l'\u00e9t\u00e9 2024, travaux. Arr\u00eat non desservi. Prenez le bus 47 \u00e0 l'arr\u00eat du bus 56 vers SCHUMAN.\", \"nl\": \"Tot zomer 2024, werken. Halte niet bediend. Neem bus 47 aan de halte van bus 56 naar SCHUMAN.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"47\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"2317\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Until Summer of 2024, works. Stop not served. Take bus 47 at ANTOON VAN OSS (stop of bus 56 to SCHUMAN).\", \"fr\": \"Jsq \u00e9t\u00e9 2024, travaux. Arr\u00eat non desservi. Prenez le bus 47 \u00e0 ANTOON VAN OSS (arr\u00eat du bus 56 vers SCHUMAN).\", \"nl\": \"Tot zomer 2024, werken. Halte niet bediend. Neem bus 47 aan ANTOON VAN OSS (halte van bus 56 naar SCHUMAN).\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"47\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"2316\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Feb 6, works. STOP NOT SERVED. Temporary stop: Vlierkensstraat 94.\", \"fr\": \"D\u00e8s le 6/2, travaux. ARRET NON DESSERVI. Arr\u00eat provisoire: Vlierkensstraat 94.\", \"nl\": \"Vanaf 6/2, werken. HALTE NIET BEDIEND. Tijdelijke halte: Vlierkensstraat 94.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"47\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"2841\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Until Summer of 2024, works. Stop not served. Take bus 47 at ANTOON VAN OSS (stop of bus 56 to BUDA).\", \"fr\": \"Jsq \u00e9t\u00e9 2024, travaux. Arr\u00eat non desservi. Prenez le bus 47 \u00e0 ANTOON VAN OSS (arr\u00eat du bus 56 vers BUDA).\", \"nl\": \"Tot zomer 2024, werken. Halte niet bediend. Neem bus 47 aan ANTOON VAN OSS (halte van bus 56 naar BUDA).\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"47\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"2359\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Until Summer of 2024, works. Stop not served. Stop of bus 47: av. Marlylaan, next to Verano.\", \"fr\": \"Jusqu'\u00e0 l'\u00e9t\u00e9 2024, travaux. Arr\u00eat non desservi. Arr\u00eat du bus 47: avenue du Marly, pr\u00e8s de Verano.\", \"nl\": \"Tot zomer 2024, werken. Halte niet bediend. Halte van bus 47: Marlylaan, naast Verano.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"47\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"2315\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Until Summer of 2024, works. Bus 47 diverted from RAMIER / BOSDUIF to DOCKS BRUXSEL via avenue des Croix de Guerre\", \"fr\": \"Jsq \u00e9t\u00e9 2024, travaux. Bus 47 d\u00e9vi\u00e9 depuis RAMIER vers DOCKS BRUXSEL via avenue des Croix de Guerre.\", \"nl\": \"Tot zomer 2024, werken. Bus 47 omgeleid vanaf BOSDUIF naar DOCKS BRUXSEL via Oorlogskruisenlaan.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"47\"}]",
+        "priority": 5,
+        "points": "[{\"id\": \"2361\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. As of Apr 17 at 7AM, stop moved to av. R. M.-Henriette / K. M. -Hendrikalaan, in front of the stop to Decroly.\", \"fr\": \"Travaux. D\u00e8s le 17/4 \u00e0 7h, arr\u00eat d\u00e9plac\u00e9 avenue Reine Marie-Henriette, en face de l'arr\u00eat vers Decroly.\", \"nl\": \"Werken. Vanaf 17/4 om 7u, halte verplaatst naar de Koningin Maria- Hendrikalaan, tegenover de halte naar Decroly.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"48\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"2460\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"End of the works. As of Monday Apr 15, stop served by bus 49 to SIMONIS. Bus 90 withdrawn.\", \"fr\": \"Fin des travaux. D\u00e8s le lundi 15/4, arr\u00eat desservi par les bus 49 vers SIMONIS. Bus 90 supprim\u00e9\", \"nl\": \"Einde van de werken. Vanaf maandag 15/4 wordt deze halte bediend door bus 49 naar SIMONIS. Bus 90 geschrapt.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"49\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"1257\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"End of the works. As of Monday Apr 15, bus 49 operates normally btw PRINCE DE LIEGE / PRINS VAN LUIK and MEIR.\", \"fr\": \"Fin des travaux. D\u00e8s le lundi 15/4, bus 49 circule \u00e0 nouveau normalement entre PRINCE DE LIEGE et MEIR.\", \"nl\": \"Einde van de werken. Vanaf maandag 15/4 rijdt bus 49 opnieuw normaal tussen PRINS VAN LUIK en MEIR.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"49\"}]",
+        "priority": 5,
+        "points": "[{\"id\": \"3638\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Until 2026, works. Bus 50 diverted between BEMPT and FOREST CENTRE/VORST CENTRUM.\", \"fr\": \"Jusqu'en 2026, travaux. Bus 50 d\u00e9vi\u00e9 entre BEMPT et FOREST CENTRE.\", \"nl\": \"Tot 2026, werken. Bus 50 omgeleid tussen BEMPT en VORST CENTRUM.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"50\"}]",
+        "priority": 5,
+        "points": "[{\"id\": \"9685\"}, {\"id\": \"9683\"}, {\"id\": \"9678\"}, {\"id\": \"9679\"}, {\"id\": \"9677\"}, {\"id\": \"2661\"}, {\"id\": \"9658\"}, {\"id\": \"2662B\"}, {\"id\": \"9659\"}, {\"id\": \"9682\"}, {\"id\": \"2659\"}, {\"id\": \"9680\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From May 2 at 5AM, works. STOP NOT SERVED. Temporary stop: Karel Gilsonstraat, 2.\", \"fr\": \"D\u00e8s le 2/5 \u00e0 5h,travaux. ARRET NON DESSERVI. Arr\u00eat provisoire: Karel Gilsonstraat, 2.\", \"nl\": \"Vanaf 2/5 om 5u, werken. HALTE NIET BEDIEND. Tijdelijke halte: Karel Gilsonstraat, 2.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"50\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"9651\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. Until 2026, stop not served. Stop of T-bus 82 and of bus 50: rue de la Soierie / Zijdeweverijstraat 9.\", \"fr\": \"Travaux. Jusqu'en 2026, arr\u00eat non desservi. Arr\u00eat du T-bus 82 et du bus 50 : rue de la Soierie 9.\", \"nl\": \"Werken. Tot 2026, halte niet bediend. Halte van T-bus 82 en van bus 50: Zijdeweverijstraat 9.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"50\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"3603\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Until 2026, works. Stop not served. Stop of bus 50: rue de la Soierie / Zijdeweverijstraat 4.\", \"fr\": \"Jusqu'en 2026, travaux. Arr\u00eat non desservi. Arr\u00eat du bus 50: rue de la Soierie 4.\", \"nl\": \"Tot 2026, werken. Halte niet bediend. Halte van bus 50: Zijdeweverijstraat 4.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"50\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"3602\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Until 2026, works. Bus 50 diverted. Stop of bus 50: rue des Abbesses / Abdissenstraat, in front of number 1.\", \"fr\": \"Jusqu'en 2026, travaux. Bus 50 d\u00e9vi\u00e9. Arr\u00eat du bus 50: rue des Abbesses, en face du num\u00e9ro 1.\", \"nl\": \"Tot 2026, werken. Bus 50 omgeleid. Halte van bus 50: Abdissenstraat, tegenover nummer 1.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"50\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"5161\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. As of Apr 15 at 6AM, bus 53 diverted between PETER BENOIT and BEYSEGHEM / BEIZEGEM.\", \"fr\": \"Travaux. D\u00e8s le 15/4 \u00e0 6h, bus 53 d\u00e9vi\u00e9 entre PETER BENOIT et BEYSEGHEM.\", \"nl\": \"Werken. Vanaf 15/4 om 6u, bus 53 omgeleid tussen PETER BENOIT en BEIZEGEM.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"53\"}]",
+        "priority": 5,
+        "points": "[{\"id\": \"2823B\"}, {\"id\": \"2766\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Until Summer of 2024, works. Bus 53 diverted. Stop of bus 53: rue Bruynstraat, after the military area.\", \"fr\": \"Jsq \u00e9t\u00e9 2024, travaux. Bus 53 d\u00e9vi\u00e9. Arr\u00eat du bus 53 : rue Bruyn, apr\u00e8s le domaine militaire.\", \"nl\": \"Tot zomer 2024, werken. Bus 53 omgeleid. Halte van bus 53: Bruynstraat, na het militair domein.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"53\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"2352\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. As of Apr 15 at 6AM, bus 53 diverted between PETER BENOIT and BEYSEGHEM / BEIZEGEM.\", \"fr\": \"Travaux. D\u00e8s le 15/4 \u00e0 6h, bus 53 d\u00e9vi\u00e9 entre PETER BENOIT et BEYSEGHEM.\", \"nl\": \"Werken. Vanaf 15/4 om 6u, bus 53 omgeleid tussen PETER BENOIT en BEIZEGEM.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"53\"}]",
+        "priority": 5,
+        "points": "[{\"id\": \"3001B\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Apr 2, 2024 to June 2025, works. STOP NOT SERVED. Stop of bus 54: FOREST NATIONAL (av. du Globelaan 8).\", \"fr\": \"Du 2/4/2024 \u00e0 juin 2025, travaux. ARRET NON DESSERVI. Arr\u00eat des bus 54: FOREST NATIONAL. (avenue du Globe 8).\", \"nl\": \"Van 2/4/2024 tot juni 2025, werken. HALTE NIET BEDIEND. Halte van bus 54: VORST NATIONAAL (Globelaan 8)\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"54\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"2939B\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Apr 2, 2024-June 2025, works. Bus 54 diverted btw FOREST NATIONAL and FOREST CENTRE. Info: stib-mivb.brussels\", \"fr\": \"Du 2/4/2024 \u00e0 juin 2025, travaux. Bus 54 d\u00e9vi\u00e9 entre FOREST NATIONAL et FOREST CENTRE. Info: stib.brussels.\", \"nl\": \"2/4/2024-juni 2025, werken. Bus 54 omgeleid tussen VORST NATIONAAL en VORST CENTRUM. Info: mivb.brussels\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"54\"}]",
+        "priority": 5,
+        "points": "[{\"id\": \"2934A\"}, {\"id\": \"1780\"}, {\"id\": \"2937B\"}, {\"id\": \"1734\"}, {\"id\": \"2932\"}, {\"id\": \"2931\"}, {\"id\": \"2972\"}, {\"id\": \"2950\"}, {\"id\": \"2411B\"}, {\"id\": \"2929\"}, {\"id\": \"2928\"}, {\"id\": \"2936\"}, {\"id\": \"2935\"}, {\"id\": \"3518B\"}, {\"id\": \"3506\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Until Summer of 2024, works. Stop of bus 47 and 56: av. Croix de Guerre, at the other side of Delhaize.\", \"fr\": \"Jusqu'\u00e0 l'\u00e9t\u00e9 2024, travaux. Arr\u00eat des bus 47 et 56 : avenue des Croix de Guerre, de l'autre c\u00f4t\u00e9 du Delhaize\", \"nl\": \"Tot zomer 2024, werken. Halte van bus 47 en 56: Oorlogskruisenlaan, aan de andere kant van de Delhaize.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"56\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"1974\"}, {\"id\": \"1967\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Until Summer of 2024, works. Stop not served. Stop of bus 56: place Peter Benoitplein 3\", \"fr\": \"Jusqu'\u00e0 l'\u00e9t\u00e9 2024, travaux. Arr\u00eat non desservi. Arr\u00eat du bus 56 : place Peter Benoit 3\", \"nl\": \"Tot zomer 2024, werken. Halte niet bediend. Halte van bus 56: Peter Benoitplein 3\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"56\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"1987\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Until Summer of 2024, works. Bus 56 diverted between VAN PRAET and PETER BENOIT via avenue des Croix de Guerre.\", \"fr\": \"Jusqu'\u00e0 l'\u00e9t\u00e9 2024, travaux. Bus 56 d\u00e9vi\u00e9 entre VAN PRAET et PETER BENOIT via avenue des Croix de Guerre.\", \"nl\": \"Tot zomer 2024, werken. Bus 56 omgeleid tussen VAN PRAET en PETER BENOIT via Oorlogskruisenlaan.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"56\"}]",
+        "priority": 5,
+        "points": "[{\"id\": \"2098\"}, {\"id\": \"3451\"}, {\"id\": \"6190\"}, {\"id\": \"9296\"}, {\"id\": \"2051\"}, {\"id\": \"6082\"}, {\"id\": \"2898\"}, {\"id\": \"2106\"}, {\"id\": \"1006\"}, {\"id\": \"2367\"}, {\"id\": \"3412\"}, {\"id\": \"2101\"}, {\"id\": \"6459\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. As of Apr 15, bus 56 diverted. Take bus 56 at the stop of bus 64 to BORDET STATION.\", \"fr\": \"Travaux. D\u00e8s le 15/4, bus 56 d\u00e9vi\u00e9. Prenez le bus 56 \u00e0 l'arr\u00eat du bus 64 vers BORDET STATION.\", \"nl\": \"Werken. Vanaf 15/4, bus 56 omgeleid. Neem bus 56 aan de halte van bus 64 naar BORDET STATION.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"56\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"2068\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Until Summer of 2024, works. As of March 18, buses 56 and 57 serve this stop normally.\", \"fr\": \"Jusqu'\u00e0 l'\u00e9t\u00e9 2024, travaux. D\u00e8s le 18/3, les bus 56 et 57 desservent \u00e0 nouveau cet arr\u00eat.\", \"nl\": \"Tot zomer 2024, werken. Vanaf 18/3 bedienen bus 56 en 57 opnieuw deze halte.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"56\"}]",
+        "priority": 5,
+        "points": "[{\"id\": \"2829B\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Until Summer of 2024, works. Stop not served. Stop of bus 57: MARLY (moved to ch. Vilvorde, next to number 150)\", \"fr\": \"Jsq \u00e9t\u00e9 2024, travaux. Arr\u00eat non desservi.Arr\u00eat du bus 57: MARLY (d\u00e9plac\u00e9 ch. Vilvorde, en face du num\u00e9ro 150)\", \"nl\": \"Tot zomer 2024, werken. Halte niet bediend. Halte van bus 57:MARLY (verplaatst Vilvoordsest tegenover nr. 150)\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"57\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"2315\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Until Summer of 2024, works. Stop not served. Take bus 57 at ANTOON VAN OSS (stop of bus 56 to SCHUMAN).\", \"fr\": \"Jsq \u00e9t\u00e9 2024, travaux. Arr\u00eat non desservi. Prenez le bus 57 \u00e0 ANTOON VAN OSS (arr\u00eat du bus 56 vers SCHUMAN).\", \"nl\": \"Tot zomer 2024, werken. Halte niet bediend. Neem bus 57 aan ANTOON VAN OSS (halte van bus 56 naar SCHUMAN).\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"57\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"2316\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Until Summer of 2024, works. Stop not served. Take bus 57 at ANTOON VAN OSS (stop of bus 56 to BUDA).\", \"fr\": \"Jsq \u00e9t\u00e9 2024, travaux. Arr\u00eat non desservi. Prenez le bus 57 \u00e0 ANTOON VAN OSS (arr\u00eat du bus 56 vers BUDA).\", \"nl\": \"Tot zomer 2024, werken. Halte niet bediend. Neem bus 57 aan ANTOON VAN OSS (halte van bus 56 naar BUDA).\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"57\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"2359\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Until Summer of 2024, works. Stop not served. Stop of bus 57: chauss\u00e9e de Vilvorde, next to ropery Barrois\", \"fr\": \"Jsq \u00e9t\u00e9 2024, travaux. Arr\u00eat non desservi. Arr\u00eat du bus 57: ch\u00e9e de Vilvorde, le long de la corderie Barrois\", \"nl\": \"Tot zomer 2024, werken. Halte niet bediend. Halte B57: Vilvoordsestwg, naast de touwslagerij Barrois\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"57\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"3003\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Until Summer of 2024, works. Stop not served. Take bus 47 or 57 at ANTOON VAN OSS (stop of bus 56 to BUDA).\", \"fr\": \"Jsq \u00e9t\u00e9 2024, travaux. Arr\u00eat non desservi. Prenez le bus 47 ou 57 \u00e0 ANTOON VAN OSS (arr\u00eat du bus 56 vers BUDA).\", \"nl\": \"Tot zomer 2024, werken. Halte niet bediend. Neem bus 47 of 57 aan ANTOON VAN OSS (halte van bus 56 naar BUDA).\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"57\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"1837\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Until Summer 2024,works. B57 divtd btw MARLY and ANT VAN OSS. As of Oct 16, B57 divtd btw MARLY and HOP. MILITAIRE\", \"fr\": \"Jsq \u00e9t\u00e9 2024, travaux. Bus 57 d\u00e9vi\u00e9 entre MARLY et ANT VAN OSS. D\u00e8s le 16/10, B57 d\u00e9vi\u00e9 entre MARLY et HOP MILITAIRE.\", \"nl\": \"Tot zomer 2024, werken. Bus 57 omgeleid ts MARLY en ANT VAN OSS. Vanaf 16/10, B57 omgeleid tss MARLY en MILITAIR HOSP.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"57\"}]",
+        "priority": 5,
+        "points": "[{\"id\": \"1090\"}, {\"id\": \"2327\"}, {\"id\": \"2305\"}, {\"id\": \"2326\"}, {\"id\": \"1356\"}, {\"id\": \"3058\"}, {\"id\": \"1052\"}, {\"id\": \"1051\"}, {\"id\": \"2308\"}, {\"id\": \"2868\"}, {\"id\": \"3061\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. As of Apr 24 at 6.30AM, STOP NOT SERVED. Stop of bus 59: COTEAUX (rue des Coteaux, 213).\", \"fr\": \"Travaux. D\u00e8s le 24/4 \u00e0 6h30, ARRET NON DESSERVI. Arr\u00eat du bus 59: COTEAUX (rue des Coteaux, 213).\", \"nl\": \"Werken. Vanaf 24/4 om 6. 30u, HALTE NIET BEDIEND. Halte van bus 59: WIJNHEUVELEN (Wijnheuvelenstr. 213).\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"59\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"3113\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Feb 8, works. STOP NOT SERVED. Temporary stop: Place de Houffalizeplein 2-6.\", \"fr\": \"D\u00e8s le 8/2, travaux. ARRET NON DESSERVI. Arr\u00eat provisoire: Place de Houffalize 2-6.\", \"nl\": \"Vanaf 8/2, werken. HALTE NIET BEDIEND. Tijdelijke halte: Houffalizeplein 2-6.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"59\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"3110\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Mar 11, works. Bus 60 diverted. Temporary stop: chauss\u00e9e de Saint- Job/Sint-Jobsesteenweg, in front of nr. 390.\", \"fr\": \"D\u00e8s le 11/3, travaux. Bus 60 d\u00e9vi\u00e9. Arr\u00eat provisoire: chauss\u00e9e de Saint-Job, face au num\u00e9ro 390.\", \"nl\": \"Vanaf 11/3, werken. Bus 60 omgeleid. Tijdelijke halte: Sint-Jobsesteenweg, tegenover nr. 390.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"60\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"1738\"}, {\"id\": \"2705\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Mar 11, works. Bus 60 diverted. Temporary stop: chauss\u00e9e de Saint- Job/Sint-Jobsesteenweg 265.\", \"fr\": \"D\u00e8s le 11/3, travaux. Bus 60 d\u00e9vi\u00e9. Arr\u00eat provisoire: chauss\u00e9e de Saint-Job 265.\", \"nl\": \"Vanaf 11/3, werken. Bus 60 omgeleid. Tijdelijke halte: Sint-Jobsesteenweg 265.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"60\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"2704\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. As of Apr 15, STOP NOT SERVED. Walk to AMBIORIX.\", \"fr\": \"Travaux. D\u00e8s le 15/4, ARRET NON DESSERVI. Pour rejoindre AMBIORIX, continuez \u00e0 pied.\", \"nl\": \"Werken. Vanaf 15/4, HALTE NIET BEDIEND. Ga te voet verder om naar AMBIORIX te gaan.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"60\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"1418B\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. As of April 7th, stop served only by bus 66. Take bus 29, 63 or 65 at the stop of bus 71 to DELTA.\", \"fr\": \"Travaux. D\u00e8s le 7/4, arr\u00eat uniquement desservi par bus 66. Bus 29, 63 ou 65 \u00e0 l'arr\u00eat du bus 71 vers DELTA.\", \"nl\": \"Werken. Vanaf 7/4, halte enkel bediend door bus 66. Neem bus 29, 63 of 65 aan de halte van bus 71 naar DELTA.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"63\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"6445\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Risk of subsidence. Stop of bus 65, 66 and N04 moved to chauss\u00e9e de Haecht/Haachtsesteenweg, next to number 162\", \"fr\": \"Risque d'effondrement. Arr\u00eat des bus 65, 66 et N04 d\u00e9plac\u00e9 chauss\u00e9e de Haecht, \u00e0 hauteur du num\u00e9ro 162.\", \"nl\": \"Risico op instorting. Halte van bus 65, 66 en N04 verplaatst naar de Haachtsesteenweg, ter hoogte van nummer 162.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"65\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"6418\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Jan 7, 9PM-Jun 28, works. Stop not served. To continue to HEYSEL / HEIZEL, take tram 3 direction CHURCHILL.\", \"fr\": \"7/1, 21h-28/6, travaux. Arr\u00eat non desservi. Pour continuer vers HEYSEL, prenez le tram 3 direction CHURCHILL.\", \"nl\": \"7/1, 21u-28/6, werken. Halte niet bediend. Om naar HEIZEL te reizen, neem tram 3 richting CHURCHILL.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"7\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"6421F\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Jan 7, 9PM-Jun 28,works. Tram 3 and 7 replaced by T-bus to DOCKS BRUXSEL. T-bus at this stop.\", \"fr\": \"7/1, 21h-28/6, travaux. Tram 3 et 7 remplac\u00e9s par des T-bus jusqu'\u00e0 DOCKS BRUXSEL. T-bus \u00e0 cet arr\u00eat.\", \"nl\": \"7/1, 21u-28/6, werken. Tram 3 en 7 vervangen door T-bus tot DOCKS BRUXSEL. T-bus aan deze halte.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"7\"}]",
+        "priority": 5,
+        "points": "[{\"id\": \"5707\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Jan 8-Jun 28, works. Tram 7 interrupted btw HEEMBEEK and DOCKS BXL. T-bus to DOCKS BXL at stop of B83 to VAL MARIA\", \"fr\": \"8/1-28/6, travaux. T7 interrompu de HEEMBEEK \u00e0 DOCKS BXL. T-bus vers DOCKS BXL \u00e0 l'arr\u00eat du B83 vers VAL MARIA.\", \"nl\": \"8/1-28/6, werken. T7 onderbroken tss HEEMBEEK en DOCKS BRUXSEL. T-bus naar DOCKS BRUXSEL aan halte B83 naar MARI\u00cbND.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"7\"}]",
+        "priority": 5,
+        "points": "[{\"id\": \"5700G\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Mar 18, works. STOP NOT SERVED. Temporary stop: avenue de la Couronne / Kroonlaan 439-443.\", \"fr\": \"D\u00e8s le 18/3, travaux. ARRET NON DESSERVI. Arr\u00eat provisoire: avenue de la Couronne 439-443.\", \"nl\": \"Vanaf 18/3, werken. HALTE NIET BEDIEND. Tijdelijke halte: Kroonlaan 439-443.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"71\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"3558\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. As of April 7th, STOP NOT SERVED. To go to DE BROUCKERE, take metro lines 1 or 5.\", \"fr\": \"Travaux. D\u00e8s le 7/4, ARRET NON DESSERVI. Pour rejoindre DE BROUCKERE, prenez le m\u00e9tro 1 ou 5.\", \"nl\": \"Werken. Vanaf 7/4, HALTE NIET BEDIEND. Om naar DE BROUCKERE te gaan, neem metrolijn 1 of 5.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"71\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"6447\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Mar 18, works. STOP NOT SERVED. stop of bus 72: avenue de l'Universit\u00e9 / Hogeschoollaan 4-10.\", \"fr\": \"D\u00e8s le 18/3, travaux. ARRET NON DESSERVI. Arr\u00eat du bus 72: avenue de l'Universit\u00e9 4-10.\", \"nl\": \"Vanaf 18/3, werken. HALTE NIET BEDIEND. Halte van bus 72: Hogeschoollaan 4-10.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"72\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"3514\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Apr 2, 2024 to June 2025, works. STOP NOT SERVED. Stop of bus 74: chauss\u00e9e de Bruxelles / Brusselsesteenweg 84.\", \"fr\": \"Du 2/4/2024 \u00e0 juin 2025, travaux. ARRET NON DESSERVI. Arr\u00eat du bus 74: chauss\u00e9e de Bruxelles 84.\", \"nl\": \"Van 2/4/2024 tot juni 2025, werken. HALTE NIET BEDIEND. Halte van bus 74: Brusselsesteenweg 84.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"74\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"5152\"}, {\"id\": \"5161\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Apr 20, works. Stop not served. Take B74 next to number 26 (100m before this stop).\", \"fr\": \"D\u00e8s le 20/4, travaux. Arr\u00eat non desservi. Arr\u00eat du B74 \u00e0  hauteur du num\u00e9ro 26 (100 m avant cet arr\u00eat).\", \"nl\": \"Vanaf 20/4, werken. Halte niet bediend. Neem B74 ter hoogte van nummer 26 (100m voor deze halte).\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"74\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"2225\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Apr 2, 2024-June 2025, works. Bus 74 diverted btw FOREST CENTRE and FOREST NATIONAL. Info: stib-mivb.brussels.\", \"fr\": \"Du 2/4/2024 \u00e0 juin 2025, travaux. Bus 74 d\u00e9vi\u00e9 entre FOREST CENTRE et FOREST NATIONAL. Info: stib.brussels.\", \"nl\": \"2/4/2024-juni 2025, werken. Bus 74 omgeleid tussen VORST CENTRUM en VORST NATIONAAL. Info: mivb.brussels.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"74\"}]",
+        "priority": 5,
+        "points": "[{\"id\": \"2631\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Mar 18, works. STOP NOT SERVED. Take the bus at the next stop, VICTOR ALLARD.\", \"fr\": \"D\u00e8s le 18/3, travaux. ARRET NON DESSERVI. Prenez le bus \u00e0 l'arr\u00eat suivant, VICTOR ALLARD.\", \"nl\": \"Vanaf 18/3, werken. HALTE NIET BEDIEND. Neem de bus aan de volgende halte, VICTOR ALLARD.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"74\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"2417\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"T81-T97 operate normally againBAREEL and JANSON\", \"fr\": \"T81-T97 circulent \u00e0 nouveau entre BARRIERE et JANSON\", \"nl\": \"T81-T97 worden weer bediend tussen BAREEL en JANSON\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"81\"}]",
+        "priority": 3,
+        "points": "[{\"id\": \"6099\"}, {\"id\": \"6121F\"}, {\"id\": \"3611F\"}, {\"id\": \"6113F\"}, {\"id\": \"3613F\"}, {\"id\": \"3123\"}, {\"id\": \"6858G\"}, {\"id\": \"6705F\"}, {\"id\": \"2260F\"}, {\"id\": \"1805F\"}, {\"id\": \"6799F\"}, {\"id\": \"6860G\"}, {\"id\": \"6106\"}, {\"id\": \"6008\"}, {\"id\": \"6109\"}, {\"id\": \"2971F\"}, {\"id\": \"2331F\"}, {\"id\": \"6120\"}, {\"id\": \"6077F\"}, {\"id\": \"2539F\"}, {\"id\": \"3612F\"}, {\"id\": \"6114F\"}, {\"id\": \"3371F\"}, {\"id\": \"0631\"}, {\"id\": \"6427F\"}, {\"id\": \"6117\"}, {\"id\": \"2259F\"}, {\"id\": \"6856\"}, {\"id\": \"3508F\"}, {\"id\": \"2257G\"}, {\"id\": \"6857\"}, {\"id\": \"2960F\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"T81-T97 operate normally againBAREEL and JANSON\", \"fr\": \"T81-T97 circulent \u00e0 nouveau entre BARRIERE et JANSON\", \"nl\": \"T81-T97 worden weer bediend tussen BAREEL en JANSON\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"81\"}]",
+        "priority": 3,
+        "points": "[{\"id\": \"6462F\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. Until 2026, stop not served. Stop of T-bus 82 and of bus 50: rue de la Soierie / Zijdeweverijstraat 9.\", \"fr\": \"Travaux. Jusqu'en 2026, arr\u00eat non desservi. Arr\u00eat du T-bus 82 et du bus 50 : rue de la Soierie 9.\", \"nl\": \"Werken. Tot 2026, halte niet bediend. Halte van T-bus 82 en van bus 50: Zijdeweverijstraat 9.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"82\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"5156F\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Until 2026, works. Stop not served. Stop of the T-bus: rue de la Soierie / Zijdeweverijstraat 4.\", \"fr\": \"Jusqu'en 2026, travaux. Arr\u00eat non desservi. Arr\u00eat du T-bus: rue de la Soierie 4.\", \"nl\": \"Tot 2026, werken. Halte niet bediend. Halte van de T-bus: Zijdeweverijstraat 4.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"82\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"5154F\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. Until 2026, tram 82 replaced by T-bus between DROGENBOS and FOREST CENTRE / VORST CENTRUM.\", \"fr\": \"Travaux. Jusqu'en 2026, tram 82 remplac\u00e9 par des T-bus entre DROGENBOS et FOREST CENTRE. T-bus \u00e0 cet arr\u00eat.\", \"nl\": \"Werken. Tot 2026, tram 82 vervangen door T-bus tussen DROGENBOS en VORST CENTRUM. T-bus aan deze halte.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"82\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"5753F\"}, {\"id\": \"5751\"}, {\"id\": \"5754\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Until 2026, works. Tram 82 replaced by T-bus to FOREST CENTRE. T-bus at this stop.\", \"fr\": \"Jusqu'en 2026, travaux. Tram 82 remplac\u00e9 par des T-bus jusqu'\u00e0 FOREST CENTRE. T-bus \u00e0 cet arr\u00eat.\", \"nl\": \"Tot 2026, werken. Tram 82 vervangen door T-bus tot VORST CENTRUM. T-bus aan deze halte.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"82\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"5756F\"}, {\"id\": \"1258G\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Until 2026, works. Tram 82 interrupted. T-bus to DROGENBOS at the stop of bus 54 to TRONE/TROON.\", \"fr\": \"Jusqu'en 2026, travaux. Tram 82 interrompu. T-bus vers DROGENBOS \u00e0 l'arr\u00eat du bus 54 vers TRONE.\", \"nl\": \"Tot 2026, werken. Tram 82 onderbroken. T-bus naar DROGENBOS aan de halte van bus 54 naar TROON.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"82\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"5121F\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. Until 2026, tram 82 replaced by T-bus btw FOREST CENTRE / VORST CENTRUM and DROGENBOS. T-bus at this stop.\", \"fr\": \"Travaux. Jusqu'en 2026, tram 82 remplac\u00e9 par des T-bus entre FOREST CENTRE et DROGENBOS. T-bus \u00e0 cet arr\u00eat.\", \"nl\": \"Werken. Tot 2026, tram 82 vervangen door T-bus tussen VORST CENTRUM en DROGENBOS. T-bus aan deze halte.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"82\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"5722F\"}, {\"id\": \"5723G\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Until 2026, works. Tram 82 replaced by T-bus between FOREST CENTRE / VORST CENTRUM and DROGENBOS.\", \"fr\": \"Jusqu'en 2026, travaux. Tram 82 remplac\u00e9 par des T-bus entre FOREST CENTRE et DROGENBOS. Info: stib.brussels.\", \"nl\": \"Tot 2026, werken. Tram 82 vervangen door T-bus tussen VORST CENTRUM en DROGENBOS. Info: mivb. brussels.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"82\"}]",
+        "priority": 5,
+        "points": "[{\"id\": \"2603\"}, {\"id\": \"5718\"}, {\"id\": \"0631\"}, {\"id\": \"5120\"}, {\"id\": \"2539F\"}, {\"id\": \"5123\"}, {\"id\": \"2548F\"}, {\"id\": \"2604F\"}, {\"id\": \"2544F\"}, {\"id\": \"5119\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Until 2026, works. Tram 82 interrupted. Take tram 82 at the stop in the other direction.\", \"fr\": \"Jusqu'en 2026, travaux. Tram 82 interrompu. Prenez le tram 82 \u00e0 l'arr\u00eat dans l'autre sens.\", \"nl\": \"Tot 2026, werken. Tram 82 onderbroken. Neem tram 82 aan de halte in de andere richting.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"82\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"5161F\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Jan 22 at 6AM to end of June, works. Bus 86 diverted. Take the bus at the previous stop GARE DE L'OUEST.\", \"fr\": \"Du 22/1 \u00e0 6h jusqu'\u00e0 fin juin, travaux. Bus 86 d\u00e9vi\u00e9. Prenez le bus \u00e0 l'arr\u00eat pr\u00e9c\u00e9dent GARE DE  L'OUEST.\", \"nl\": \"Van 22/1 om 6u tot eind juni, werken. Bus 86 omgeleid. Neem de bus aan vorige halte WESTSTATION.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"86\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"3257\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Jan 22 at 6AM to end of June, works. Bus 86 diverted. B86 at the stop RIBAUCOURT of bus 20 to GARE DU NORD.\", \"fr\": \"Du 22/1 \u00e0 6h jusqu'\u00e0 fin juin, travaux. Bus 86 d\u00e9vi\u00e9. Bus 86 \u00e0 l'arr\u00eat RIBAUCOURT du bus 20 vers GARE DU NORD.\", \"nl\": \"Van 22/1 om 6u tot eind juni, werken. Bus 86 omgeleid. Bus 86 aan de halte RIBAUCOURT van bus 20 naar NOORDSTATION.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"86\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"4253\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Feb 2 7AM, works. STOP NOT SERVED. Temporary halte: Boulevard Emile Jacqmainlaan 82-94.\", \"fr\": \"D\u00e8s le 8/2 7h, travaux. ARRET NON DESSERVI. Arr\u00eat provisoire: Boulevard Emile Jacqmain 82-94.\", \"nl\": \"Vanaf 8/2 7u, werken. HALTE NIET BEDIEND. Tijdelijke halte: Emile Jacqmainlaan 82-94.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"88\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"2070\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. From Apr 23 until Jun 2, bus 13 and 88 diverted. Take bus 13 or 88 at the stop of bus 820 to UZ Brussel.\", \"fr\": \"Travaux; Du 23/4 au 2/6, bus 13 et 88 d\u00e9vi\u00e9s. Prenez le bus 13 ou 88 \u00e0 l'arr\u00eat du bus 820 vers UZ Brussel.\", \"nl\": \"Werken. Van 23/4 tot en met 2/6, bus 13 en 88 omgeleid. Neem bus 13 of 88 aan de halte van bus 820 naar UZ Brussel.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"88\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"1721\"}, {\"id\": \"1328\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. As of Apr 22 at 9.30AM, bus 89 diverted. Stop of bus 89: rue des Quatre-Vents / Vier Windenstraat 141\", \"fr\": \"Travaux. D\u00e8s le 22/4 \u00e0 9h30, bus 89 d\u00e9vi\u00e9. Arr\u00eat du bus 89: rue des Quatre-Vents, 141.\", \"nl\": \"Werken. Vanaf 22/4 om 9. 30u, bus 89 omgeleid. Halte van bus 89: Vier Windenstraat 141\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"89\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"4594\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Until end of August, works. Bus 89 diverted. For the city center, take metro 1 or 5 at COMTE DE FLANDRE.\", \"fr\": \"Jusque fin ao\u00fbt, travaux. Bus 89 d\u00e9vi\u00e9. Pour le centre-ville, prenez le m\u00e9tro 1 ou 5 \u00e0 COMTE DE FLANDRE.\", \"nl\": \"Tot einde augustus, werken. Bus 89 omgeleid. Om naar het stadscentrum te gaan, neem M 1 5 aan GRAAF VAN VLAANDEREN.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"89\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"3259C\"}, {\"id\": \"3260\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. As of Apr 22 at 9.30AM, bus 89 diverted. Stop of bus 89: rue Delaunoystraat 15.\", \"fr\": \"Travaux. D\u00e8s le 22/4 \u00e0 9h30, bus 89 d\u00e9vi\u00e9. Arr\u00eat du bus 89: rue Delaunoy, 15.\", \"nl\": \"Werken. Vanaf 22/4 om 9. 30u, bus 89 omgeleid. Halte van bus 89: Delaunoystraat 15.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"89\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"3228\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Until end of August, works. Bus 89 diverted. To continue to CENTRAL STATION, take bus 29 71\", \"fr\": \"Jusque fin ao\u00fbt, travaux. Bus 89 d\u00e9vi\u00e9. Pour continuer vers GARE CENTRALE, prenez le bus 29 ou 71.\", \"nl\": \"Tot einde augustus, werken. Bus 89 omgeleid. Om verder naar CENTRAAL STATION te reizen, neem bus 29 of 71.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"89\"}]",
+        "priority": 5,
+        "points": "[{\"id\": \"1820\"}, {\"id\": \"2296\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. From Apr 26 at 9PM until May 12, stop not served. T-bus to ROI BAUDOUIN at the stop of bus 13 to ETANGS NOIRS.\", \"fr\": \"Travaux. Du 26/4 \u00e0 21h au 12/5, arr\u00eat non desservi. T-bus vers ROI BAUDOUIN \u00e0 l'arr\u00eat du bus 13 vers ETANGS NOIRS\", \"nl\": \"Werken. 26/4, 21u-12/5, halte niet bediend.T-bus naar KONING BOUDEWIJN aan de halte van bus 13 naar ZWARTE VIJVERS.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"9\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"1683F\"}, {\"id\": \"1685F\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Mar 25 until Jun 30, works. STOP NOT SERVED. Stop of bus 95: av. Couronne / Kroonln, in front of number 384\", \"fr\": \"Du 25/3 au 30/6, travaux. ARRET NON DESSERVI. Arr\u00eat du bus 95: av. de la Couronne, en face du num\u00e9ro 384.\", \"nl\": \"Van 25/3 tot en met 30/6, werken. HALTE NIET BEDIEND. Halte van bus 95: Kroonlaan, tegenover nummer 384\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"95\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"4306\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Mar 25-Jun 30, works. STOP NOT SERVED. Stop of bus 95: CIMETIERE D'IXELLES / BEGR. VAN ELSENE.\", \"fr\": \"25/3-30/6,travaux. ARRET NON DESSERVI. Arr\u00eat du bus 95: CIM. D'IXELLES (ch\u00e9e de Boondael, avant le rond-point).\", \"nl\": \"25/3-30/6, werken. HALTE NIET BEDIEND. Halte van bus 95: BEGR. VAN ELSENE (Boondaalsestwg, voor de rotonde)\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"95\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"4362\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"As of September 21, works. Stop moved to av. de la Fauconnerie / Valkerijlaan, next to number 53a.\", \"fr\": \"D\u00e8s le 21/9, travaux. Arr\u00eat d\u00e9plac\u00e9 avenue de la Fauconnerie, \u00e0 hauteur du num\u00e9ro 53a.\", \"nl\": \"Vanaf 21/9, werken. Halte verplaatst naar de Valkerijlaan, ter hoogte van huisnummer 53a.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"95\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"4314\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Mar 25 until Jun 30, works. Bus 95 diverted btw CIMETIERE D'IXELLES and ETTERBEEK GARE\", \"fr\": \"Du 25/3 au 30/6, travaux. Bus 95 d\u00e9vi\u00e9 entre CIMETIERE D'IXELLES et  ETTERBEEK GARE.\", \"nl\": \"Van 25/3 tot en met 30/6, werken. Bus 95 omgeleid tussen BEGRAAFPLAATS VAN ELSENE en ETTERBEEK STATION.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"95\"}]",
+        "priority": 5,
+        "points": "[{\"id\": \"4360\"}, {\"id\": \"4351\"}, {\"id\": \"1455\"}, {\"id\": \"4355\"}, {\"id\": \"4357\"}, {\"id\": \"4358\"}, {\"id\": \"4359\"}, {\"id\": \"4348\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"T81-T97 operate normally againBAREEL and JANSON\", \"fr\": \"T81-T97 circulent \u00e0 nouveau entre BARRIERE et JANSON\", \"nl\": \"T81-T97 worden weer bediend tussen BAREEL en JANSON\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"97\"}]",
+        "priority": 3,
+        "points": "[{\"id\": \"5723G\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"T81-T97 operate normally againBAREEL and JANSON\", \"fr\": \"T81-T97 circulent \u00e0 nouveau entre BARRIERE et JANSON\", \"nl\": \"T81-T97 worden weer bediend tussen BAREEL en JANSON\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"97\"}]",
+        "priority": 3,
+        "points": "[{\"id\": \"6078\"}, {\"id\": \"6428F\"}, {\"id\": \"5018F\"}, {\"id\": \"5016F\"}, {\"id\": \"2404F\"}, {\"id\": \"6314\"}, {\"id\": \"2336G\"}, {\"id\": \"6162\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"T81-T97 operate normally againBAREEL and JANSON\", \"fr\": \"T81-T97 circulent \u00e0 nouveau entre BARRIERE et JANSON\", \"nl\": \"T81-T97 worden weer bediend tussen BAREEL en JANSON\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"97\"}]",
+        "priority": 3,
+        "points": "[{\"id\": \"5164F\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"T81-T97 operate normally againBAREEL and JANSON\", \"fr\": \"T81-T97 circulent \u00e0 nouveau entre BARRIERE et JANSON\", \"nl\": \"T81-T97 worden weer bediend tussen BAREEL en JANSON\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"97\"}]",
+        "priority": 3,
+        "points": "[{\"id\": \"5722F\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"T81-T97 operate normally againBAREEL and JANSON\", \"fr\": \"T81-T97 circulent \u00e0 nouveau entre BARRIERE et JANSON\", \"nl\": \"T81-T97 worden weer bediend tussen BAREEL en JANSON\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"97\"}]",
+        "priority": 3,
+        "points": "[{\"id\": \"5916F\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"T81-T97 operate normally againBAREEL and JANSON\", \"fr\": \"T81-T97 circulent \u00e0 nouveau entre BARRIERE et JANSON\", \"nl\": \"T81-T97 worden weer bediend tussen BAREEL en JANSON\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"97\"}]",
+        "priority": 3,
+        "points": "[{\"id\": \"2708G\"}, {\"id\": \"5952F\"}, {\"id\": \"2709F\"}, {\"id\": \"2710G\"}, {\"id\": \"1984G\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"T81-T97 operate normally againBAREEL and JANSON\", \"fr\": \"T81-T97 circulent \u00e0 nouveau entre BARRIERE et JANSON\", \"nl\": \"T81-T97 worden weer bediend tussen BAREEL en JANSON\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"97\"}]",
+        "priority": 3,
+        "points": "[{\"id\": \"5121F\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"T81-T97 operate normally againBAREEL and JANSON\", \"fr\": \"T81-T97 circulent \u00e0 nouveau entre BARRIERE et JANSON\", \"nl\": \"T81-T97 worden weer bediend tussen BAREEL en JANSON\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"97\"}]",
+        "priority": 3,
+        "points": "[{\"id\": \"5151\"}, {\"id\": \"2668\"}, {\"id\": \"5155\"}, {\"id\": \"2667F\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"T81-T97 operate normally againBAREEL and JANSON\", \"fr\": \"T81-T97 circulent \u00e0 nouveau entre BARRIERE et JANSON\", \"nl\": \"T81-T97 worden weer bediend tussen BAREEL en JANSON\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"97\"}]",
+        "priority": 3,
+        "points": "[{\"id\": \"1985G\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"T81-T97 operate normally againBAREEL and JANSON\", \"fr\": \"T81-T97 circulent \u00e0 nouveau entre BARRIERE et JANSON\", \"nl\": \"T81-T97 worden weer bediend tussen BAREEL en JANSON\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"97\"}]",
+        "priority": 3,
+        "points": "[{\"id\": \"5161F\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Until 2026, works. T-bus 82/97 diverted between BEMPT and FOREST CENTRE/VORST CENTRUM.\", \"fr\": \"Jusqu'en 2026, travaux. T-bus 82/97 d\u00e9vi\u00e9 entre BEMPT et FOREST CENTRE.\", \"nl\": \"Tot 2026, werken. Bus T-bus 82/97 omgeleid tussen BEMPT en VORST CENTRUM.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"T82\"}]",
+        "priority": 5,
+        "points": "[{\"id\": \"3405\"}, {\"id\": \"7472\"}, {\"id\": \"7474\"}, {\"id\": \"7465\"}, {\"id\": \"3255\"}, {\"id\": \"5755\"}, {\"id\": \"5756\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Until 2026, works. Bus 50 and T-bus diverted between FOREST CENTRE / VORST CENTRUM and BEMPT.\", \"fr\": \"Jusqu'en 2026, travaux. Bus 50 et T-bus d\u00e9vi\u00e9s entre FOREST CENTRE et BEMPT.\", \"nl\": \"Tot 2026, werken. Bus 50 en T-bus omgeleid tussen VORST CENTRUM en BEMPT.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"T82\"}]",
+        "priority": 5,
+        "points": "[{\"id\": \"3196\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. As of Apr 15, STOP NOT SERVED. Stop of bus 12: rue Archim\u00e8de / Archimedesstraat 16.\", \"fr\": \"Travaux. D\u00e8s le 15/4, ARRET NON DESSERVI. Arr\u00eat du bus 12: rue Archim\u00e8de 16.\", \"nl\": \"Werken. Vanaf 15/4, HALTE NIET BEDIEND. Halte van bus 12: Archimedesstraat 16.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"12\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"1418B\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. From Apr 23 until Jun 2, bus 13 and 88 diverted. Take bus 13 or 88 at the stop of bus 820 to UZ Brussel.\", \"fr\": \"Travaux; Du 23/4 au 2/6, bus 13 et 88 d\u00e9vi\u00e9s. Prenez le bus 13 ou 88 \u00e0 l'arr\u00eat du bus 820 vers UZ Brussel.\", \"nl\": \"Werken. Van 23/4 tot en met 2/6, bus 13 en 88 omgeleid. Neem bus 13 of 88 aan de halte van bus 820 naar UZ Brussel.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"13\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"1721\"}, {\"id\": \"1328\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Sep 5 6AM, works. STOP NOT SERVED. Temporary stop: rue du Brillant (across stop towards Heiligenborre)\", \"fr\": \"D\u00e8s le 5/9 6h, travaux. ARRET NON DESSERVI. Arr\u00eat provisoire: rue du Brillant (face \u00e0 l'arr\u00eat vers Heiligenborre)\", \"nl\": \"Vanaf 5/9 6u, werken. HALTE NIET BEDIEND. Tijdelijke halte: Briljantstraat (tgnover halte > Heiligenborre)\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"17\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"4293\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Sep 5 6AM, works. STOP NOT SERVED. Bus 17 diverted between BRILLANT and BEAULIEU via Michiels\", \"fr\": \"D\u00e8s le 5/9 6h, travaux. ARRET NON DESSERVI. Bus 17 d\u00e9vi\u00e9 entre BRILLANT et BEAULIEU via Michiels\", \"nl\": \"Vanaf 5/9 6u, werken. HALTE NIET BEDIEND. Bus 17 omgeleid tussen BRILJANT en BEAULIEU via Michiels\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"17\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"4295\"}, {\"id\": \"4296\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. Until mid-2024, T19 interrupted at MIROIR. Stop of T-bus 19: av. Jette 126 (next to this stop)\", \"fr\": \"Travaux. Jusque mi-2024, T19 interrompu \u00e0 MIROIR. Arr\u00eat du T-bus 19: av. de Jette, 126 (\u00e0 c\u00f4t\u00e9 de cet arr\u00eat).\", \"nl\": \"Werken. Tot midden 2024, T19 onderbroken aan SPIEGEL. Halte van T-bus 19: Jetselaan 126 (naast deze halte)\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"19\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"6864F\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. Until mid-2024, T19 replaced by T-bus btw MIROIR and CIMETIERE DE JETTE. T-bus at stop of bus 13 to UZ-VUB.\", \"fr\": \"Travaux. Jsq mi-2024, T19 remplac\u00e9 par T-bus entre MIROIR et CIM. JETTE. T-bus \u00e0 l'arr\u00eat du bus 13 vers UZ-VUB.\", \"nl\": \"Werken. Tot midden 2024, T19 vervangen door T-bus tss SPIEGEL en KERKH. JETTE.  T-bus aan halte van B13 naar UZ-VUB.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"19\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"0471\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. Until mid-2024, stop not served. Take tram 19 at CIMETIERE DE JETTE / KERKHOF VAN JETTE.\", \"fr\": \"Travaux. Jusque mi-2024, arr\u00eat non desservi. Prenez le tram 19 \u00e0 CIMETIERE DE JETTE.\", \"nl\": \"Werken. Tot midden 2024, halte niet bediend. Neem tram 19 aan KERKHOF VAN JETTE.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"19\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"6869G\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. As of April 29th, STOP NOT SERVED. Take tram 19 at the next stop, STUYVENBERGH.\", \"fr\": \"Travaux. D\u00e8s le 29/4, ARRET NON DESSERVI. Prenez le tram 19 \u00e0 l'arr\u00eat suivant, STUYVENBERGH.\", \"nl\": \"Werken. Vanaf 29/4, HALTE NIET BEDIEND. Neem tram 19 aan de volgende halte, STUYVENBERGH.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"19\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"5082\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. Until mid-2024, T19 replaced by T-bus between MIROIR and CIMETIERE DE JETTE.\", \"fr\": \"Travaux. Jusque mi-2024, tram 19 remplac\u00e9 par des T-bus entre MIROIR et CIMETIERE DE JETTE.\", \"nl\": \"Werken. Tot midden 2024, tram 19 vervangen door T-bus tussen SPIEGEL en KERKHOF VAN JETTE.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"19\"}]",
+        "priority": 5,
+        "points": "[{\"id\": \"1306F\"}, {\"id\": \"5105F\"}, {\"id\": \"1094F\"}, {\"id\": \"1111\"}, {\"id\": \"5104F\"}, {\"id\": \"5103\"}, {\"id\": \"5102F\"}, {\"id\": \"1064\"}, {\"id\": \"5108\"}, {\"id\": \"5109\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. Until mid-2024, stop not served. T-bus at VERBEYST (bd de Smet de Naeyer 211, stop of bus 14 to GARE DU NORD).\", \"fr\": \"Travaux, jusque mi-2024, arr\u00eat non desservi.T-bus \u00e0 VERBEYST (bd de Smet de Naeyer 211, arr\u00eat B14 vers GARE DU NORD).\", \"nl\": \"Werken. Tot midden 2024, halte niet bediend. T-bus aan VERBEYST (de Smet de Naeyerlaan 211, halte B14 naar NOORDST.)\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"19\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"6803F\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. As of Apr 15, STOP NOT SERVED. Stop of bus 21: rue Franklinstraat 2a.\", \"fr\": \"Travaux. D\u00e8s le 15/4, ARRET NON DESSERVI. Arr\u00eat du bus 21: rue Franklin, 2a.\", \"nl\": \"Werken. Vanaf 15/4, HALTE NIET BEDIEND. Halte van bus 21: Franklinstraat 2a.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"21\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"1270B\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. As of Apr 15, bus 21 diverted. Take bus 21 at the stop of bus 64 to BORDET STATION.\", \"fr\": \"Travaux. D\u00e8s le 15/4, bus 21 d\u00e9vi\u00e9. Prenez le bus 21 \u00e0 l'arr\u00eat du bus 64 vers BORDET STATION.\", \"nl\": \"Werken. Vanaf 15/4, bus 21 omgeleid. Neem bus 21 aan de halte van bus 64 naar BORDET STATION.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"21\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"1133\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Apr 29 at 7AM, works. STOP NOT SERVED. Take bus 21 at the next stop, DIAMANT.\", \"fr\": \"D\u00e8s le 29/4 \u00e0 7h, travaux. ARRET NON DESSERVI. Prenez le bus 21 \u00e0 l'arr\u00eat suivant DIAMANT.\", \"nl\": \"Vanaf 29/4, 7u, werken. HALTE NIET BEDIEND. Neem bus 21 aan de volgende halte, DIAMANT.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"21\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"6451\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. As of Apr 15, bus 21 diverted btw MICHEL- ANGE and TOULOUSE via MAELBEEK. Stop SCHUMAN moved rue Franklin.\", \"fr\": \"Travaux. D\u00e8s le 15/4,bus 21 d\u00e9vi\u00e9 entre MICHEL- ANGE et TOULOUSE via MAELBEEK. Arr\u00eat SCHUMAN d\u00e9plac\u00e9 rue Franklin.\", \"nl\": \"Werken. Vanaf 15/4, bus 21 omgeleid tss MICHELANGELO en TOULOUSE via MAALBEEK. SCHUMAN verplaatst Franklinstr.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"21\"}]",
+        "priority": 6,
+        "points": "[{\"id\": \"1464\"}, {\"id\": \"1463\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. As of Apr 15, STOP NOT SERVED. Take bus 21 at MAELBEEK / MAALBEEK (stop of bus 64 to BORDET STATION).\", \"fr\": \"Travaux. D\u00e8s le 15/4, ARRET NON DESSERVI. Prenez le bus 21 \u00e0 MAELBEEK (halte van bus 64 naar BORDET STATION).\", \"nl\": \"Werken. Vanaf 15/4, HALTE NIET BEDIEND. Neem bus 21 aan MAALBEEK (arr\u00eat du bus 64 vers BORDET STATION).\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"21\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"1416\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Apr 29 at 7AM, works. STOP NOT SERVED. Take bus 29 at the stop DIAMANT of bus 21 to MAES.\", \"fr\": \"D\u00e8s le 29/4,7h, travaux. ARRET NON DESSERVI. Prenez le bus 29 \u00e0 l'arr\u00eat DIAMANT du bus 21 vers MAES.\", \"nl\": \"Vanaf 29/4, 7u, werken. HALTE NIET BEDIEND. Neem bus 29 aan de halte DIAMANT van bus 21 naar MAES.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"29\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"6454\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. As of Apr 29, stop moved to avenue de Mai / Meilaan, next to numbers 65-67\", \"fr\": \"Travaux. D\u00e8s le 29/4, arr\u00eat d\u00e9plac\u00e9 avenue de Mai, \u00e0 hauteur des num\u00e9ros 65-67.\", \"nl\": \"Werken. Vanaf 29/4, halte verplaatst naar de Meilaan, ter hoogte van huisnummers 65-67.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"29\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"1521\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Jan 7, 9PM-Jun 28,works. Tram 3 interrupted btw ESPLANADE and DOCKS BRUXSEL. Stop of the T-bus: next to this stop\", \"fr\": \"7/1, 21h-28/6, travaux. Tram 3 interrompu entre ESPLANADE et DOCKS BRUXSEL. Arr\u00eat du T-bus: \u00e0 c\u00f4t\u00e9 de cet arr\u00eat.\", \"nl\": \"7/1, 21u-28/6, werken. Tram 3 onderbroken tss ESPLANADE en DOCKS BRUXSEL. Halte van de T-bus: naast deze halte.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"3\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"5705\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Jan 7 at 9PM to Jun 28, works. Terminus not served. Stop of the T-bus: av. de Meysse, in front of number 125.\", \"fr\": \"Du 7/1 \u00e0 21h au 28/6, travaux. Terminus non desservi. Arr\u00eat du T-bus: avenue de Meysse, en face du num\u00e9ro 125.\", \"nl\": \"7/1, 21u-28/6, werken. Eindpunt niet bediend. Halte van de T-bus: Meiseselaan, tegenover nummer 125.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"3\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"5701\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Jan 7, 9PM-Jun 28, works. Stop not served. T-bus to ESPLANADE at the stop of bus 56 to BUDA.\", \"fr\": \"7/1, 21h-28/6, travaux. Arr\u00eat non desservi. T-bus vers ESPLANADE \u00e0 l'arr\u00eat du bus 56 vers BUDA.\", \"nl\": \"7/1, 21u-28/6, werken. Halte niet bediend. T-bus naar ESPLANADE aan de halte van bus 56 naar BUDA.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"3\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"5770F\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Jan 7, 9PM-Jun 28,works. Tram 3 interrupted btw ESPLANADE and DOCKS BRUXSEL. T-bus at stop of bus 83 to VAL MARIA\", \"fr\": \"7/1, 21h-28/6, travaux. Tram 3 interrompu entre ESPLANADE et DOCKS BRUXSEL. T-bus \u00e0 l'arr\u00eat du bus 83 vers VAL MARIA\", \"nl\": \"7/1, 21u-28/6, werken. Tram 3 onderbroken tss ESPLANADE en DOCKS BRUXSEL. T-bus halte van bus 83 naar MARI\u00cbNDAAL.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"3\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"5700G\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Jan 7, 9PM-Jun 28, works. Tram 3 replaced by T-bus between DOCKS BRUXSEL and ESPLANADE. Info: stib-mivb.brussels\", \"fr\": \"7/1, 21h-28/6, travaux. Tram 3 remplac\u00e9 par des T-bus entre DOCKS BRUXSEL et ESPLANADE. Info: stib.brussels.\", \"nl\": \"7/1, 21u-28/6, werken. Tram 3 vervangen door T-bus tussen DOCKS BRUXSEL en ESPLANADE. info: mivb.brussels.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"3\"}]",
+        "priority": 5,
+        "points": "[{\"id\": \"5219F\"}, {\"id\": \"6179\"}, {\"id\": \"2537F\"}, {\"id\": \"0722\"}, {\"id\": \"9986F\"}, {\"id\": \"6424F\"}, {\"id\": \"0606\"}, {\"id\": \"6177F\"}, {\"id\": \"0626\"}, {\"id\": \"0516\"}, {\"id\": \"6209\"}, {\"id\": \"0725\"}, {\"id\": \"0726\"}, {\"id\": \"0616\"}, {\"id\": \"0506\"}, {\"id\": \"2200F\"}, {\"id\": \"0723\"}, {\"id\": \"0526\"}, {\"id\": \"0724\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Jan 15, works. Bus 34 diverted between HANKAR and BERGOJE via DEMEY.\", \"fr\": \"D\u00e8s le 15/1, travaux. Bus 34 d\u00e9vi\u00e9 entre HANKAR et BERGOJE via DEMEY.\", \"nl\": \"Vanaf 15/1, werken. Bus 34 omgeleid tussen HANKAR en BERGOJE via DEMEY.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"34\"}]",
+        "priority": 5,
+        "points": "[{\"id\": \"6433\"}, {\"id\": \"1712\"}, {\"id\": \"1733\"}, {\"id\": \"2291B\"}, {\"id\": \"1233\"}, {\"id\": \"1729\"}, {\"id\": \"1728\"}, {\"id\": \"1706\"}, {\"id\": \"1716\"}, {\"id\": \"1715\"}, {\"id\": \"1714\"}, {\"id\": \"1824\"}, {\"id\": \"1713\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Jan 15, works. STOP NOT SERVED. Take bus 34 at the stop RO(O)DENBERG of bus 72 to ADEPS.\", \"fr\": \"D\u00e8s le 15/1, travaux. ARRET NON DESSERVI. Prenez le bus 34 \u00e0 l'arr\u00eat ROODENBERG du bus 72 vers ADEPS.\", \"nl\": \"Vanaf 15/1, werken. HALTE NIET BEDIEND. Neem bus 34 aan de halte RODENBERG van bus 72 naar ADEPS.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"34\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"1720B\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Jan 15, works. STOP NOT SERVED. Stop of bus 34: boulevard du Souverain / Vorstlaan 159.\", \"fr\": \"D\u00e8s le 15/1, travaux. ARRET NON DESSERVI. Arr\u00eat du bus 34: boulevard du Souverain 159.\", \"nl\": \"Vanaf 15/1, werken. HALTE NIET BEDIEND. Halte van bus 34: Vorstlaan 159.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"34\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"1731\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Apr 3 at 6AM, works. STOP NOT SERVED. Take bus 38 and 41 at the previous stop, HOUZEAU.\", \"fr\": \"D\u00e8s le 3/4 \u00e0 6h, travaux. ARRET NON DESSERVI. Prenez les bus 38 et 41 \u00e0 l'arr\u00eat pr\u00e9c\u00e9dent, HOUZEAU.\", \"nl\": \"Vanaf 3/4 om 6u, werken. HALTE NIET BEDIEND. Neem bus 38 en 41 aan de vorige halte, HOUZEAU.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"38\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"1970\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Apr 3 at 6AM, works. Bus 38 diverted between LONGCHAMP and HOUZEAU via rue Edith Cavellstraat.\", \"fr\": \"D\u00e8s le 3/4 \u00e0 6h, travaux. Bus 38 d\u00e9vi\u00e9 entre LONGCHAMP et HOUZEAU via rue Edith Cavell.\", \"nl\": \"Vanaf 3/4 om 6u, werken. Bus 38 omgeleid tussen LONGCHAMP en HOUZEAU via Edith Cavellstraat.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"38\"}]",
+        "priority": 5,
+        "points": "[{\"id\": \"1916\"}, {\"id\": \"1915\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Apr 3 at 6AM, works. STOP NOT SERVED. Bus 38 at GOSSART (avenue Winston Churchilllaan 202).\", \"fr\": \"D\u00e8s le 3/4 \u00e0 6h, travaux. ARRET NON DESSERVI. Bus 38 \u00e0 GOSSART (avenue Winston Churchill 202).\", \"nl\": \"Vanaf 3/4 om 6u, werken. HALTE NIET BEDIEND. Bus 38 aan GOSSART (Winston Churchilllaan 202).\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"38\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"1918\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Apr 3 at 6AM, works. STOP NOT SERVED. Bus 38 at GOSSART (avenue Winston Churchilllaan 187).\", \"fr\": \"D\u00e8s le 3/4 \u00e0 6h, travaux. ARRET NON DESSERVI. Bus 38 \u00e0 GOSSART (avenue Winston Churchill 187).\", \"nl\": \"Vanaf 3/4 om 6u, werken. HALTE NIET BEDIEND. Bus 38 aan GOSSART (Winston Churchilllaan 187).\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"38\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"1972\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. As of April 7th, bus 38 diverted. Take bus 38 at the next stop, ROYALE / KONING.\", \"fr\": \"Travaux. D\u00e8s le 7/4, bus 38 d\u00e9vi\u00e9. Prenez le bus 38 \u00e0 l'arr\u00eat suivant, ROYALE.\", \"nl\": \"Werken. Vanaf 7/4, bus 38 omgeleid. Neem bus 38 aan de volgende halte, KONING.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"38\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"3502\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. As of Apr 29, STOP NOT SERVED. Stop of bus 38: WASHINGTON (stop of bus 60 to UCCLE CALEVOET).\", \"fr\": \"Travaux. D\u00e8s le 29/4, ARRET NON DESSERVI. Arr\u00eat du bus 38: WASHINGTON (arr\u00eat du bus 60 vers UCCLE CALEVOET)\", \"nl\": \"Werken. Vanaf 29/4,HALTE NIET BEDIEND. Halte van bus 38: WASHINGTON (halte van bus 60 naar UKKEL KALEVOET)\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"38\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"1913\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Obstacle on the road: B41 diverted between BOONDAAL STATION and MONTANA direction HELDEN\", \"fr\": \"Obstacle sur la route: B41 d\u00e9vi\u00e9 entre BOONDAEL GARE et MONTANA direction HEROS\", \"nl\": \"Hindernis op de weg: B41 omgeleid tussen BOONDAAL STATION en MONTANA richting HELDEN\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"41\"}]",
+        "priority": 2,
+        "points": "[{\"id\": \"2763\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Mar 4, works. Bus 43 and N11 diverted. Weekdays before 8PM: B43 at BRAVES. Otherwise: bus at GRIOTTES.\", \"fr\": \"D\u00e8s le 4/3, travaux. Bus 43 et N11 d\u00e9vi\u00e9s. En semaine avant 20h: B43 \u00e0 BRAVES. Autres moments: bus \u00e0 GRIOTTES.\", \"nl\": \"Vanaf 4/3, werken. Bus 43 en N11 omgeleid. Weekdagen voor 20u: B43 aan DAPPEREN. Anders: bus aan NOORDKRIEKEN.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"43\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"1963\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Enjoy your trip on our lines !\", \"fr\": \"Bon voyage sur nos lignes !\", \"nl\": \"Geniet van uw reis op onze lijnen !\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"44\"}]",
+        "priority": 9,
+        "points": "[{\"id\": \"9552\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Until end of August 2024, works. Stop not served. Walk to WTC-GLIBERT.\", \"fr\": \"Jusque fin ao\u00fbt 2024, travaux. Arr\u00eat non desservi. Continuez \u00e0 pied pour WTC-GLIBERT.\", \"nl\": \"Tot einde augustus 2024, werken. halte niet bediend. Ga te voet verder om naar WTC-GLIBERT te gaan.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"46\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"1894\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Until end of August, works. Bus 46 interrupted. Take bus 46 at ANNEESSENS (via bus 33).\", \"fr\": \"Jusque fin ao\u00fbt, travaux. Bus 46 interrompu. Prenez le bus 46 \u00e0 ANNEESSENS (via bus 33).\", \"nl\": \"Tot einde augustus, werken. Bus 46 onderbroken. Neem bus 46 aan ANNEESSENS (via bus 33).\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"46\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"1895\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. Until end of August, B46 not operated btw WTC-GLIBERT and PTE ANDERLECHT. For the center, bus 88 at WTC.\", \"fr\": \"Travaux. Jsq fin ao\u00fbt, B46 ne circule pas entre WTC-GLIBERT et PORTE D'ANDERLECHT. Pour le centre, bus 88 \u00e0 WTC.\", \"nl\": \"Werken. Tot einde augustus rijdt bus 46 niet tss WTC-GLIBERT en ANDERLECHTSEPT. Voor het centrum,neem B88 aan WTC\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"46\"}]",
+        "priority": 5,
+        "points": "[{\"id\": \"9025\"}, {\"id\": \"1896\"}, {\"id\": \"2209\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Until Summer of 2024, works. As of Mar 4, stop of bus 47: Military Area, stop of bus 57 to GARE DU NORD.\", \"fr\": \"Jsq \u00e9t\u00e9 2024, travaux. D\u00e8s le 4/3, arr\u00eat du bus 47 : Domaine Militaire, arr\u00eat du bus 57 vers GARE DU NORD.\", \"nl\": \"Tot zomer 2024, werken. Vanaf 4/3, halte van bus 47: Militair Domein, halte van bus 57 naar NOORDSTATION..\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"47\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"3068\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Until Summer of 2024, works. Stop not served. Take bus 47 or 57 at ANTOON VAN OSS (stop of bus 56 to BUDA).\", \"fr\": \"Jsq \u00e9t\u00e9 2024, travaux. Arr\u00eat non desservi. Prenez le bus 47 ou 57 \u00e0 ANTOON VAN OSS (arr\u00eat du bus 56 vers BUDA).\", \"nl\": \"Tot zomer 2024, werken. Halte niet bediend. Neem bus 47 of 57 aan ANTOON VAN OSS (halte van bus 56 naar BUDA).\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"47\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"1837\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Until Summer of 2024, works. Bus 47 diverted btw VTM and RAMIER. As of Mar 18, stop HOPITAL MILITAIRE in rue Bruyn.\", \"fr\": \"Jsq \u00e9t\u00e9 2024, travaux. Bus 47 d\u00e9vi\u00e9 entre VTM et RAMIER. D\u00e8s le 18/3, arr\u00eat HOPITAL MILITAIRE rue Bruyn.\", \"nl\": \"Tot zomer 2024, werken. Bus 47 omgeleid tussen VTM en BOSDUIF. Vanaf 18/3,halte MILITAIR HOSP in de Bruynstraat.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"47\"}]",
+        "priority": 5,
+        "points": "[{\"id\": \"9784B\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. STOP NOT SERVED. B47: at the stop CROIX DE GUERRE of B56 (av. des Croix de Guerre)\", \"fr\": \"Travaux. ARRET NON DESSERVI. B47 : \u00e0 l'arr\u00eat CROIX DE GUERRE du B56 (av. des Croix de Guerre)\", \"nl\": \"Werken. HALTE NIET BEDIEND. B47: aan de halte OORLOGSKRUISEN van B56 (Oorlogskruisenlaan)\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"47\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"2362B\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Until Summer of 2024, works. Stop of bus 47: rue de Ransbeekstraat 201.\", \"fr\": \"Jusqu'\u00e0 l'\u00e9t\u00e9 2024, travaux. Arr\u00eat du bus 47: rue de Ransbeek 201.\", \"nl\": \"Tot zomer 2024, werken. Halte van bus 47: Ransbeekstraat 201.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"47\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"2360\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Until Summer of 2024, works. Stop not served. Take bus 47 at the stop of bus 56 to BUDA.\", \"fr\": \"Jusqu'\u00e0 l'\u00e9t\u00e9 2024, travaux. Arr\u00eat non desservi. Prenez le bus 47 \u00e0 l'arr\u00eat du bus 56 vers BUDA.\", \"nl\": \"Tot zomer 2024, werken. Halte niet bediend. Neem bus 47 aan de halte van bus 56 naar BUDA.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"47\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"2358\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Oct 18 9.30AM, stop not served. Go to the previous stop : HELDENPLEIN.\", \"fr\": \"A partir du 18/10 9h30, arr\u00eat non desservi. Rejoignez l'arr\u00eat pr\u00e9c\u00e9dent : HELDENPLEIN.\", \"nl\": \"Vanaf 18/10 9u30, halte niet bediend. Ga naar de vorige halte HELDENPLEIN.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"47\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"9787\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Until Summer of 2024, works. Bus 47 diverted btw VTM and RAMIER. As of Mar 18, stop HOPITAL MILITAIRE in rue Bruyn.\", \"fr\": \"Jsq \u00e9t\u00e9 2024, travaux. Bus 47 d\u00e9vi\u00e9 entre VTM et RAMIER. D\u00e8s le 18/3, arr\u00eat HOPITAL MILITAIRE rue Bruyn.\", \"nl\": \"Tot zomer 2024, werken. Bus 47 omgeleid tussen VTM en BOSDUIF. Vanaf 18/3,halte MILITAIR HOSP in de Bruynstraat.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"47\"}]",
+        "priority": 5,
+        "points": "[{\"id\": \"9634\"}, {\"id\": \"9632\"}, {\"id\": \"9606\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"End of the works. As of Monday Apr 15, stop served by bus 49 to GARE DU MIDI / ZUIDSTATION. Bus 90 withdrawn.\", \"fr\": \"Fin des travaux. D\u00e8s le lundi 15/4, arr\u00eat desservi par les bus 49 vers GARE DU MIDI. Bus 90 supprim\u00e9\", \"nl\": \"Einde van de werken. Vanaf maandag 15/4 wordt deze halte bediend door bus 49 naar ZUIDSTATION. Bus 90 geschrapt.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"49\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"1207\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. Until 2026, tram 82 and 97 interrupted. Stop of the T-bus and of bus 50: ch. de Neerstalsestwg 236.\", \"fr\": \"Travaux. Jsq 2026, tram 82 et 97 interrompus. Arr\u00eat du T-bus et du bus 50: chauss\u00e9e de Neerstalle 236\", \"nl\": \"Werken. Tot 2026, tram 82 en 97 onderbroken. Halte van de T-bus en van bus 50: Neerstalsesteenweg 236\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"50\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"3604\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Until 2026, works. Bus 50 diverted. Stop bus 50: bd 2e Arm\u00e9e Britannique / Britse Tweedelegerlaan.\", \"fr\": \"Jsq 2026, travaux. Bus 50 d\u00e9vi\u00e9. Arr\u00eat bus 50: bd 2e Arm\u00e9e Britannique, carrefour rue de la Station.\", \"nl\": \"Tot 2026, werken. Bus 50 omgeleid. Halte bus 50: Britse Tweedelegerlaan, kruispunt Stationstraat.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"50\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"5719\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Until 2026, works. Bus 50 and T-bus diverted between FOREST CENTRE / VORST CENTRUM and BEMPT.\", \"fr\": \"Jusqu'en 2026, travaux. Bus 50 et T-bus d\u00e9vi\u00e9s entre FOREST CENTRE et BEMPT.\", \"nl\": \"Tot 2026, werken. Bus 50 en T-bus omgeleid tussen VORST CENTRUM en BEMPT.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"50\"}]",
+        "priority": 5,
+        "points": "[{\"id\": \"5915\"}, {\"id\": \"2548\"}, {\"id\": \"2546\"}, {\"id\": \"2544\"}, {\"id\": \"2555\"}, {\"id\": \"1015\"}, {\"id\": \"2553\"}, {\"id\": \"3211\"}, {\"id\": \"2539\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From May 18, 5AM, works. STOP NOT SERVED. Stop of bus 52: avenue du Parc / Parklaan 26, in front of number 26.\", \"fr\": \"D\u00e8s le 18/5, 5h, travaux. ARRET NON DESSERVI. Arr\u00eat du bus 52: avenue du Parc, en face du num\u00e9ro 26.\", \"nl\": \"Vanaf 18/5, 5u, werken. HALTE NIET BEDIEND. Halte van bus 52: Parklaan, tegenover nummer 26.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"52\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"2334B\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. As of Apr 15 at 6AM, STOP NOT SERVED. Take bus 53 at BEYSEGHEM / BEIZEGEM.\", \"fr\": \"Travaux. D\u00e8s le 15/4 \u00e0 6h, ARRET NON DESSERVI. Prenez le bus 53 \u00e0 BEYSEGHEM.\", \"nl\": \"Werken. Vanaf 15/4 om 6u, HALTE NIET BEDIEND. Neem bus 53 aan BEIZEGEM.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"53\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"2852\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Until Summer of 2024, works. Stop not served. Stop of bus 53: place Peter Benoitplein 3\", \"fr\": \"Jusqu'\u00e0 l'\u00e9t\u00e9 2024, travaux. Arr\u00eat non desservi. Arr\u00eat du bus 53 : place Peter Benoit 3\", \"nl\": \"Tot zomer 2024, werken. Halte niet bediend. Halte van bus 53: Peter Benoitplein 3\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"53\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"2362B\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. As of Apr 15 at 6AM, STOP NOT SERVED. Take bus 53 at BEYSEGHEM / BEIZEGEM.\", \"fr\": \"Travaux. D\u00e8s le 15/4 \u00e0 6h, ARRET NON DESSERVI. Prenez le bus 53 \u00e0 BEYSEGHEM.\", \"nl\": \"Werken. Vanaf 15/4 om 6u, HALTE NIET BEDIEND. Neem bus 53 aan BEIZEGEM.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"53\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"2819\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. As of Apr 15 at 6AM, bus 53 diverted between BEYSEGHEM / BEIZEGEM and PETER BENOIT.\", \"fr\": \"Travaux. D\u00e8s le 15/4 \u00e0 6h, bus 53 d\u00e9vi\u00e9 entre BEYSEGHEM et PETER BENOIT.\", \"nl\": \"Werken. Vanaf 15/4 om 6u, bus 53 omgeleid tussen BEIZEGEM en PETER BENOIT.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"53\"}]",
+        "priority": 5,
+        "points": "[{\"id\": \"2813B\"}, {\"id\": \"2815B\"}, {\"id\": \"2566B\"}, {\"id\": \"2572\"}, {\"id\": \"2571\"}, {\"id\": \"2570\"}, {\"id\": \"3085\"}, {\"id\": \"2171\"}, {\"id\": \"2647\"}, {\"id\": \"2569\"}, {\"id\": \"2547\"}, {\"id\": \"2568\"}, {\"id\": \"2567\"}, {\"id\": \"4132B\"}, {\"id\": \"2565\"}, {\"id\": \"2564\"}, {\"id\": \"2809\"}, {\"id\": \"2573B\"}, {\"id\": \"2648\"}, {\"id\": \"2824\"}, {\"id\": \"3637\"}, {\"id\": \"1767\"}, {\"id\": \"2811\"}, {\"id\": \"1204\"}, {\"id\": \"2810\"}, {\"id\": \"2575\"}, {\"id\": \"2817\"}, {\"id\": \"2816\"}, {\"id\": \"2814\"}, {\"id\": \"3605\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Apr 2, 2024-June 2025, works. Bus 54 diverted btw FOREST CENTRE and FOREST NATIONAL. Info: stib-mivb.brussels.\", \"fr\": \"Du 2/4/2024 \u00e0 juin 2025, travaux. Bus 54 d\u00e9vi\u00e9 entre FOREST CENTRE et FOREST NATIONAL. Info: stib.brussels.\", \"nl\": \"2/4/2024-juni 2025, werken. Bus 54 omgeleid tussen VORST CENTRUM en VORST NATIONAAL. Info: mivb.brussels.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"54\"}]",
+        "priority": 5,
+        "points": "[{\"id\": \"5915\"}, {\"id\": \"1015\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Apr 2, 2024 to June 2025, works. STOP NOT SERVED. Stop of bus 54 and 74: avenue du Globelaan 8.\", \"fr\": \"Du 2/4/2024 \u00e0 juin 2025, travaux. ARRET NON DESSERVI. Arr\u00eat des bus 54 et 74: avenue du Globe 8.\", \"nl\": \"Van 2/4/2024 tot juni 2025, werken. HALTE NIET BEDIEND. Halte van bus 54 en 74: Globelaan 8.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"54\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"2616B\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Apr 2, 2024 to June 2025, works. STOP NOT SERVED. Take bus 54 at the next stop, FOREST NATIONAL.\", \"fr\": \"Du 2/4/2024 \u00e0 juin 2025, travaux. ARRET NON DESSERVI. Prenez le bus 54 \u00e0 l'arr\u00eat suivant, FOREST NATIONAL.\", \"nl\": \"Van 2/4/2024 tot juni 2025, werken. HALTE NIET BEDIEND. Neem bus 54 aan de volgende halte, VORST NATIONAAL.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"54\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"2952B\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Apr 2, 2024-June 2025, works. Bus 54 diverted btw FOREST CENTRE and FOREST NATIONAL. Info: stib-mivb.brussels.\", \"fr\": \"Du 2/4/2024 \u00e0 juin 2025, travaux. Bus 54 d\u00e9vi\u00e9 entre FOREST CENTRE et FOREST NATIONAL. Info: stib.brussels.\", \"nl\": \"2/4/2024-juni 2025, werken. Bus 54 omgeleid tussen VORST CENTRUM en VORST NATIONAAL. Info: mivb.brussels.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"54\"}]",
+        "priority": 5,
+        "points": "[{\"id\": \"3243\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"As of Nov 14, stop moved to avenue Van Praetlaan, after Van Praet bridge.\", \"fr\": \"D\u00e8s le 14/11, arr\u00eat d\u00e9plac\u00e9 avenue Van Praet, apr\u00e8s le pont Van Praet.\", \"nl\": \"Vanaf 14/11, halte verplaatst naar de Van Praetlaan, na het Van Praetbrug.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"56\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"6370\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Until Summer of 2024, works. As of March 18, buses 56 and 57 serve this stop normally.\", \"fr\": \"Jusqu'\u00e0 l'\u00e9t\u00e9 2024, travaux. D\u00e8s le 18/3, les bus 56 et 57 desservent \u00e0 nouveau cet arr\u00eat.\", \"nl\": \"Tot zomer 2024, werken. Vanaf 18/3 bedienen bus 56 en 57 opnieuw deze halte.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"56\"}]",
+        "priority": 5,
+        "points": "[{\"id\": \"1839\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. As of Apr 15, bus 56 diverted. Take bus 56 at the previous stop, at the St-Cyr house.\", \"fr\": \"Travaux. D\u00e8s le 15/4, bus 56 d\u00e9vi\u00e9. Prenez le bus 56 \u00e0 l'arr\u00eat pr\u00e9c\u00e9dent, devant la maison Saint-Cyr.\", \"nl\": \"Werken. Vanaf 15/4, bus 56 omgeleid. Neem bus 56 aan de vorige halte, voor het St-Cyr-huis.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"56\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"1273\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Until Summer of 2024, works. Stop not served. Take bus 47 or 56 at ANTOON VAN OSS. For HOP MILITAIRE , walk.\", \"fr\": \"Jsq \u00e9t\u00e9 2024, travaux. Arr\u00eat non desservi. Bus 47 ou 56 \u00e0 ANTOON VAN OSS. Pour HOPITAL MILITAIRE, \u00e0 pied.\", \"nl\": \"Tot zomer 2024, werken. Halte niet bediend. Neem bus 47 of 56 aan ANTOON VAN OSS. Voor MILITAIR HOSPITAAL, ga te voet.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"56\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"1838\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Until Summer of 2024, works. As of Mar 18, stop served normally by bus 56.\", \"fr\": \"Jusqu'\u00e0 l'\u00e9t\u00e9 2024, travaux. D\u00e8s le 18/3, arr\u00eat \u00e0 nouveau desservi par les bus 56.\", \"nl\": \"Tot zomer 2024, werken. Vanaf 18/3, halte opnieuw bediend door bus 56.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"56\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"2352\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Until Summer of 2024, works. Stop not served. Take bus 57 at the stop of bus 56 to SCHUMAN.\", \"fr\": \"Jusqu'\u00e0 l'\u00e9t\u00e9 2024, travaux. Arr\u00eat non desservi. Prenez le bus 57 \u00e0 l'arr\u00eat du bus 56 vers SCHUMAN.\", \"nl\": \"Tot zomer 2024, werken. Halte niet bediend. Neem bus 57 aan de halte van bus 56 naar SCHUMAN.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"57\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"2317\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Until Summer of 2024, works. Stop not served. Take bus 57 at the stop of bus 56 to BUDA.\", \"fr\": \"Jusqu'\u00e0 l'\u00e9t\u00e9 2024, travaux. Arr\u00eat non desservi. Prenez le bus 57 \u00e0 l'arr\u00eat du bus 56 vers BUDA.\", \"nl\": \"Tot zomer 2024, werken. Halte niet bediend. Neem bus 57 aan de halte van bus 56 naar BUDA.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"57\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"2358\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Until Summer of 2024, works. Bus 57 diverted. Take bus 57 at ANTOON VAN OSS (stop of bus 56 to BUDA)\", \"fr\": \"Jusqu'\u00e0 l'\u00e9t\u00e9 2024, travaux. Bus 57 d\u00e9vi\u00e9. Prenez le bus 57 \u00e0 ANTOON VAN OSS (arr\u00eat du bus 56 vers BUDA).\", \"nl\": \"Tot zomer 2024, werken. Bus 57 omgeleid. Neem bus 57 aan ANTOON VAN OSS (halte van bus 56 naar BUDA).\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"57\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"1827\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. As of Apr 24 at 6.30AM, STOP NOT SERVED. Take bus 59 at the next stop, COTEAUX / WIJNHEUVELEN.\", \"fr\": \"Travaux. D\u00e8s le 24/4 \u00e0 6h30, ARRET NON DESSERVI. Prenez le bus 59 \u00e0 l'arr\u00eat suivant, COTEAUX.\", \"nl\": \"Werken. Vanaf 24/4 om 6. 30u, HALTE NIET BEDIEND. Neem bus 59 aan de volgende halte, WIJNHEUVELEN.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"59\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"3163\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. As of Apr 24 at 6.30AM, STOP NOT SERVED. Stop of bus 59: ST-JOSSE / ST-JOOST (rue Willemsstraat 9).\", \"fr\": \"Travaux. D\u00e8s le 24/4 \u00e0 6h30, ARRET NON DESSERVI. Arr\u00eat du bus 59: SAINT-JOSSE (rue Willems, 9).\", \"nl\": \"Werken. Vanaf 24/4 om 6. 30u, HALTE NIET BEDIEND. Halte van bus 59: SINT-JOOST (Willemsstraat 9).\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"59\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"3162\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. As of Apr 24 at 6.30AM, bus 59 diverted. Stop bus 59: GUTENBERG (rue des Eburons / Eburonenstraat 10)\", \"fr\": \"Travaux. D\u00e8s le 24/4 \u00e0 6h30, bus 59 d\u00e9vi\u00e9. Arr\u00eat du bus 59: GUTENBERG (rue des Eburons, 10).\", \"nl\": \"Werken. Vanaf 24/4 om 6. 30u, bus 59 omgeleid. Halte van bus 59: GUTENBERG (Eburonenstraat, 10).\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"59\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"3118\"}, {\"id\": \"3114\"}, {\"id\": \"6017\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. As of Apr 24 at 6.30AM, STOP NOT SERVED. Stop of bus 59: rue des Coteaux / Wijnheuvelenstraat 213.\", \"fr\": \"Travaux. D\u00e8s le 24/4 \u00e0 6h30, ARRET NON DESSERVI. Arr\u00eat du bus 59, rue des Coteaux, 213.\", \"nl\": \"Werken. Vanaf 24/4 om 6. 30u, HALTE NIET BEDIEND. Halte van bus 59: Wijnheuvelenstraat, 213.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"59\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"3112\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. As of Apr 15, bus 60 diverted between JOURDAN and AMBIORIX via MAELBEEK. Connection metro at MAELBEEK.\", \"fr\": \"Travaux. D\u00e8s le 15/4, bus 60 d\u00e9vi\u00e9 entre JOURDAN et AMBIORIX via MAELBEEK. Correspondance m\u00e9tro \u00e0 MAELBEEK.\", \"nl\": \"Werken. Vanaf 15/4, bus 60 omgeleid tussen JOURDAN en AMBIORIX via MAALBEEK. Aansluiting metro aan MAALBEEK.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"60\"}]",
+        "priority": 6,
+        "points": "[{\"id\": \"3158B\"}, {\"id\": \"6453\"}, {\"id\": \"6112\"}, {\"id\": \"2133\"}, {\"id\": \"2132\"}, {\"id\": \"2131\"}, {\"id\": \"1250\"}, {\"id\": \"4857B\"}, {\"id\": \"4804B\"}, {\"id\": \"6956B\"}, {\"id\": \"3160\"}, {\"id\": \"1976\"}, {\"id\": \"1986\"}, {\"id\": \"1884\"}, {\"id\": \"1653\"}, {\"id\": \"1883\"}, {\"id\": \"1980\"}, {\"id\": \"2134\"}, {\"id\": \"1739\"}, {\"id\": \"6406\"}, {\"id\": \"2847\"}, {\"id\": \"1977\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. As of Apr 15, STOP NOT SERVED. Take bus 60 at PARC LEOPOLD (ch. Etterbeek, in front of number 166).\", \"fr\": \"Travaux. D\u00e8s le 15/4, ARRET NON DESSERVI. Bus 60 \u00e0 PARC LEOPOLD (chauss\u00e9e d'Etterbeek, en face du num\u00e9ro 166).\", \"nl\": \"Werken. Vanaf 15/4, HALTE NIET BEDIEND. Neem bus 60 aan LEOPOLDSPARK (Etterbeeksesteenweg, tegenover nummer 166)\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"60\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"1271B\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. As of Apr 15, STOP NOT SERVED. Take bus 60 at MAELBEEK / MAALBEEK.\", \"fr\": \"Travaux. D\u00e8s le 15/4, ARRET NON DESSERVI. Prenez le bus 60 \u00e0 MAELBEEK.\", \"nl\": \"Werken. Vanaf 15/4, HALTE NIET BEDIEND. Neem bus 60 aan MAALBEEK.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"60\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"1270B\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Apr 24 at 6AM, works. STOP NOT SERVED. Temporary stop: rue Guillaume Kennisstraat 8.\", \"fr\": \"D\u00e8s le 24/4 \u00e0 6h, travaux. ARRET NON DESSERVI. Arr\u00eat provisoire: rue Guillaume Kennis 8.\", \"nl\": \"Vanaf 24/4 om 6u, werken. HALTE NIET BEDIEND. Tijdelijke halte: Guillaume Kennisstraat 8.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"66\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"2346\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Risk of subsidence. Stop of bus 65, 66 and N04 moved to chauss\u00e9e de Haecht/Haachtsesteenweg, next to number 162\", \"fr\": \"Risque d'effondrement. Arr\u00eat des bus 65, 66 et N04 d\u00e9plac\u00e9 chauss\u00e9e de Haecht, \u00e0 hauteur du num\u00e9ro 162.\", \"nl\": \"Risico op instorting. Halte van bus 65, 66 en N04 verplaatst naar de Haachtsesteenweg, ter hoogte van nummer 162.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"66\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"6418\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Jan 7 at 9PM to Jun 28, works. Tram 7 does not serve this stop. Take tram 3 to go to VANDERKINDERE.\", \"fr\": \"Du 7/1 \u00e0 21h au 28/6, travaux. Tram 7 ne dessert pas cet arr\u00eat. Prenez le tram 3 pour rejoindre VANDERKINDERE.\", \"nl\": \"Van 7/1 om 21u tot en met 28/6, werken. Tram 7 bedient deze halte niet. Neem tram 3 om naar VANDERKINDERE te gaan.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"7\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"5219F\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Jan 8 to Jun 28, works. Tram 7 interrupted to HEEMBEEK. T-bus at the stop of bus 56 to BUDA.\", \"fr\": \"Du 8/1 au 28/6, travaux. Tram 7 interrompu jusqu'\u00e0 HEEMBEEK. T-bus \u00e0 l'arr\u00eat du bus 56 vers BUDA.\", \"nl\": \"8/1-28/6, werken. Tram 7 onderbroken tot HEEMBEEK. T-bus aan de halte van bus 56 naar BUDA.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"7\"}]",
+        "priority": 5,
+        "points": "[{\"id\": \"5759F\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Jan 8-Jun 28, works. Tram 7 replaced by T-bus between DOCKS BRUXSEL and HEEMBEEK. Info: stib-mivb.brussels\", \"fr\": \"8/1-28/6, travaux. Tram 7 remplac\u00e9 par des T-bus entre DOCKS BRUXSEL et HEEMBEEK. Info: stib. brussels.\", \"nl\": \"8/1-28/6, werken. Tram 7 vervangen door T-bus tussen DOCKS BRUXSEL en HEEMBEEK. info: mivb. brussels.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"7\"}]",
+        "priority": 5,
+        "points": "[{\"id\": \"2636F\"}, {\"id\": \"9056F\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Mar 18, works. STOP NOT SERVED. stop of bus 71: avenue de l'Universit\u00e9 / Hogeschoollaan 4-10.\", \"fr\": \"D\u00e8s le 18/3, travaux. ARRET NON DESSERVI. Arr\u00eat du bus 71: avenue de l'Universit\u00e9 4-10.\", \"nl\": \"Vanaf 18/3, werken. HALTE NIET BEDIEND. Halte van bus 71: Hogeschoollaan 4-10.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"71\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"3514\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Apr 2, 2024-June 2025, works. Bus 74 diverted btw FOREST CENTRE and FOREST NATIONAL. Info: stib-mivb.brussels.\", \"fr\": \"Du 2/4/2024 \u00e0 juin 2025, travaux. Bus 74 d\u00e9vi\u00e9 entre FOREST CENTRE et FOREST NATIONAL. Info: stib.brussels.\", \"nl\": \"2/4/2024-juni 2025, werken. Bus 74 omgeleid tussen VORST CENTRUM en VORST NATIONAAL. Info: mivb.brussels.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"74\"}]",
+        "priority": 5,
+        "points": "[{\"id\": \"3682\"}, {\"id\": \"3074\"}, {\"id\": \"5915\"}, {\"id\": \"2614\"}, {\"id\": \"2602\"}, {\"id\": \"2601\"}, {\"id\": \"2600\"}, {\"id\": \"2226\"}, {\"id\": \"2523\"}, {\"id\": \"2555\"}, {\"id\": \"2599\"}, {\"id\": \"1015\"}, {\"id\": \"2598\"}, {\"id\": \"2607\"}, {\"id\": \"2606\"}, {\"id\": \"2605\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Apr 2, 2024 to June 2025, works. STOP NOT SERVED. Stop of bus 54 and 74: avenue du Globelaan 8.\", \"fr\": \"Du 2/4/2024 \u00e0 juin 2025, travaux. ARRET NON DESSERVI. Arr\u00eat des bus 54 et 74: avenue du Globe 8.\", \"nl\": \"Van 2/4/2024 tot juni 2025, werken. HALTE NIET BEDIEND. Halte van bus 54 en 74: Globelaan 8.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"74\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"2616B\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Jan 18, works. STOP NOT SERVED. Temporary stop: Avenue de Roodebeeklaan 45.\", \"fr\": \"D\u00e8s le 18/1, travaux. ARRET NON DESSERVI. Arr\u00eat provisoire: Avenue de Roodebeek 45.\", \"nl\": \"Vanaf 18/1, werken. HALTE NIET BEDIEND. Tijdelijke halte: Roodebeeklaan 45.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"79\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"1404\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. As of Apr 15, STOP NOT SERVED. Stop of bus 79: rue Archim\u00e8de / Archimedesstraat 16.\", \"fr\": \"Travaux. D\u00e8s le 15/4, ARRET NON DESSERVI. Arr\u00eat du bus 79: rue Archim\u00e8de 16.\", \"nl\": \"Werken. Vanaf 15/4, HALTE NIET BEDIEND. Halte van bus 79: Archimedesstraat 16.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"79\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"1474B\"}, {\"id\": \"2083\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works.From Apr 29 at 7AM until May 3 at 5PM, bus 80 diverted. Stop B80: av. L. Grosjeanl, before the highway bridge.\", \"fr\": \"Travaux. Du 29/4 \u00e0 7h au 3/5 \u00e0 17h, bus 80 d\u00e9vi\u00e9. Arr\u00eat du bus 80: av. L\u00e9on Grosjean, avant le pont de l'autoroute\", \"nl\": \"Werken. Van 29/4 om 7u tot 3/5 om 17u, bus 80 omgeleid. Halte van bus 80: L\u00e9on Grosjeanlaan, voor brug autostrade\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"80\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"3904\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works.From Apr 29 at 7AM until May 3 at 5PM, bus 80 diverted. Stop B80: ch. Roodebeeksestwg 493.\", \"fr\": \"Travaux. Du 29/4 \u00e0 7h au 3/5 \u00e0 17h, bus 80 d\u00e9vi\u00e9. Arr\u00eat du bus 80: chauss\u00e9e de Roodebeek 493\", \"nl\": \"Werken. Van 29/4 om 7u tot 3/5 om 17u, bus 80 omgeleid. Halte van bus 80: Roodebeeksesteenweg 493\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"80\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"3905\"}, {\"id\": \"3906\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"T81-T97 operate normally againBAREEL and JANSON\", \"fr\": \"T81-T97 circulent \u00e0 nouveau entre BARRIERE et JANSON\", \"nl\": \"T81-T97 worden weer bediend tussen BAREEL en JANSON\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"81\"}]",
+        "priority": 3,
+        "points": "[{\"id\": \"6463F\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"T81-T97 operate normally againBAREEL and JANSON\", \"fr\": \"T81-T97 circulent \u00e0 nouveau entre BARRIERE et JANSON\", \"nl\": \"T81-T97 worden weer bediend tussen BAREEL en JANSON\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"81\"}]",
+        "priority": 3,
+        "points": "[{\"id\": \"2286G\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Until 2026, works. Stop not served. Take tram 82 at FOREST CENTRE / VORST CENTRUM (stop to Drogenbos).\", \"fr\": \"Jusqu'en 2026, travaux. Arr\u00eat non desservi. Prenez le tram 82 \u00e0 FOREST CENTRE (arr\u00eat vers Drogenbos).\", \"nl\": \"Tot 2026, werken. Halte niet bediend. Neem tram 82 aan VORST CENTRUM (halte naar Drogenbos).\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"82\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"5152G\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. Until 2026, stop not served. Walk to DROGENBOS.\", \"fr\": \"Travaux. Jusqu'en 2026, arr\u00eat non desservi. Pour rejoindre DROGENBOS, continuez \u00e0 pied.\", \"nl\": \"Werken. Tot 2026, halte niet bediend. Ga te voet verder om naar DROGENBOS te gaan.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"82\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"5729\"}, {\"id\": \"5725\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. Until 2026, stop not served. T-bus 82 to DROGENBOS at the previous stop, CARREFOUR STALLE.\", \"fr\": \"Travaux. Jusqu'en 2026, arr\u00eat non desservi. T-bus 82 vers DROGENBOS \u00e0 l'arr\u00eat pr\u00e9c\u00e9dent, CARREFOUR STALLE.\", \"nl\": \"Werken. Tot 2026, halte niet bediend. T-bus 82 naar DROGENBOS aan de vorige halte, KRUISPUNT STALLE.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"82\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"5724\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Jan 22, 6AM-end of June, works. B86 diverted. Stop of B86:ch.De Gand/ Gentsestwg, in front of number 219 (Stop B13).\", \"fr\": \"Du 22/1 \u00e0 6h jusqu'\u00e0 fin juin, travaux. Bus 86 d\u00e9vi\u00e9. Arr\u00eat du B86: ch. de Gand, en face du num\u00e9ro 219 (arr\u00eat B13).\", \"nl\": \"Van 22/1 om 6u tot eind juni, werken. Bus 86 omgeleid. Halte van B86: Gentsesteenweg,tegenover nr. 219 (halte bus 13).\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"86\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"6754\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Jan 22, 6AM-end of June, works. Bus 86 diverted. Bus 86 at stop MERCHTEM of bus 20 to GARE DU NORD / NOORDSTATION.\", \"fr\": \"Du 22/1 \u00e0 6h jusqu'\u00e0 fin juin, travaux. Bus 86 d\u00e9vi\u00e9. Bus 86 \u00e0 l'arr\u00eat MERCHTEM du bus 20 vers GARE DU NORD.\", \"nl\": \"Van 22/1 om 6u tot eind juni, werken. Bus 86 omgeleid. B86 aan halte MERCHTEM van bus 20 naar NOORDSTATION.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"86\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"6755\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Mar 3 at 7AM, works. STOP NOT SERVED. Take bus 86 at the next stop DUCHESSE BRABANT / HERTOGIN BRABANT.\", \"fr\": \"D\u00e8s le 3/3 \u00e0 7h, travaux. ARRET NON DESSERVI. Prenez le bus 86 \u00e0 l'arr\u00eat suivant, DUCHESSE BRABANT.\", \"nl\": \"Vanaf 3/3 om 7u, werken. HALTE NIET BEDIEND. Neem bus 86 aan de volgende halte HERTOGIN BRABANT.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"86\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"6706\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Jan 22 at 6AM to end of June, works. Bus 86 diverted. Stop of bus 86: rue A. Vandenpeereboomstraat 44\", \"fr\": \"Du 22/1 \u00e0 6h jusqu'\u00e0 fin juin, travaux. Bus 86 d\u00e9vi\u00e9. Arr\u00eat du bus 86: rue  A. Vandenpeereboom 44.\", \"nl\": \"Van 22/1 om 6u tot eind juni, werken. Bus 86 omgeleid. Halte van bus 86: A. Vandenpeereboomstraat 44\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"86\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"4595\"}, {\"id\": \"1242\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Dec 4, works. STOP NOT SERVED. Stop of bus 88: rue du Progr\u00e8s / Vooruitgangstraat 64.\", \"fr\": \"D\u00e8s le 4/12, travaux. ARRET NON DESSERVI. Arr\u00eat du bus 88: rue du Progr\u00e8s 64.\", \"nl\": \"Vanaf 4/12, werken. HALTE NIET BEDIEND. Halte van bus 88: Vooruitgangstraat 64.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"88\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"3400\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"As of Nov 16 at 6AM, works. Stop moved to av. Port / Havenln, in front of number 100 (moved backward of +/- 120m)\", \"fr\": \"D\u00e8s le 16/11 \u00e0 6h, travaux. Arr\u00eat d\u00e9plac\u00e9 avenue du Port, en face du num\u00e9ro 100 (recul\u00e9 de +/- 120m).\", \"nl\": \"Vanaf 16/11 om 6u,werken Halte verplaatst naar de Havenlaan, tegenover nr 100 (achteruitgebracht van +/- 120m)\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"88\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"2305\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Dec 4, works. STOP NOT SERVED. Stop of bus 58 and 88 : rue du Progr\u00e8s, after crossing rue des Charbonniers.\", \"fr\": \"D\u00e8s le 4/12, travaux. ARRET NON DESSERVI. Arr\u00eat des bus 58 et 88 : rue du Progr\u00e8s, apr\u00e8s rue des Charbonniers.\", \"nl\": \"Vanaf 4/12, werken. HALTE NIET BEDIEND. Halte bus 58 en 88 : Vooruitgangstraat, na Koolbrandersstraat.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"88\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"1083\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Until end of August, works. Bus 89 diverted btw PTE DE NINOVE and BOURSE, and interrupted bt BOURSE and CENTRAL ST\", \"fr\": \"Jsq fin ao\u00fbt, travaux. Bus 89 d\u00e9vi\u00e9 entre PORTE DE NINOVE et BOURSE, et interrompu entre BOURSE et GARE CENTRALE.\", \"nl\": \"Tot einde augustus, werken. Bus 89 omgeleid tss NINOOFSEPOORT en BEURS, en onderbroken tss BEURS en CENTR ST\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"89\"}]",
+        "priority": 5,
+        "points": "[{\"id\": \"2754\"}, {\"id\": \"2776\"}, {\"id\": \"2748B\"}, {\"id\": \"4595\"}, {\"id\": \"1178\"}, {\"id\": \"2784\"}, {\"id\": \"2782\"}, {\"id\": \"6648\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Until end of August 2024, works. Stop not served. Take bus 29 or 71 at DE BROUCKERE to go to CENTRAL STATION.\", \"fr\": \"Jsq fin ao\u00fbt 2024, travaux. Arr\u00eat non desservi. Prenez le bus 29 ou 71 \u00e0 DE BROUCKERE pour GARE CENTRALE.\", \"nl\": \"Tot einde augustus 2024, werken. halte niet bediend. Neem bus 29 of 71 aan DE BROUCKERE om naar CENTR. ST. te gaan\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"89\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"1894\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Until end of August, works. Bus 89 diverted. For the city center, take metro 1 or 5 at STE-CATHERINE.\", \"fr\": \"Jusque fin ao\u00fbt, travaux. Bus 89 d\u00e9vi\u00e9. Pour le centre-ville, prenez le m\u00e9tro 1 ou 5 \u00e0 SAINTE-CATHERINE.\", \"nl\": \"Tot einde augustus, werken. Bus 89 omgeleid. Om naar het stadscentrum te gaan, neem M 1 5 aan SINT-KATELIJNE.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"89\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"3261\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. From Apr 26 at 9PM until May 12, stop not served. Walk to ROI BAUDOUIN / KONING BOUDEWIJN.\", \"fr\": \"Travaux. Du 26/4 \u00e0 21h au 12/5, arr\u00eat non desservi. Pour rejoindre ROI BAUDOUIN, continuez \u00e0 pied.\", \"nl\": \"Werken. Van 26/4 om 21u tot en met 12/5, halte niet bediend. Ga te voet verder naar KONING BOUDEWIJN.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"9\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"1693F\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. From Apr 26 at 9PM until May 12, stop not served. T-bus to UZ BRUSSEL at the stop of bus 820 to UZ BRUSSEL.\", \"fr\": \"Travaux. Du 26/4 \u00e0 21h au 12/5, arr\u00eat non desservi. T-bus vers UZ BRUSSEL \u00e0 l'arr\u00eat du bus 820 vers UZ BRUSSEL.\", \"nl\": \"Werken. 26/4, 21u-12/5, halte niet bediend. T-bus naar UZ BRUSSEL aan de halte van bus 820 naar UZ BRUSSEL.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"9\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"1686F\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. From Apr 26 at 9PM until May 12, stop not served. T-bus to ROI BAUDOUIN at the stop of bus 820 to ZAVENTEM.\", \"fr\": \"Travaux. Du 26/4 \u00e0 21h au 12/5, arr\u00eat non desservi. T-bus vers ROI BAUDOUIN \u00e0 l'arr\u00eat du bus 820 vers ZAVENTEM.\", \"nl\": \"Werken. 26/4, 21u-12/5, halte niet bediend.T-bus naar KONING BOUDEWIJN aan de halte van bus 820 naar ZAVENTEM.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"9\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"1687F\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. From Apr 26 at 9PM until May 12, stop not served. Stop of the T-bus: av. Arbre Ballon / Dikke Beuklaan 117\", \"fr\": \"Travaux. Du 26/4 \u00e0 21h au 12/5, arr\u00eat non desservi. Arr\u00eat du T-bus: avenue de l'Arbre Ballon 117.\", \"nl\": \"Werken. Van 26/4 om 21u tot en met 12/5, halte niet bediend. Halte van de T-bus: Dikke Beuklaan 117.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"9\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"4223F\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Mar 5 at 9AM, works. STOP NOT SERVED. Temporary stop: avenue Jean & Pierre Carsoellaan 4.\", \"fr\": \"D\u00e8s le 5/3 \u00e0 9h, travaux. ARRET NON DESSERVI. Arr\u00eat provisoire: avenue Jean et Pierre Carsoel 4.\", \"nl\": \"Vanaf 5/3 om 9u, werken. HALTE NIET BEDIEND. Tijdelijke halte: Jean en Pierre Carsoellaan 4.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"92\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"6931H\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. As of Mar 27, STOP MOVED. Stop of bus 95: rue des Thuyas / Thujastraat 13.\", \"fr\": \"Travaux. D\u00e8s le 27/3, ARRET DEPLACE. Arr\u00eat du bus 95: rue des Thuyas, 13.\", \"nl\": \"Werken. Vanaf 27/3, HALTE VERPLAATST. Halte van bus 95: Thujastraat 13.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"95\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"4310\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Mar 25 until Jun 30, works. STOP NOT SERVED. Stop of bus 95: bd. Gen. Jacqueslaan 235.\", \"fr\": \"Du 25/3 au 30/6, travaux. ARRET NON DESSERVI. Arr\u00eat du bus 95: boulevard G\u00e9n\u00e9ral Jacques, 235.\", \"nl\": \"Van 25/3 tot en met 30/6, werken. HALTE NIET BEDIEND. Halte van bus 95:  Generaal Jacqueslaan 235.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"95\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"4363\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Mar 18, works. STOP NOT SERVED. stop of bus 95: chauss\u00e9e de Boondael / Boondaalsesteenweg, before roundabout.\", \"fr\": \"D\u00e8s le 18/3, travaux. ARRET NON DESSERVI. Arr\u00eat du bus 95: chauss\u00e9e de Boondael, avant le rond-point.\", \"nl\": \"Vanaf 18/3, werken. HALTE NIET BEDIEND. Halte van bus 95: Boondaalsesteenweg, voor rondpunt.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"95\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"3514\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Mar 18, works. STOP NOT SERVED. Temporary stop: avenue de la Couronne / Kroonlaan 439-443.\", \"fr\": \"D\u00e8s le 18/3, travaux. ARRET NON DESSERVI. Arr\u00eat provisoire: avenue de la Couronne 439-443.\", \"nl\": \"Vanaf 18/3, werken. HALTE NIET BEDIEND. Tijdelijke halte: Kroonlaan 439-443.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"95\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"3558\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"T81-T97 operate normally againBAREEL and JANSON\", \"fr\": \"T81-T97 circulent \u00e0 nouveau entre BARRIERE et JANSON\", \"nl\": \"T81-T97 worden weer bediend tussen BAREEL en JANSON\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"97\"}]",
+        "priority": 3,
+        "points": "[{\"id\": \"5917F\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"T81-T97 operate normally againBAREEL and JANSON\", \"fr\": \"T81-T97 circulent \u00e0 nouveau entre BARRIERE et JANSON\", \"nl\": \"T81-T97 worden weer bediend tussen BAREEL en JANSON\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"97\"}]",
+        "priority": 3,
+        "points": "[{\"id\": \"5163F\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"T81-T97 operate normally againBAREEL and JANSON\", \"fr\": \"T81-T97 circulent \u00e0 nouveau entre BARRIERE et JANSON\", \"nl\": \"T81-T97 worden weer bediend tussen BAREEL en JANSON\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"97\"}]",
+        "priority": 3,
+        "points": "[{\"id\": \"5719H\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"T81-T97 operate normally againBAREEL and JANSON\", \"fr\": \"T81-T97 circulent \u00e0 nouveau entre BARRIERE et JANSON\", \"nl\": \"T81-T97 worden weer bediend tussen BAREEL en JANSON\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"97\"}]",
+        "priority": 3,
+        "points": "[{\"id\": \"5953F\"}, {\"id\": \"6361\"}, {\"id\": \"5120\"}, {\"id\": \"5175\"}, {\"id\": \"6077F\"}, {\"id\": \"5123\"}, {\"id\": \"2604F\"}, {\"id\": \"5158\"}, {\"id\": \"5068F\"}, {\"id\": \"5066F\"}, {\"id\": \"2603\"}, {\"id\": \"2462F\"}, {\"id\": \"6427F\"}, {\"id\": \"9972F\"}, {\"id\": \"6430F\"}, {\"id\": \"5119\"}, {\"id\": \"6109\"}, {\"id\": \"2333F\"}, {\"id\": \"2463F\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"T81-T97 operate normally againBAREEL and JANSON\", \"fr\": \"T81-T97 circulent \u00e0 nouveau entre BARRIERE et JANSON\", \"nl\": \"T81-T97 worden weer bediend tussen BAREEL en JANSON\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"97\"}]",
+        "priority": 3,
+        "points": "[{\"id\": \"2765\"}, {\"id\": \"2764G\"}]"
+    }
+]

--- a/storage/app/samples/2024-05-10-travellers-information-rt-production.json
+++ b/storage/app/samples/2024-05-10-travellers-information-rt-production.json
@@ -1,1 +1,2508 @@
-[{"content": "[{\"text\": [{\"en\": \"Rescue service interv.: T81 is not operated between MEIR and ZUIDSTATION\", \"fr\": \"Interv. serv. de secours : T81 ne circule pas entre MEIR et GARE DU MIDI\", \"nl\": \"Interventie hulpdiensten: T81 rijdt niet tussen MEIR en ZUIDSTATION\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"81\"}]", "priority": 2, "points": "[{\"id\": \"6153\"}, {\"id\": \"6078\"}, {\"id\": \"3611F\"}, {\"id\": \"3123\"}, {\"id\": \"6858G\"}, {\"id\": \"2286G\"}, {\"id\": \"6705F\"}, {\"id\": \"1805F\"}, {\"id\": \"6106\"}, {\"id\": \"6155F\"}, {\"id\": \"6109\"}, {\"id\": \"6462F\"}, {\"id\": \"2331F\"}, {\"id\": \"6120\"}, {\"id\": \"6166\"}, {\"id\": \"6165\"}, {\"id\": \"3610F\"}, {\"id\": \"2539F\"}, {\"id\": \"3371F\"}, {\"id\": \"6808G\"}, {\"id\": \"6162\"}, {\"id\": \"2671F\"}, {\"id\": \"6427F\"}, {\"id\": \"2380F\"}, {\"id\": \"6117\"}, {\"id\": \"2259F\"}, {\"id\": \"6463F\"}, {\"id\": \"6156F\"}, {\"id\": \"2336G\"}, {\"id\": \"3608\"}, {\"id\": \"6175\"}, {\"id\": \"6099\"}, {\"id\": \"6121F\"}, {\"id\": \"6113F\"}, {\"id\": \"3613F\"}, {\"id\": \"6809F\"}, {\"id\": \"1042\"}, {\"id\": \"3370F\"}, {\"id\": \"3572F\"}, {\"id\": \"2220F\"}, {\"id\": \"2260F\"}, {\"id\": \"6799F\"}, {\"id\": \"6860G\"}, {\"id\": \"6157F\"}, {\"id\": \"2931F\"}, {\"id\": \"6009\"}, {\"id\": \"6008\"}, {\"id\": \"2971F\"}, {\"id\": \"6077F\"}, {\"id\": \"3612F\"}, {\"id\": \"6068\"}, {\"id\": \"6114F\"}, {\"id\": \"2218F\"}, {\"id\": \"2285G\"}, {\"id\": \"0631\"}, {\"id\": \"6425F\"}, {\"id\": \"6810\"}, {\"id\": \"2217F\"}, {\"id\": \"6158H\"}, {\"id\": \"6856\"}, {\"id\": \"6811\"}, {\"id\": \"3508F\"}, {\"id\": \"2257G\"}, {\"id\": \"6857\"}, {\"id\": \"3609F\"}, {\"id\": \"6792F\"}, {\"id\": \"2960F\"}, {\"id\": \"2972F\"}, {\"id\": \"0636\"}]"},{"content": "[{\"text\": [{\"en\": \"T81 is operated again between MEIR and ZUIDSTATION\", \"fr\": \"T81 circule \u00e0 nouveau entre MEIR et GARE DU MIDI\", \"nl\": \"T81 wordt weer bediend tussen MEIR en ZUIDSTATION\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"81\"}]", "priority": 2, "points": "[{\"id\": \"6153\"}, {\"id\": \"6078\"}, {\"id\": \"3611F\"}, {\"id\": \"3123\"}, {\"id\": \"6858G\"}, {\"id\": \"2286G\"}, {\"id\": \"6705F\"}, {\"id\": \"1805F\"}, {\"id\": \"6106\"}, {\"id\": \"6155F\"}, {\"id\": \"6109\"}, {\"id\": \"6462F\"}, {\"id\": \"2331F\"}, {\"id\": \"6120\"}, {\"id\": \"6166\"}, {\"id\": \"6165\"}, {\"id\": \"3610F\"}, {\"id\": \"2539F\"}, {\"id\": \"3371F\"}, {\"id\": \"6808G\"}, {\"id\": \"6162\"}, {\"id\": \"2671F\"}, {\"id\": \"6427F\"}, {\"id\": \"2380F\"}, {\"id\": \"6117\"}, {\"id\": \"2259F\"}, {\"id\": \"6463F\"}, {\"id\": \"6156F\"}, {\"id\": \"2336G\"}, {\"id\": \"3608\"}, {\"id\": \"6175\"}, {\"id\": \"6099\"}, {\"id\": \"6121F\"}, {\"id\": \"6113F\"}, {\"id\": \"3613F\"}, {\"id\": \"6809F\"}, {\"id\": \"1042\"}, {\"id\": \"3370F\"}, {\"id\": \"3572F\"}, {\"id\": \"2220F\"}, {\"id\": \"2260F\"}, {\"id\": \"6799F\"}, {\"id\": \"6860G\"}, {\"id\": \"6157F\"}, {\"id\": \"2931F\"}, {\"id\": \"6009\"}, {\"id\": \"6008\"}, {\"id\": \"2971F\"}, {\"id\": \"6077F\"}, {\"id\": \"3612F\"}, {\"id\": \"6068\"}, {\"id\": \"6114F\"}, {\"id\": \"2218F\"}, {\"id\": \"2285G\"}, {\"id\": \"0631\"}, {\"id\": \"6425F\"}, {\"id\": \"6810\"}, {\"id\": \"2217F\"}, {\"id\": \"6158H\"}, {\"id\": \"6856\"}, {\"id\": \"6811\"}, {\"id\": \"3508F\"}, {\"id\": \"2257G\"}, {\"id\": \"6857\"}, {\"id\": \"3609F\"}, {\"id\": \"6792F\"}, {\"id\": \"2960F\"}, {\"id\": \"2972F\"}, {\"id\": \"0636\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. As of Apr 15, STOP NOT SERVED. Stop of bus 12: rue Archim\u00e8de / Archimedesstraat 16.\", \"fr\": \"Travaux. D\u00e8s le 15/4, ARRET NON DESSERVI. Arr\u00eat du bus 12: rue Archim\u00e8de 16.\", \"nl\": \"Werken. Vanaf 15/4, HALTE NIET BEDIEND. Halte van bus 12: Archimedesstraat 16.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"12\"}]", "priority": 4, "points": "[{\"id\": \"1418B\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. From Apr 23 until Jun 2, bus 13 and 88 diverted. Take bus 13 or 88 at the stop of bus 820 to UZ Brussel.\", \"fr\": \"Travaux; Du 23/4 au 2/6, bus 13 et 88 d\u00e9vi\u00e9s. Prenez le bus 13 ou 88 \u00e0 l'arr\u00eat du bus 820 vers UZ Brussel.\", \"nl\": \"Werken. Van 23/4 tot en met 2/6, bus 13 en 88 omgeleid. Neem bus 13 of 88 aan de halte van bus 820 naar UZ Brussel.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"13\"}]", "priority": 4, "points": "[{\"id\": \"1721\"}, {\"id\": \"1328\"}]"},{"content": "[{\"text\": [{\"en\": \"From Sep 5 6AM, works. STOP NOT SERVED. Temporary stop: rue du Brillant (across stop towards Heiligenborre)\", \"fr\": \"D\u00e8s le 5/9 6h, travaux. ARRET NON DESSERVI. Arr\u00eat provisoire: rue du Brillant (face \u00e0 l'arr\u00eat vers Heiligenborre)\", \"nl\": \"Vanaf 5/9 6u, werken. HALTE NIET BEDIEND. Tijdelijke halte: Briljantstraat (tgnover halte > Heiligenborre)\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"17\"}]", "priority": 4, "points": "[{\"id\": \"4293\"}]"},{"content": "[{\"text\": [{\"en\": \"From Sep 5 6AM, works. STOP NOT SERVED. Bus 17 diverted between BRILLANT and BEAULIEU via Michiels\", \"fr\": \"D\u00e8s le 5/9 6h, travaux. ARRET NON DESSERVI. Bus 17 d\u00e9vi\u00e9 entre BRILLANT et BEAULIEU via Michiels\", \"nl\": \"Vanaf 5/9 6u, werken. HALTE NIET BEDIEND. Bus 17 omgeleid tussen BRILJANT en BEAULIEU via Michiels\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"17\"}]", "priority": 4, "points": "[{\"id\": \"4295\"}, {\"id\": \"4296\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. Until mid-2024, T19 replaced by T-bus between MIROIR and CIMETIERE DE JETTE.\", \"fr\": \"Travaux. Jusque mi-2024, tram 19 remplac\u00e9 par des T-bus entre MIROIR et CIMETIERE DE JETTE.\", \"nl\": \"Werken. Tot midden 2024, tram 19 vervangen door T-bus tussen SPIEGEL en KERKHOF VAN JETTE.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"19\"}]", "priority": 5, "points": "[{\"id\": \"1306F\"}, {\"id\": \"5105F\"}, {\"id\": \"1094F\"}, {\"id\": \"1111\"}, {\"id\": \"5104F\"}, {\"id\": \"5103\"}, {\"id\": \"5102F\"}, {\"id\": \"1064\"}, {\"id\": \"5108\"}, {\"id\": \"5109\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. Until mid-2024, T19 interrupted at MIROIR. Stop of T-bus 19: av. Jette 126 (next to this stop)\", \"fr\": \"Travaux. Jusque mi-2024, T19 interrompu \u00e0 MIROIR. Arr\u00eat du T-bus 19: av. de Jette, 126 (\u00e0 c\u00f4t\u00e9 de cet arr\u00eat).\", \"nl\": \"Werken. Tot midden 2024, T19 onderbroken aan SPIEGEL. Halte van T-bus 19: Jetselaan 126 (naast deze halte)\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"19\"}]", "priority": 4, "points": "[{\"id\": \"6864F\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. Until mid-2024, T19 replaced by T-bus btw MIROIR and CIMETIERE DE JETTE. T-bus at stop of bus 13 to UZ-VUB.\", \"fr\": \"Travaux. Jsq mi-2024, T19 remplac\u00e9 par T-bus entre MIROIR et CIM. JETTE. T-bus \u00e0 l'arr\u00eat du bus 13 vers UZ-VUB.\", \"nl\": \"Werken. Tot midden 2024, T19 vervangen door T-bus tss SPIEGEL en KERKH. JETTE.  T-bus aan halte van B13 naar UZ-VUB.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"19\"}]", "priority": 4, "points": "[{\"id\": \"0471\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. From May 8 at 9PM until May 12, tram 19 does not serve this stop. To go to DE WAND, take tram 7.\", \"fr\": \"Travaux. Du 8/5 \u00e0 21h au 12/5, tram 19 ne dessert pas cet arr\u00eat. Pour DE WAND, prenez le tram 7.\", \"nl\": \"Werken. Van 8/5 om 21u tot 12/5 bedient tram 19 deze halte niet. Om naar DE WAND te gaan, neem tram 7.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"19\"}]", "priority": 4, "points": "[{\"id\": \"2636F\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. Until mid-2024, stop not served. Take tram 19 at CIMETIERE DE JETTE / KERKHOF VAN JETTE.\", \"fr\": \"Travaux. Jusque mi-2024, arr\u00eat non desservi. Prenez le tram 19 \u00e0 CIMETIERE DE JETTE.\", \"nl\": \"Werken. Tot midden 2024, halte niet bediend. Neem tram 19 aan KERKHOF VAN JETTE.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"19\"}]", "priority": 4, "points": "[{\"id\": \"6869G\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. May 8, 9PM-May 12, tram 19 replaced by a T-bus to DE WAND.T-bus at PR. LEOPOLD (stop of bus 88 to UZ-VUB).\", \"fr\": \"Travaux. 8/5, 21h-12/5, tram 19 remplac\u00e9 par des T-bus jsq DE WAND. T-bus \u00e0 PRINCE LEOPOLD (arr\u00eat du bus 88 vers UZ-VUB).\", \"nl\": \"Werken. 8/5, 21u-12/5, tram 19 vervangen door T-bus tot DE WAND. T-bus aan PRINS LEOPOLD (halte van bus 88 naar UZ-VUB)\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"19\"}]", "priority": 4, "points": "[{\"id\": \"5082\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. Until mid-2024, stop not served. T-bus at VERBEYST (bd de Smet de Naeyer 211, stop of bus 14 to GARE DU NORD).\", \"fr\": \"Travaux, jusque mi-2024, arr\u00eat non desservi.T-bus \u00e0 VERBEYST (bd de Smet de Naeyer 211, arr\u00eat B14 vers GARE DU NORD).\", \"nl\": \"Werken. Tot midden 2024, halte niet bediend. T-bus aan VERBEYST (de Smet de Naeyerlaan 211, halte B14 naar NOORDST.)\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"19\"}]", "priority": 4, "points": "[{\"id\": \"6803F\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. May 8, 9PM-May 12, STOP NOT SERVED. T-bus to SIMONIS at CIM. / KERKH. JETTE, via bus 88 from PR. LEOPOLD.\", \"fr\": \"Travaux. 8/5, 21h-12/5, ARRET NON DESSERVI. T-bus vers SIMONIS \u00e0 CIM. JETTE, via bus 88 depuis PRINCE LEOPOLD.\", \"nl\": \"Werken. 8/5, 21u-12/5, HALTE NIET BEDIEND. T-bus naar SIMONIS aan KERKH. JETTE, via bus 88 vanaf PRINS LEOPOLD.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"19\"}]", "priority": 4, "points": "[{\"id\": \"4955F\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. As of Apr 15, STOP NOT SERVED. Stop of bus 21: rue Franklinstraat 2a.\", \"fr\": \"Travaux. D\u00e8s le 15/4, ARRET NON DESSERVI. Arr\u00eat du bus 21: rue Franklin, 2a.\", \"nl\": \"Werken. Vanaf 15/4, HALTE NIET BEDIEND. Halte van bus 21: Franklinstraat 2a.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"21\"}]", "priority": 4, "points": "[{\"id\": \"1270B\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. As of Apr 15, bus 21 diverted. Take bus 21 at the stop of bus 64 to BORDET STATION.\", \"fr\": \"Travaux. D\u00e8s le 15/4, bus 21 d\u00e9vi\u00e9. Prenez le bus 21 \u00e0 l'arr\u00eat du bus 64 vers BORDET STATION.\", \"nl\": \"Werken. Vanaf 15/4, bus 21 omgeleid. Neem bus 21 aan de halte van bus 64 naar BORDET STATION.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"21\"}]", "priority": 4, "points": "[{\"id\": \"1133\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. As of Apr 15, STOP NOT SERVED. Take bus 21 at MAELBEEK / MAALBEEK (stop of bus 64 to BORDET STATION).\", \"fr\": \"Travaux. D\u00e8s le 15/4, ARRET NON DESSERVI. Prenez le bus 21 \u00e0 MAELBEEK (halte van bus 64 naar BORDET STATION).\", \"nl\": \"Werken. Vanaf 15/4, HALTE NIET BEDIEND. Neem bus 21 aan MAALBEEK (arr\u00eat du bus 64 vers BORDET STATION).\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"21\"}]", "priority": 4, "points": "[{\"id\": \"1416\"}]"},{"content": "[{\"text\": [{\"en\": \"From Jan 7 at 9PM to Jun 28, works. Terminus not served. Stop of the T-bus: av. de Meysse, in front of number 125.\", \"fr\": \"Du 7/1 \u00e0 21h au 28/6, travaux. Terminus non desservi. Arr\u00eat du T-bus: avenue de Meysse, en face du num\u00e9ro 125.\", \"nl\": \"7/1, 21u-28/6, werken. Eindpunt niet bediend. Halte van de T-bus: Meiseselaan, tegenover nummer 125.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"3\"}]", "priority": 4, "points": "[{\"id\": \"5701\"}]"},{"content": "[{\"text\": [{\"en\": \"Jan 7, 9PM-Jun 28, works. Stop not served. T-bus to ESPLANADE at the stop of bus 56 to BUDA.\", \"fr\": \"7/1, 21h-28/6, travaux. Arr\u00eat non desservi. T-bus vers ESPLANADE \u00e0 l'arr\u00eat du bus 56 vers BUDA.\", \"nl\": \"7/1, 21u-28/6, werken. Halte niet bediend. T-bus naar ESPLANADE aan de halte van bus 56 naar BUDA.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"3\"}]", "priority": 4, "points": "[{\"id\": \"5770F\"}]"},{"content": "[{\"text\": [{\"en\": \"Jan 7, 9PM-Jun 28,works. Tram 3 interrupted btw ESPLANADE and DOCKS BRUXSEL. Stop of the T-bus: next to this stop\", \"fr\": \"7/1, 21h-28/6, travaux. Tram 3 interrompu entre ESPLANADE et DOCKS BRUXSEL. Arr\u00eat du T-bus: \u00e0 c\u00f4t\u00e9 de cet arr\u00eat.\", \"nl\": \"7/1, 21u-28/6, werken. Tram 3 onderbroken tss ESPLANADE en DOCKS BRUXSEL. Halte van de T-bus: naast deze halte.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"3\"}]", "priority": 4, "points": "[{\"id\": \"5705\"}]"},{"content": "[{\"text\": [{\"en\": \"Jan 7, 9PM-Jun 28,works. Tram 3 interrupted btw ESPLANADE and DOCKS BRUXSEL. T-bus at stop of bus 83 to VAL MARIA\", \"fr\": \"7/1, 21h-28/6, travaux. Tram 3 interrompu entre ESPLANADE et DOCKS BRUXSEL. T-bus \u00e0 l'arr\u00eat du bus 83 vers VAL MARIA\", \"nl\": \"7/1, 21u-28/6, werken. Tram 3 onderbroken tss ESPLANADE en DOCKS BRUXSEL. T-bus halte van bus 83 naar MARI\u00cbNDAAL.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"3\"}]", "priority": 4, "points": "[{\"id\": \"5700G\"}]"},{"content": "[{\"text\": [{\"en\": \"Jan 7, 9PM-Jun 28, works. Tram 3 replaced by T-bus between DOCKS BRUXSEL and ESPLANADE. Info: stib-mivb.brussels\", \"fr\": \"7/1, 21h-28/6, travaux. Tram 3 remplac\u00e9 par des T-bus entre DOCKS BRUXSEL et ESPLANADE. Info: stib.brussels.\", \"nl\": \"7/1, 21u-28/6, werken. Tram 3 vervangen door T-bus tussen DOCKS BRUXSEL en ESPLANADE. info: mivb.brussels.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"3\"}]", "priority": 5, "points": "[{\"id\": \"5219F\"}, {\"id\": \"6179\"}, {\"id\": \"2537F\"}, {\"id\": \"0722\"}, {\"id\": \"9986F\"}, {\"id\": \"6424F\"}, {\"id\": \"0606\"}, {\"id\": \"6177F\"}, {\"id\": \"0626\"}, {\"id\": \"0516\"}, {\"id\": \"6209\"}, {\"id\": \"0725\"}, {\"id\": \"0726\"}, {\"id\": \"0616\"}, {\"id\": \"0506\"}, {\"id\": \"2200F\"}, {\"id\": \"0723\"}, {\"id\": \"0526\"}, {\"id\": \"0724\"}]"},{"content": "[{\"text\": [{\"en\": \"From Jan 15, works. STOP NOT SERVED. Take bus 34 at the stop RO(O)DENBERG of bus 72 to ADEPS.\", \"fr\": \"D\u00e8s le 15/1, travaux. ARRET NON DESSERVI. Prenez le bus 34 \u00e0 l'arr\u00eat ROODENBERG du bus 72 vers ADEPS.\", \"nl\": \"Vanaf 15/1, werken. HALTE NIET BEDIEND. Neem bus 34 aan de halte RODENBERG van bus 72 naar ADEPS.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"34\"}]", "priority": 4, "points": "[{\"id\": \"1720B\"}]"},{"content": "[{\"text\": [{\"en\": \"From Jan 15, works. STOP NOT SERVED. Stop of bus 34: boulevard du Souverain / Vorstlaan 159.\", \"fr\": \"D\u00e8s le 15/1, travaux. ARRET NON DESSERVI. Arr\u00eat du bus 34: boulevard du Souverain 159.\", \"nl\": \"Vanaf 15/1, werken. HALTE NIET BEDIEND. Halte van bus 34: Vorstlaan 159.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"34\"}]", "priority": 4, "points": "[{\"id\": \"1731\"}]"},{"content": "[{\"text\": [{\"en\": \"From Jan 15, works. Bus 34 diverted between HANKAR and BERGOJE via DEMEY.\", \"fr\": \"D\u00e8s le 15/1, travaux. Bus 34 d\u00e9vi\u00e9 entre HANKAR et BERGOJE via DEMEY.\", \"nl\": \"Vanaf 15/1, werken. Bus 34 omgeleid tussen HANKAR en BERGOJE via DEMEY.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"34\"}]", "priority": 5, "points": "[{\"id\": \"6433\"}, {\"id\": \"1712\"}, {\"id\": \"1733\"}, {\"id\": \"2291B\"}, {\"id\": \"1233\"}, {\"id\": \"1729\"}, {\"id\": \"1728\"}, {\"id\": \"1706\"}, {\"id\": \"1716\"}, {\"id\": \"1715\"}, {\"id\": \"1714\"}, {\"id\": \"1824\"}, {\"id\": \"1713\"}]"},{"content": "[{\"text\": [{\"en\": \"From Apr 3 at 6AM, works. Bus 38 diverted between LONGCHAMP and HOUZEAU via rue Edith Cavellstraat.\", \"fr\": \"D\u00e8s le 3/4 \u00e0 6h, travaux. Bus 38 d\u00e9vi\u00e9 entre LONGCHAMP et HOUZEAU via rue Edith Cavell.\", \"nl\": \"Vanaf 3/4 om 6u, werken. Bus 38 omgeleid tussen LONGCHAMP en HOUZEAU via Edith Cavellstraat.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"38\"}]", "priority": 5, "points": "[{\"id\": \"1916\"}, {\"id\": \"1915\"}]"},{"content": "[{\"text\": [{\"en\": \"From Apr 3 at 6AM, works. STOP NOT SERVED. Bus 38 at GOSSART (avenue Winston Churchilllaan 187).\", \"fr\": \"D\u00e8s le 3/4 \u00e0 6h, travaux. ARRET NON DESSERVI. Bus 38 \u00e0 GOSSART (avenue Winston Churchill 187).\", \"nl\": \"Vanaf 3/4 om 6u, werken. HALTE NIET BEDIEND. Bus 38 aan GOSSART (Winston Churchilllaan 187).\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"38\"}]", "priority": 4, "points": "[{\"id\": \"1972\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. As of April 7th, bus 38 diverted. Take bus 38 at the next stop, ROYALE / KONING.\", \"fr\": \"Travaux. D\u00e8s le 7/4, bus 38 d\u00e9vi\u00e9. Prenez le bus 38 \u00e0 l'arr\u00eat suivant, ROYALE.\", \"nl\": \"Werken. Vanaf 7/4, bus 38 omgeleid. Neem bus 38 aan de volgende halte, KONING.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"38\"}]", "priority": 4, "points": "[{\"id\": \"3502\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. As of Apr 29, STOP NOT SERVED. Stop of bus 38: WASHINGTON (stop of bus 60 to UCCLE CALEVOET).\", \"fr\": \"Travaux. D\u00e8s le 29/4, ARRET NON DESSERVI. Arr\u00eat du bus 38: WASHINGTON (arr\u00eat du bus 60 vers UCCLE CALEVOET)\", \"nl\": \"Werken. Vanaf 29/4,HALTE NIET BEDIEND. Halte van bus 38: WASHINGTON (halte van bus 60 naar UKKEL KALEVOET)\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"38\"}]", "priority": 4, "points": "[{\"id\": \"1913\"}]"},{"content": "[{\"text\": [{\"en\": \"From Apr 3 at 6AM, works. STOP NOT SERVED. Take bus 38 and 41 at the previous stop, HOUZEAU.\", \"fr\": \"D\u00e8s le 3/4 \u00e0 6h, travaux. ARRET NON DESSERVI. Prenez les bus 38 et 41 \u00e0 l'arr\u00eat pr\u00e9c\u00e9dent, HOUZEAU.\", \"nl\": \"Vanaf 3/4 om 6u, werken. HALTE NIET BEDIEND. Neem bus 38 en 41 aan de vorige halte, HOUZEAU.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"38\"}]", "priority": 4, "points": "[{\"id\": \"1970\"}]"},{"content": "[{\"text\": [{\"en\": \"From Apr 3 at 6AM, works. STOP NOT SERVED. Bus 38 at GOSSART (avenue Winston Churchilllaan 202).\", \"fr\": \"D\u00e8s le 3/4 \u00e0 6h, travaux. ARRET NON DESSERVI. Bus 38 \u00e0 GOSSART (avenue Winston Churchill 202).\", \"nl\": \"Vanaf 3/4 om 6u, werken. HALTE NIET BEDIEND. Bus 38 aan GOSSART (Winston Churchilllaan 202).\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"38\"}]", "priority": 4, "points": "[{\"id\": \"1918\"}]"},{"content": "[{\"text\": [{\"en\": \"From Apr 3 at 6AM, works. STOP NOT SERVED. Temporary stop: chauss\u00e9e de Waterloosesteenweg 803, stop De Fr\u00e9 of TEC.\", \"fr\": \"D\u00e8s 3/4 \u00e0 6h, travaux. ARRET NON DESSERVI. Arr\u00eat provisoire: ch. de Waterloo 803, arr\u00eat De Fr\u00e9 des TEC.\", \"nl\": \"Vanaf 3/4 om 6u, werken. HALTE NIET BEDIEND. Tijdelijke halte: Waterloosesteenweg 803, halte De Fr\u00e9 van TEC.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"41\"}]", "priority": 5, "points": "[{\"id\": \"2763\"}]"},{"content": "[{\"text\": [{\"en\": \"From Apr 3 at 6AM, works. STOP NOT SERVED. Temporary stop: chauss\u00e9e de Waterloosesteenweg 965, stop of TEC.\", \"fr\": \"D\u00e8s le 3/4 \u00e0 6h, travaux. ARRET NON DESSERVI. Arr\u00eat provisoire: chauss\u00e9e de Waterloo 965, arr\u00eat TEC.\", \"nl\": \"Vanaf 3/4 om 6u, werken. HALTE NIET BEDIEND. Tijdelijke halte: Waterloosesteenweg 965, halte van TEC.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"41\"}]", "priority": 5, "points": "[{\"id\": \"2714\"}]"},{"content": "[{\"text\": [{\"en\": \"From Apr 3 at 6AM, works. Bus 41 diverted between VERT CHASSEUR / GROENE JAGER and HOUZEAU via rue Edith Cavell.\", \"fr\": \"D\u00e8s le 3/4 \u00e0 6h, travaux. Bus 41 d\u00e9vi\u00e9 entre VERT CHASSEUR et HOUZEAU via rue Edith Cavell.\", \"nl\": \"Vanaf 3/4 om 6u, werken. Bus 41 omgeleid tussen GROENE JAGER en HOUZEAU via Edith Cavellstraat.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"41\"}]", "priority": 5, "points": "[{\"id\": \"5451\"}, {\"id\": \"4452\"}, {\"id\": \"4454\"}, {\"id\": \"2107\"}, {\"id\": \"2018\"}, {\"id\": \"1754\"}, {\"id\": \"1753\"}, {\"id\": \"2016\"}, {\"id\": \"1752\"}, {\"id\": \"2762\"}, {\"id\": \"2079\"}, {\"id\": \"4455\"}, {\"id\": \"4456\"}, {\"id\": \"6468\"}, {\"id\": \"5458\"}, {\"id\": \"4358\"}, {\"id\": \"5459\"}, {\"id\": \"6439\"}, {\"id\": \"4449\"}, {\"id\": \"1725\"}, {\"id\": \"4407\"}]"},{"content": "[{\"text\": [{\"en\": \"From Mar 4, works. Bus 43 and N11 diverted. Weekdays before 8PM: B43 at BRAVES. Otherwise: bus at GRIOTTES.\", \"fr\": \"D\u00e8s le 4/3, travaux. Bus 43 et N11 d\u00e9vi\u00e9s. En semaine avant 20h: B43 \u00e0 BRAVES. Autres moments: bus \u00e0 GRIOTTES.\", \"nl\": \"Vanaf 4/3, werken. Bus 43 en N11 omgeleid. Weekdagen voor 20u: B43 aan DAPPEREN. Anders: bus aan NOORDKRIEKEN.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"43\"}]", "priority": 4, "points": "[{\"id\": \"1963\"}]"},{"content": "[{\"text\": [{\"en\": \"Enjoy your trip on our lines !\", \"fr\": \"Bon voyage sur nos lignes !\", \"nl\": \"Geniet van uw reis op onze lijnen !\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"44\"}]", "priority": 9, "points": "[{\"id\": \"9552\"}]"},{"content": "[{\"text\": [{\"en\": \"Until end of August 2024, works. Stop not served. Walk to WTC-GLIBERT.\", \"fr\": \"Jusque fin ao\u00fbt 2024, travaux. Arr\u00eat non desservi. Continuez \u00e0 pied pour WTC-GLIBERT.\", \"nl\": \"Tot einde augustus 2024, werken. halte niet bediend. Ga te voet verder om naar WTC-GLIBERT te gaan.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"46\"}]", "priority": 4, "points": "[{\"id\": \"1894\"}]"},{"content": "[{\"text\": [{\"en\": \"Until end of August, works. Bus 46 interrupted. Take bus 46 at ANNEESSENS (via bus 33).\", \"fr\": \"Jusque fin ao\u00fbt, travaux. Bus 46 interrompu. Prenez le bus 46 \u00e0 ANNEESSENS (via bus 33).\", \"nl\": \"Tot einde augustus, werken. Bus 46 onderbroken. Neem bus 46 aan ANNEESSENS (via bus 33).\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"46\"}]", "priority": 4, "points": "[{\"id\": \"1895\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. Until end of August, B46 not operated btw WTC-GLIBERT and PTE ANDERLECHT. For the center, bus 88 at WTC.\", \"fr\": \"Travaux. Jsq fin ao\u00fbt, B46 ne circule pas entre WTC-GLIBERT et PORTE D'ANDERLECHT. Pour le centre, bus 88 \u00e0 WTC.\", \"nl\": \"Werken. Tot einde augustus rijdt bus 46 niet tss WTC-GLIBERT en ANDERLECHTSEPT. Voor het centrum,neem B88 aan WTC\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"46\"}]", "priority": 5, "points": "[{\"id\": \"9025\"}, {\"id\": \"1896\"}, {\"id\": \"2209\"}]"},{"content": "[{\"text\": [{\"en\": \"Until Summer of 2024, works. Stop not served. Take bus 47 at the stop of bus 56 to BUDA.\", \"fr\": \"Jusqu'\u00e0 l'\u00e9t\u00e9 2024, travaux. Arr\u00eat non desservi. Prenez le bus 47 \u00e0 l'arr\u00eat du bus 56 vers BUDA.\", \"nl\": \"Tot zomer 2024, werken. Halte niet bediend. Neem bus 47 aan de halte van bus 56 naar BUDA.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"47\"}]", "priority": 4, "points": "[{\"id\": \"2358\"}]"},{"content": "[{\"text\": [{\"en\": \"From Oct 18 9.30AM, stop not served. Go to the previous stop : HELDENPLEIN.\", \"fr\": \"A partir du 18/10 9h30, arr\u00eat non desservi. Rejoignez l'arr\u00eat pr\u00e9c\u00e9dent : HELDENPLEIN.\", \"nl\": \"Vanaf 18/10 9u30, halte niet bediend. Ga naar de vorige halte HELDENPLEIN.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"47\"}]", "priority": 4, "points": "[{\"id\": \"9787\"}]"},{"content": "[{\"text\": [{\"en\": \"Until Summer of 2024, works. As of Mar 4, stop of bus 47: Military Area, stop of bus 57 to GARE DU NORD.\", \"fr\": \"Jsq \u00e9t\u00e9 2024, travaux. D\u00e8s le 4/3, arr\u00eat du bus 47 : Domaine Militaire, arr\u00eat du bus 57 vers GARE DU NORD.\", \"nl\": \"Tot zomer 2024, werken. Vanaf 4/3, halte van bus 47: Militair Domein, halte van bus 57 naar NOORDSTATION..\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"47\"}]", "priority": 4, "points": "[{\"id\": \"3068\"}]"},{"content": "[{\"text\": [{\"en\": \"Until Summer of 2024, works. Stop of bus 47: rue de Ransbeekstraat 201.\", \"fr\": \"Jusqu'\u00e0 l'\u00e9t\u00e9 2024, travaux. Arr\u00eat du bus 47: rue de Ransbeek 201.\", \"nl\": \"Tot zomer 2024, werken. Halte van bus 47: Ransbeekstraat 201.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"47\"}]", "priority": 4, "points": "[{\"id\": \"2360\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. STOP NOT SERVED. B47: at the stop CROIX DE GUERRE of B56 (av. des Croix de Guerre)\", \"fr\": \"Travaux. ARRET NON DESSERVI. B47 : \u00e0 l'arr\u00eat CROIX DE GUERRE du B56 (av. des Croix de Guerre)\", \"nl\": \"Werken. HALTE NIET BEDIEND. B47: aan de halte OORLOGSKRUISEN van B56 (Oorlogskruisenlaan)\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"47\"}]", "priority": 4, "points": "[{\"id\": \"2362B\"}]"},{"content": "[{\"text\": [{\"en\": \"Until Summer of 2024, works. Stop not served. Take bus 47 or 57 at ANTOON VAN OSS (stop of bus 56 to BUDA).\", \"fr\": \"Jsq \u00e9t\u00e9 2024, travaux. Arr\u00eat non desservi. Prenez le bus 47 ou 57 \u00e0 ANTOON VAN OSS (arr\u00eat du bus 56 vers BUDA).\", \"nl\": \"Tot zomer 2024, werken. Halte niet bediend. Neem bus 47 of 57 aan ANTOON VAN OSS (halte van bus 56 naar BUDA).\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"47\"}]", "priority": 4, "points": "[{\"id\": \"1837\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. Until 2026, tram 82 and 97 interrupted. Stop of the T-bus and of bus 50: ch. de Neerstalsestwg 236.\", \"fr\": \"Travaux. Jsq 2026, tram 82 et 97 interrompus. Arr\u00eat du T-bus et du bus 50: chauss\u00e9e de Neerstalle 236\", \"nl\": \"Werken. Tot 2026, tram 82 en 97 onderbroken. Halte van de T-bus en van bus 50: Neerstalsesteenweg 236\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"50\"}]", "priority": 4, "points": "[{\"id\": \"3604\"}]"},{"content": "[{\"text\": [{\"en\": \"Until 2026, works. Bus 50 and T-bus diverted between FOREST CENTRE / VORST CENTRUM and BEMPT.\", \"fr\": \"Jusqu'en 2026, travaux. Bus 50 et T-bus d\u00e9vi\u00e9s entre FOREST CENTRE et BEMPT.\", \"nl\": \"Tot 2026, werken. Bus 50 en T-bus omgeleid tussen VORST CENTRUM en BEMPT.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"50\"}]", "priority": 5, "points": "[{\"id\": \"5915\"}, {\"id\": \"2548\"}, {\"id\": \"2546\"}, {\"id\": \"2544\"}, {\"id\": \"2555\"}, {\"id\": \"1015\"}, {\"id\": \"2553\"}, {\"id\": \"3211\"}, {\"id\": \"2539\"}]"},{"content": "[{\"text\": [{\"en\": \"Until 2026, works. Bus 50 diverted. Stop bus 50: bd 2e Arm\u00e9e Britannique / Britse Tweedelegerlaan.\", \"fr\": \"Jsq 2026, travaux. Bus 50 d\u00e9vi\u00e9. Arr\u00eat bus 50: bd 2e Arm\u00e9e Britannique, carrefour rue de la Station.\", \"nl\": \"Tot 2026, werken. Bus 50 omgeleid. Halte bus 50: Britse Tweedelegerlaan, kruispunt Stationstraat.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"50\"}]", "priority": 4, "points": "[{\"id\": \"5719\"}]"},{"content": "[{\"text\": [{\"en\": \"From May 18, 5AM, works. STOP NOT SERVED. Stop of bus 52: avenue du Parc / Parklaan 26, in front of number 26.\", \"fr\": \"D\u00e8s le 18/5, 5h, travaux. ARRET NON DESSERVI. Arr\u00eat du bus 52: avenue du Parc, en face du num\u00e9ro 26.\", \"nl\": \"Vanaf 18/5, 5u, werken. HALTE NIET BEDIEND. Halte van bus 52: Parklaan, tegenover nummer 26.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"52\"}]", "priority": 4, "points": "[{\"id\": \"2334B\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. As of Apr 15 at 6AM, STOP NOT SERVED. Take bus 53 at BEYSEGHEM / BEIZEGEM.\", \"fr\": \"Travaux. D\u00e8s le 15/4 \u00e0 6h, ARRET NON DESSERVI. Prenez le bus 53 \u00e0 BEYSEGHEM.\", \"nl\": \"Werken. Vanaf 15/4 om 6u, HALTE NIET BEDIEND. Neem bus 53 aan BEIZEGEM.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"53\"}]", "priority": 4, "points": "[{\"id\": \"2819\"}]"},{"content": "[{\"text\": [{\"en\": \"Until Summer of 2024, works. Stop not served. Stop of bus 53: place Peter Benoitplein 3\", \"fr\": \"Jusqu'\u00e0 l'\u00e9t\u00e9 2024, travaux. Arr\u00eat non desservi. Arr\u00eat du bus 53 : place Peter Benoit 3\", \"nl\": \"Tot zomer 2024, werken. Halte niet bediend. Halte van bus 53: Peter Benoitplein 3\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"53\"}]", "priority": 4, "points": "[{\"id\": \"2362B\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. As of Apr 15 at 6AM, STOP NOT SERVED. Take bus 53 at BEYSEGHEM / BEIZEGEM.\", \"fr\": \"Travaux. D\u00e8s le 15/4 \u00e0 6h, ARRET NON DESSERVI. Prenez le bus 53 \u00e0 BEYSEGHEM.\", \"nl\": \"Werken. Vanaf 15/4 om 6u, HALTE NIET BEDIEND. Neem bus 53 aan BEIZEGEM.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"53\"}]", "priority": 4, "points": "[{\"id\": \"2852\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. As of Apr 15 at 6AM, bus 53 diverted between BEYSEGHEM / BEIZEGEM and PETER BENOIT.\", \"fr\": \"Travaux. D\u00e8s le 15/4 \u00e0 6h, bus 53 d\u00e9vi\u00e9 entre BEYSEGHEM et PETER BENOIT.\", \"nl\": \"Werken. Vanaf 15/4 om 6u, bus 53 omgeleid tussen BEIZEGEM en PETER BENOIT.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"53\"}]", "priority": 5, "points": "[{\"id\": \"2813B\"}, {\"id\": \"2815B\"}, {\"id\": \"2566B\"}, {\"id\": \"2572\"}, {\"id\": \"2571\"}, {\"id\": \"2570\"}, {\"id\": \"3085\"}, {\"id\": \"2171\"}, {\"id\": \"2647\"}, {\"id\": \"2569\"}, {\"id\": \"2547\"}, {\"id\": \"2568\"}, {\"id\": \"2567\"}, {\"id\": \"4132B\"}, {\"id\": \"2565\"}, {\"id\": \"2564\"}, {\"id\": \"2809\"}, {\"id\": \"2573B\"}, {\"id\": \"2648\"}, {\"id\": \"2824\"}, {\"id\": \"3637\"}, {\"id\": \"1767\"}, {\"id\": \"2811\"}, {\"id\": \"1204\"}, {\"id\": \"2810\"}, {\"id\": \"2575\"}, {\"id\": \"2817\"}, {\"id\": \"2816\"}, {\"id\": \"2814\"}, {\"id\": \"3605\"}]"},{"content": "[{\"text\": [{\"en\": \"From Apr 2, 2024 to June 2025, works. STOP NOT SERVED. Stop of bus 54 and 74: avenue du Globelaan 8.\", \"fr\": \"Du 2/4/2024 \u00e0 juin 2025, travaux. ARRET NON DESSERVI. Arr\u00eat des bus 54 et 74: avenue du Globe 8.\", \"nl\": \"Van 2/4/2024 tot juni 2025, werken. HALTE NIET BEDIEND. Halte van bus 54 en 74: Globelaan 8.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"54\"}]", "priority": 4, "points": "[{\"id\": \"2616B\"}]"},{"content": "[{\"text\": [{\"en\": \"Apr 2, 2024-June 2025, works. Bus 54 diverted btw FOREST CENTRE and FOREST NATIONAL. Info: stib-mivb.brussels.\", \"fr\": \"Du 2/4/2024 \u00e0 juin 2025, travaux. Bus 54 d\u00e9vi\u00e9 entre FOREST CENTRE et FOREST NATIONAL. Info: stib.brussels.\", \"nl\": \"2/4/2024-juni 2025, werken. Bus 54 omgeleid tussen VORST CENTRUM en VORST NATIONAAL. Info: mivb.brussels.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"54\"}]", "priority": 5, "points": "[{\"id\": \"5915\"}, {\"id\": \"1015\"}]"},{"content": "[{\"text\": [{\"en\": \"Apr 2, 2024-June 2025, works. Bus 54 diverted btw FOREST CENTRE and FOREST NATIONAL. Info: stib-mivb.brussels.\", \"fr\": \"Du 2/4/2024 \u00e0 juin 2025, travaux. Bus 54 d\u00e9vi\u00e9 entre FOREST CENTRE et FOREST NATIONAL. Info: stib.brussels.\", \"nl\": \"2/4/2024-juni 2025, werken. Bus 54 omgeleid tussen VORST CENTRUM en VORST NATIONAAL. Info: mivb.brussels.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"54\"}]", "priority": 5, "points": "[{\"id\": \"3243\"}]"},{"content": "[{\"text\": [{\"en\": \"From Apr 2, 2024 to June 2025, works. STOP NOT SERVED. Take bus 54 at the next stop, FOREST NATIONAL.\", \"fr\": \"Du 2/4/2024 \u00e0 juin 2025, travaux. ARRET NON DESSERVI. Prenez le bus 54 \u00e0 l'arr\u00eat suivant, FOREST NATIONAL.\", \"nl\": \"Van 2/4/2024 tot juni 2025, werken. HALTE NIET BEDIEND. Neem bus 54 aan de volgende halte, VORST NATIONAAL.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"54\"}]", "priority": 4, "points": "[{\"id\": \"2952B\"}]"},{"content": "[{\"text\": [{\"en\": \"Until Summer of 2024, works. As of March 18, buses 56 and 57 serve this stop normally.\", \"fr\": \"Jusqu'\u00e0 l'\u00e9t\u00e9 2024, travaux. D\u00e8s le 18/3, les bus 56 et 57 desservent \u00e0 nouveau cet arr\u00eat.\", \"nl\": \"Tot zomer 2024, werken. Vanaf 18/3 bedienen bus 56 en 57 opnieuw deze halte.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"56\"}]", "priority": 5, "points": "[{\"id\": \"1839\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. As of Apr 15, bus 56 diverted. Take bus 56 at the previous stop, at the St-Cyr house.\", \"fr\": \"Travaux. D\u00e8s le 15/4, bus 56 d\u00e9vi\u00e9. Prenez le bus 56 \u00e0 l'arr\u00eat pr\u00e9c\u00e9dent, devant la maison Saint-Cyr.\", \"nl\": \"Werken. Vanaf 15/4, bus 56 omgeleid. Neem bus 56 aan de vorige halte, voor het St-Cyr-huis.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"56\"}]", "priority": 4, "points": "[{\"id\": \"1273\"}]"},{"content": "[{\"text\": [{\"en\": \"As of Nov 14, stop moved to avenue Van Praetlaan, after Van Praet bridge.\", \"fr\": \"D\u00e8s le 14/11, arr\u00eat d\u00e9plac\u00e9 avenue Van Praet, apr\u00e8s le pont Van Praet.\", \"nl\": \"Vanaf 14/11, halte verplaatst naar de Van Praetlaan, na het Van Praetbrug.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"56\"}]", "priority": 4, "points": "[{\"id\": \"6370\"}]"},{"content": "[{\"text\": [{\"en\": \"Until Summer of 2024, works. As of Mar 18, stop served normally by bus 56.\", \"fr\": \"Jusqu'\u00e0 l'\u00e9t\u00e9 2024, travaux. D\u00e8s le 18/3, arr\u00eat \u00e0 nouveau desservi par les bus 56.\", \"nl\": \"Tot zomer 2024, werken. Vanaf 18/3, halte opnieuw bediend door bus 56.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"56\"}]", "priority": 4, "points": "[{\"id\": \"2352\"}]"},{"content": "[{\"text\": [{\"en\": \"Until Summer of 2024, works. Stop not served. Take bus 47 or 56 at ANTOON VAN OSS. For HOP MILITAIRE , walk.\", \"fr\": \"Jsq \u00e9t\u00e9 2024, travaux. Arr\u00eat non desservi. Bus 47 ou 56 \u00e0 ANTOON VAN OSS. Pour HOPITAL MILITAIRE, \u00e0 pied.\", \"nl\": \"Tot zomer 2024, werken. Halte niet bediend. Neem bus 47 of 56 aan ANTOON VAN OSS. Voor MILITAIR HOSPITAAL, ga te voet.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"56\"}]", "priority": 4, "points": "[{\"id\": \"1838\"}]"},{"content": "[{\"text\": [{\"en\": \"Until Summer of 2024, works. Stop not served. Take bus 57 at the stop of bus 56 to SCHUMAN.\", \"fr\": \"Jusqu'\u00e0 l'\u00e9t\u00e9 2024, travaux. Arr\u00eat non desservi. Prenez le bus 57 \u00e0 l'arr\u00eat du bus 56 vers SCHUMAN.\", \"nl\": \"Tot zomer 2024, werken. Halte niet bediend. Neem bus 57 aan de halte van bus 56 naar SCHUMAN.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"57\"}]", "priority": 4, "points": "[{\"id\": \"2317\"}]"},{"content": "[{\"text\": [{\"en\": \"Until Summer of 2024, works. Bus 57 diverted. Take bus 57 at ANTOON VAN OSS (stop of bus 56 to BUDA)\", \"fr\": \"Jusqu'\u00e0 l'\u00e9t\u00e9 2024, travaux. Bus 57 d\u00e9vi\u00e9. Prenez le bus 57 \u00e0 ANTOON VAN OSS (arr\u00eat du bus 56 vers BUDA).\", \"nl\": \"Tot zomer 2024, werken. Bus 57 omgeleid. Neem bus 57 aan ANTOON VAN OSS (halte van bus 56 naar BUDA).\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"57\"}]", "priority": 4, "points": "[{\"id\": \"1827\"}]"},{"content": "[{\"text\": [{\"en\": \"Until Summer of 2024, works. Stop not served. Take bus 57 at the stop of bus 56 to BUDA.\", \"fr\": \"Jusqu'\u00e0 l'\u00e9t\u00e9 2024, travaux. Arr\u00eat non desservi. Prenez le bus 57 \u00e0 l'arr\u00eat du bus 56 vers BUDA.\", \"nl\": \"Tot zomer 2024, werken. Halte niet bediend. Neem bus 57 aan de halte van bus 56 naar BUDA.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"57\"}]", "priority": 4, "points": "[{\"id\": \"2358\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. As of Apr 15, STOP NOT SERVED. Take bus 60 at MAELBEEK / MAALBEEK.\", \"fr\": \"Travaux. D\u00e8s le 15/4, ARRET NON DESSERVI. Prenez le bus 60 \u00e0 MAELBEEK.\", \"nl\": \"Werken. Vanaf 15/4, HALTE NIET BEDIEND. Neem bus 60 aan MAALBEEK.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"60\"}]", "priority": 4, "points": "[{\"id\": \"1270B\"}]"},{"content": "[{\"text\": [{\"en\": \"From May 2 at 7AM, works. Bus 60 diverted between JOURDAN and MALIBRAN.\", \"fr\": \"D\u00e8s le 2/5 \u00e0 7h, travaux. Bus 60 d\u00e9vi\u00e9 entre JOURDAN et MALIBRAN.\", \"nl\": \"Vanaf 2/5 om 7u, werken. Bus 60 omgeleid tussen JOURDAN en MALIBRAN.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"60\"}]", "priority": 5, "points": "[{\"id\": \"1425\"}, {\"id\": \"2920\"}, {\"id\": \"3921\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. As of Apr 15, bus 60 diverted between JOURDAN and AMBIORIX via MAELBEEK. Connection metro at MAELBEEK.\", \"fr\": \"Travaux. D\u00e8s le 15/4, bus 60 d\u00e9vi\u00e9 entre JOURDAN et AMBIORIX via MAELBEEK. Correspondance m\u00e9tro \u00e0 MAELBEEK.\", \"nl\": \"Werken. Vanaf 15/4, bus 60 omgeleid tussen JOURDAN en AMBIORIX via MAALBEEK. Aansluiting metro aan MAALBEEK.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"60\"}]", "priority": 6, "points": "[{\"id\": \"3158B\"}, {\"id\": \"6453\"}, {\"id\": \"6112\"}, {\"id\": \"2133\"}, {\"id\": \"2132\"}, {\"id\": \"2131\"}, {\"id\": \"1250\"}, {\"id\": \"4857B\"}, {\"id\": \"4804B\"}, {\"id\": \"6956B\"}, {\"id\": \"3160\"}, {\"id\": \"1976\"}, {\"id\": \"1986\"}, {\"id\": \"1884\"}, {\"id\": \"1653\"}, {\"id\": \"1883\"}, {\"id\": \"1980\"}, {\"id\": \"2134\"}, {\"id\": \"1739\"}, {\"id\": \"6406\"}, {\"id\": \"2847\"}, {\"id\": \"1977\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. As of Apr 15, STOP NOT SERVED. Take bus 60 at PARC LEOPOLD (ch. Etterbeek, in front of number 166).\", \"fr\": \"Travaux. D\u00e8s le 15/4, ARRET NON DESSERVI. Bus 60 \u00e0 PARC LEOPOLD (chauss\u00e9e d'Etterbeek, en face du num\u00e9ro 166).\", \"nl\": \"Werken. Vanaf 15/4, HALTE NIET BEDIEND. Neem bus 60 aan LEOPOLDSPARK (Etterbeeksesteenweg, tegenover nummer 166)\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"60\"}]", "priority": 4, "points": "[{\"id\": \"1271B\"}]"},{"content": "[{\"text\": [{\"en\": \"Risk of subsidence. Stop of bus 65, 66 and N04 moved to chauss\u00e9e de Haecht/Haachtsesteenweg, next to number 162\", \"fr\": \"Risque d'effondrement. Arr\u00eat des bus 65, 66 et N04 d\u00e9plac\u00e9 chauss\u00e9e de Haecht, \u00e0 hauteur du num\u00e9ro 162.\", \"nl\": \"Risico op instorting. Halte van bus 65, 66 en N04 verplaatst naar de Haachtsesteenweg, ter hoogte van nummer 162.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"66\"}]", "priority": 4, "points": "[{\"id\": \"6418\"}]"},{"content": "[{\"text\": [{\"en\": \"From Jan 7 at 9PM to Jun 28, works. Tram 7 does not serve this stop. Take tram 3 to go to VANDERKINDERE.\", \"fr\": \"Du 7/1 \u00e0 21h au 28/6, travaux. Tram 7 ne dessert pas cet arr\u00eat. Prenez le tram 3 pour rejoindre VANDERKINDERE.\", \"nl\": \"Van 7/1 om 21u tot en met 28/6, werken. Tram 7 bedient deze halte niet. Neem tram 3 om naar VANDERKINDERE te gaan.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"7\"}]", "priority": 4, "points": "[{\"id\": \"5219F\"}]"},{"content": "[{\"text\": [{\"en\": \"Jan 8-Jun 28, works. Tram 7 replaced by T-bus between DOCKS BRUXSEL and HEEMBEEK. Info: stib-mivb.brussels\", \"fr\": \"8/1-28/6, travaux. Tram 7 remplac\u00e9 par des T-bus entre DOCKS BRUXSEL et HEEMBEEK. Info: stib. brussels.\", \"nl\": \"8/1-28/6, werken. Tram 7 vervangen door T-bus tussen DOCKS BRUXSEL en HEEMBEEK. info: mivb. brussels.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"7\"}]", "priority": 5, "points": "[{\"id\": \"2636F\"}, {\"id\": \"9056F\"}]"},{"content": "[{\"text\": [{\"en\": \"From Jan 8 to Jun 28, works. Tram 7 interrupted to HEEMBEEK. T-bus at the stop of bus 56 to BUDA.\", \"fr\": \"Du 8/1 au 28/6, travaux. Tram 7 interrompu jusqu'\u00e0 HEEMBEEK. T-bus \u00e0 l'arr\u00eat du bus 56 vers BUDA.\", \"nl\": \"8/1-28/6, werken. Tram 7 onderbroken tot HEEMBEEK. T-bus aan de halte van bus 56 naar BUDA.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"7\"}]", "priority": 5, "points": "[{\"id\": \"5759F\"}]"},{"content": "[{\"text\": [{\"en\": \"From Mar 18, works. STOP NOT SERVED. stop of bus 71: avenue de l'Universit\u00e9 / Hogeschoollaan 4-10.\", \"fr\": \"D\u00e8s le 18/3, travaux. ARRET NON DESSERVI. Arr\u00eat du bus 71: avenue de l'Universit\u00e9 4-10.\", \"nl\": \"Vanaf 18/3, werken. HALTE NIET BEDIEND. Halte van bus 71: Hogeschoollaan 4-10.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"71\"}]", "priority": 4, "points": "[{\"id\": \"3514\"}]"},{"content": "[{\"text\": [{\"en\": \"Works.From May 10 at 10PM to May 12, bus 73 diverted between GARE DU MIDI and VETERINAIRES.\", \"fr\": \"Travaux. Du 10/5 \u00e0 22h au 12/5, bus 73 d\u00e9vi\u00e9 entre GARE DU MIDI et VETERINAIRES.\", \"nl\": \"Werken. Van 10/5 om 22u tot en met 12/5, bus 73 omgeleid tussen ZUIDSTATION en VEEARTSEN.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"73\"}]", "priority": 5, "points": "[{\"id\": \"1664\"}]"},{"content": "[{\"text\": [{\"en\": \"Apr 2, 2024-June 2025, works. Bus 74 diverted between FOREST NATIONAL and FOREST CENTRE. Info: stib-mivb.brussels\", \"fr\": \"Du 2/4/2024 \u00e0 juin 2025, travaux. Bus 74 d\u00e9vi\u00e9 entre FOREST NATIONAL et FOREST CENTRE. Info: stib.brussels.\", \"nl\": \"2/4/2024-juni 2025, werken. Bus 74 omgeleid tussen VORST NATIONAAL en VORST CENTRUM. Info: mivb.brussels\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"74\"}]", "priority": 5, "points": "[{\"id\": \"2632\"}, {\"id\": \"2453\"}]"},{"content": "[{\"text\": [{\"en\": \"From Apr 2, 2024 to June 2025, works. STOP NOT SERVED. Stop of bus 54 and 74: avenue du Globelaan 8.\", \"fr\": \"Du 2/4/2024 \u00e0 juin 2025, travaux. ARRET NON DESSERVI. Arr\u00eat des bus 54 et 74: avenue du Globe 8.\", \"nl\": \"Van 2/4/2024 tot juni 2025, werken. HALTE NIET BEDIEND. Halte van bus 54 en 74: Globelaan 8.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"74\"}]", "priority": 4, "points": "[{\"id\": \"2616B\"}]"},{"content": "[{\"text\": [{\"en\": \"Subsidence. Bus 74 limited to DECROLY. Walk from DECROLY to UCCLE-STALLE / UKKEL-STALLE.\", \"fr\": \"Effondrement. Bus 74 limit\u00e9 \u00e0 DECROLY. Continuez \u00e0 pied depuis DECROLY jusqu'\u00e0 UCCLE STALLE.\", \"nl\": \"Wegverzakking. Bus 74 beperkt tot DECROLY. Ga te voet van DECROLY tot UKKEL-STALLE.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"74\"}]", "priority": 5, "points": "[{\"id\": \"2631\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. Stop not served. As of May 6, stop of bus 49 and 74: chauss\u00e9e de Mons / Bergensesteenweg 814a.\", \"fr\": \"Travaux. Arr\u00eat non desservi.  D\u00e8s le 6/5, arr\u00eat des bus 49 et 74: chauss\u00e9e de Mons, 814a.\", \"nl\": \"Werken.  Halte niet bediend. Vanaf 6/5, halte van bus 49 en 74: Bergensesteenweg 814a.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"74\"}]", "priority": 4, "points": "[{\"id\": \"2225\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. As of Apr 15, STOP NOT SERVED. Stop of bus 79: rue Archim\u00e8de / Archimedesstraat 16.\", \"fr\": \"Travaux. D\u00e8s le 15/4, ARRET NON DESSERVI. Arr\u00eat du bus 79: rue Archim\u00e8de 16.\", \"nl\": \"Werken. Vanaf 15/4, HALTE NIET BEDIEND. Halte van bus 79: Archimedesstraat 16.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"79\"}]", "priority": 4, "points": "[{\"id\": \"1474B\"}, {\"id\": \"2083\"}]"},{"content": "[{\"text\": [{\"en\": \"From Jan 18, works. STOP NOT SERVED. Temporary stop: Avenue de Roodebeeklaan 45.\", \"fr\": \"D\u00e8s le 18/1, travaux. ARRET NON DESSERVI. Arr\u00eat provisoire: Avenue de Roodebeek 45.\", \"nl\": \"Vanaf 18/1, werken. HALTE NIET BEDIEND. Tijdelijke halte: Roodebeeklaan 45.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"79\"}]", "priority": 4, "points": "[{\"id\": \"1404\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. Until 2026, stop not served. T-bus 82 to DROGENBOS at the previous stop, CARREFOUR STALLE.\", \"fr\": \"Travaux. Jusqu'en 2026, arr\u00eat non desservi. T-bus 82 vers DROGENBOS \u00e0 l'arr\u00eat pr\u00e9c\u00e9dent, CARREFOUR STALLE.\", \"nl\": \"Werken. Tot 2026, halte niet bediend. T-bus 82 naar DROGENBOS aan de vorige halte, KRUISPUNT STALLE.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"82\"}]", "priority": 4, "points": "[{\"id\": \"5724\"}]"},{"content": "[{\"text\": [{\"en\": \"Until 2026, works. Stop not served. Take tram 82 at FOREST CENTRE / VORST CENTRUM (stop to Drogenbos).\", \"fr\": \"Jusqu'en 2026, travaux. Arr\u00eat non desservi. Prenez le tram 82 \u00e0 FOREST CENTRE (arr\u00eat vers Drogenbos).\", \"nl\": \"Tot 2026, werken. Halte niet bediend. Neem tram 82 aan VORST CENTRUM (halte naar Drogenbos).\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"82\"}]", "priority": 4, "points": "[{\"id\": \"5152G\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. Until 2026, stop not served. Walk to DROGENBOS.\", \"fr\": \"Travaux. Jusqu'en 2026, arr\u00eat non desservi. Pour rejoindre DROGENBOS, continuez \u00e0 pied.\", \"nl\": \"Werken. Tot 2026, halte niet bediend. Ga te voet verder om naar DROGENBOS te gaan.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"82\"}]", "priority": 4, "points": "[{\"id\": \"5729\"}, {\"id\": \"5725\"}]"},{"content": "[{\"text\": [{\"en\": \"Jan 22, 6AM-end of June, works. B86 diverted. Stop of B86:ch.De Gand/ Gentsestwg, in front of number 219 (Stop B13).\", \"fr\": \"Du 22/1 \u00e0 6h jusqu'\u00e0 fin juin, travaux. Bus 86 d\u00e9vi\u00e9. Arr\u00eat du B86: ch. de Gand, en face du num\u00e9ro 219 (arr\u00eat B13).\", \"nl\": \"Van 22/1 om 6u tot eind juni, werken. Bus 86 omgeleid. Halte van B86: Gentsesteenweg,tegenover nr. 219 (halte bus 13).\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"86\"}]", "priority": 4, "points": "[{\"id\": \"6754\"}]"},{"content": "[{\"text\": [{\"en\": \"From Mar 3 at 7AM, works. STOP NOT SERVED. Take bus 86 at the next stop DUCHESSE BRABANT / HERTOGIN BRABANT.\", \"fr\": \"D\u00e8s le 3/3 \u00e0 7h, travaux. ARRET NON DESSERVI. Prenez le bus 86 \u00e0 l'arr\u00eat suivant, DUCHESSE BRABANT.\", \"nl\": \"Vanaf 3/3 om 7u, werken. HALTE NIET BEDIEND. Neem bus 86 aan de volgende halte HERTOGIN BRABANT.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"86\"}]", "priority": 4, "points": "[{\"id\": \"6706\"}]"},{"content": "[{\"text\": [{\"en\": \"From Jan 22 at 6AM to end of June, works. Bus 86 diverted. Stop of bus 86: rue A. Vandenpeereboomstraat 44\", \"fr\": \"Du 22/1 \u00e0 6h jusqu'\u00e0 fin juin, travaux. Bus 86 d\u00e9vi\u00e9. Arr\u00eat du bus 86: rue  A. Vandenpeereboom 44.\", \"nl\": \"Van 22/1 om 6u tot eind juni, werken. Bus 86 omgeleid. Halte van bus 86: A. Vandenpeereboomstraat 44\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"86\"}]", "priority": 4, "points": "[{\"id\": \"4595\"}, {\"id\": \"1242\"}]"},{"content": "[{\"text\": [{\"en\": \"Jan 22, 6AM-end of June, works. Bus 86 diverted. Bus 86 at stop MERCHTEM of bus 20 to GARE DU NORD / NOORDSTATION.\", \"fr\": \"Du 22/1 \u00e0 6h jusqu'\u00e0 fin juin, travaux. Bus 86 d\u00e9vi\u00e9. Bus 86 \u00e0 l'arr\u00eat MERCHTEM du bus 20 vers GARE DU NORD.\", \"nl\": \"Van 22/1 om 6u tot eind juni, werken. Bus 86 omgeleid. B86 aan halte MERCHTEM van bus 20 naar NOORDSTATION.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"86\"}]", "priority": 4, "points": "[{\"id\": \"6755\"}]"},{"content": "[{\"text\": [{\"en\": \"As of Nov 16 at 6AM, works. Stop moved to av. Port / Havenln, in front of number 100 (moved backward of +/- 120m)\", \"fr\": \"D\u00e8s le 16/11 \u00e0 6h, travaux. Arr\u00eat d\u00e9plac\u00e9 avenue du Port, en face du num\u00e9ro 100 (recul\u00e9 de +/- 120m).\", \"nl\": \"Vanaf 16/11 om 6u,werken Halte verplaatst naar de Havenlaan, tegenover nr 100 (achteruitgebracht van +/- 120m)\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"88\"}]", "priority": 4, "points": "[{\"id\": \"2305\"}]"},{"content": "[{\"text\": [{\"en\": \"From Dec 4, works. STOP NOT SERVED. Stop of bus 88: rue du Progr\u00e8s / Vooruitgangstraat 64.\", \"fr\": \"D\u00e8s le 4/12, travaux. ARRET NON DESSERVI. Arr\u00eat du bus 88: rue du Progr\u00e8s 64.\", \"nl\": \"Vanaf 4/12, werken. HALTE NIET BEDIEND. Halte van bus 88: Vooruitgangstraat 64.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"88\"}]", "priority": 4, "points": "[{\"id\": \"3400\"}]"},{"content": "[{\"text\": [{\"en\": \"From Dec 4, works. STOP NOT SERVED. Stop of bus 58 and 88 : rue du Progr\u00e8s, after crossing rue des Charbonniers.\", \"fr\": \"D\u00e8s le 4/12, travaux. ARRET NON DESSERVI. Arr\u00eat des bus 58 et 88 : rue du Progr\u00e8s, apr\u00e8s rue des Charbonniers.\", \"nl\": \"Vanaf 4/12, werken. HALTE NIET BEDIEND. Halte bus 58 en 88 : Vooruitgangstraat, na Koolbrandersstraat.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"88\"}]", "priority": 4, "points": "[{\"id\": \"1083\"}]"},{"content": "[{\"text\": [{\"en\": \"Until end of August, works. Bus 89 diverted. For the city center, take metro 1 or 5 at STE-CATHERINE.\", \"fr\": \"Jusque fin ao\u00fbt, travaux. Bus 89 d\u00e9vi\u00e9. Pour le centre-ville, prenez le m\u00e9tro 1 ou 5 \u00e0 SAINTE-CATHERINE.\", \"nl\": \"Tot einde augustus, werken. Bus 89 omgeleid. Om naar het stadscentrum te gaan, neem M 1 5 aan SINT-KATELIJNE.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"89\"}]", "priority": 4, "points": "[{\"id\": \"3261\"}]"},{"content": "[{\"text\": [{\"en\": \"Until end of August 2024, works. Stop not served. Take bus 29 or 71 at DE BROUCKERE to go to CENTRAL STATION.\", \"fr\": \"Jsq fin ao\u00fbt 2024, travaux. Arr\u00eat non desservi. Prenez le bus 29 ou 71 \u00e0 DE BROUCKERE pour GARE CENTRALE.\", \"nl\": \"Tot einde augustus 2024, werken. halte niet bediend. Neem bus 29 of 71 aan DE BROUCKERE om naar CENTR. ST. te gaan\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"89\"}]", "priority": 4, "points": "[{\"id\": \"1894\"}]"},{"content": "[{\"text\": [{\"en\": \"Until end of August, works. Bus 89 diverted btw PTE DE NINOVE and BOURSE, and interrupted bt BOURSE and CENTRAL ST\", \"fr\": \"Jsq fin ao\u00fbt, travaux. Bus 89 d\u00e9vi\u00e9 entre PORTE DE NINOVE et BOURSE, et interrompu entre BOURSE et GARE CENTRALE.\", \"nl\": \"Tot einde augustus, werken. Bus 89 omgeleid tss NINOOFSEPOORT en BEURS, en onderbroken tss BEURS en CENTR ST\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"89\"}]", "priority": 5, "points": "[{\"id\": \"2754\"}, {\"id\": \"2776\"}, {\"id\": \"2748B\"}, {\"id\": \"4595\"}, {\"id\": \"1178\"}, {\"id\": \"2784\"}, {\"id\": \"2782\"}, {\"id\": \"6648\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. From Apr 26 at 9PM until May 12, stop not served. Stop of the T-bus: av. Arbre Ballon / Dikke Beuklaan 117\", \"fr\": \"Travaux. Du 26/4 \u00e0 21h au 12/5, arr\u00eat non desservi. Arr\u00eat du T-bus: avenue de l'Arbre Ballon 117.\", \"nl\": \"Werken. Van 26/4 om 21u tot en met 12/5, halte niet bediend. Halte van de T-bus: Dikke Beuklaan 117.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"9\"}]", "priority": 4, "points": "[{\"id\": \"4223F\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. From Apr 26 at 9PM until May 12, stop not served. T-bus to UZ BRUSSEL at the stop of bus 820 to UZ BRUSSEL.\", \"fr\": \"Travaux. Du 26/4 \u00e0 21h au 12/5, arr\u00eat non desservi. T-bus vers UZ BRUSSEL \u00e0 l'arr\u00eat du bus 820 vers UZ BRUSSEL.\", \"nl\": \"Werken. 26/4, 21u-12/5, halte niet bediend. T-bus naar UZ BRUSSEL aan de halte van bus 820 naar UZ BRUSSEL.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"9\"}]", "priority": 4, "points": "[{\"id\": \"1686F\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. From Apr 26 at 9PM until May 12, stop not served. Walk to ROI BAUDOUIN / KONING BOUDEWIJN.\", \"fr\": \"Travaux. Du 26/4 \u00e0 21h au 12/5, arr\u00eat non desservi. Pour rejoindre ROI BAUDOUIN, continuez \u00e0 pied.\", \"nl\": \"Werken. Van 26/4 om 21u tot en met 12/5, halte niet bediend. Ga te voet verder naar KONING BOUDEWIJN.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"9\"}]", "priority": 4, "points": "[{\"id\": \"1693F\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. From Apr 26 at 9PM until May 12, stop not served. T-bus to ROI BAUDOUIN at the stop of bus 820 to ZAVENTEM.\", \"fr\": \"Travaux. Du 26/4 \u00e0 21h au 12/5, arr\u00eat non desservi. T-bus vers ROI BAUDOUIN \u00e0 l'arr\u00eat du bus 820 vers ZAVENTEM.\", \"nl\": \"Werken. 26/4, 21u-12/5, halte niet bediend.T-bus naar KONING BOUDEWIJN aan de halte van bus 820 naar ZAVENTEM.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"9\"}]", "priority": 4, "points": "[{\"id\": \"1687F\"}]"},{"content": "[{\"text\": [{\"en\": \"From Mar 5 at 9AM, works. STOP NOT SERVED. Temporary stop: avenue Jean & Pierre Carsoellaan 4.\", \"fr\": \"D\u00e8s le 5/3 \u00e0 9h, travaux. ARRET NON DESSERVI. Arr\u00eat provisoire: avenue Jean et Pierre Carsoel 4.\", \"nl\": \"Vanaf 5/3 om 9u, werken. HALTE NIET BEDIEND. Tijdelijke halte: Jean en Pierre Carsoellaan 4.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"92\"}]", "priority": 4, "points": "[{\"id\": \"6931H\"}]"},{"content": "[{\"text\": [{\"en\": \"From Mar 18, works. STOP NOT SERVED. stop of bus 95: chauss\u00e9e de Boondael / Boondaalsesteenweg, before roundabout.\", \"fr\": \"D\u00e8s le 18/3, travaux. ARRET NON DESSERVI. Arr\u00eat du bus 95: chauss\u00e9e de Boondael, avant le rond-point.\", \"nl\": \"Vanaf 18/3, werken. HALTE NIET BEDIEND. Halte van bus 95: Boondaalsesteenweg, voor rondpunt.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"95\"}]", "priority": 4, "points": "[{\"id\": \"3514\"}]"},{"content": "[{\"text\": [{\"en\": \"From Mar 25 until Jun 30, works. STOP NOT SERVED. Stop of bus 95: bd. Gen. Jacqueslaan 235.\", \"fr\": \"Du 25/3 au 30/6, travaux. ARRET NON DESSERVI. Arr\u00eat du bus 95: boulevard G\u00e9n\u00e9ral Jacques, 235.\", \"nl\": \"Van 25/3 tot en met 30/6, werken. HALTE NIET BEDIEND. Halte van bus 95:  Generaal Jacqueslaan 235.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"95\"}]", "priority": 4, "points": "[{\"id\": \"4363\"}]"},{"content": "[{\"text\": [{\"en\": \"From Mar 18, works. STOP NOT SERVED. Temporary stop: avenue de la Couronne / Kroonlaan 439-443.\", \"fr\": \"D\u00e8s le 18/3, travaux. ARRET NON DESSERVI. Arr\u00eat provisoire: avenue de la Couronne 439-443.\", \"nl\": \"Vanaf 18/3, werken. HALTE NIET BEDIEND. Tijdelijke halte: Kroonlaan 439-443.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"95\"}]", "priority": 4, "points": "[{\"id\": \"3558\"}]"},{"content": "[{\"text\": [{\"en\": \"Until 2026, works. As of Mar 11, tram 97 interrupted between WIELS and DIEWEG. Take tram 4 to go to GLOBE.\", \"fr\": \"Jsq 2026,travaux. D\u00e8s le 11/3, tram 97 interrompu entre WIELS et DIEWEG. Prenez le tram 4 pour rejoindre GLOBE.\", \"nl\": \"Tot 2026, werken. Vanaf 11/3, tram 97 onderbroken tussen WIELS en DIEWEG. Neem tram 4 om naar GLOBE te gaan.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"97\"}]", "priority": 4, "points": "[{\"id\": \"5723G\"}]"},{"content": "[{\"text\": [{\"en\": \"Until 2026, works. Tram 97 interrupted. T-bus to CARREFOUR / KRUISPUNT STALLE at the stop of bus 54 to TRONE/TROON\", \"fr\": \"Jusqu'en 2026, travaux. Tram 97 interrompu. T-bus vers CARREFOUR STALLE \u00e0 l'arr\u00eat du bus 54 vers TRONE.\", \"nl\": \"Tot 2026, werken. Tram 97 onderbroken. T-bus naar KRUISPUNT STALLE aan de halte van bus 54 naar TROON.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"97\"}]", "priority": 4, "points": "[{\"id\": \"5121F\"}]"},{"content": "[{\"text\": [{\"en\": \"Until 2026, works. As of Mar 11, T97 operated only btw LOUISE and WIELS. T82 at WIELS or T-bus at PIERRE DECOSTER\", \"fr\": \"Jsq 2026, travaux. D\u00e8s le 11/3, T97  uniquement entre LOUISE et WIELS. Tram 82 \u00e0 WIELS ou T-bus \u00e0 PIERRE DECOSTER.\", \"nl\": \"Tot 2026, werken. Vanaf 11/3 rijdt T97 enkel tss LOUIZA en WIELS.Neem T82 aan WIELS of de T-bus aan PIERRE DECOSTER.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"97\"}]", "priority": 5, "points": "[{\"id\": \"5116\"}]"},{"content": "[{\"text\": [{\"en\": \"Until 2026, works. T97 interrupted to WIELS. Stop of the T-bus to ROCHEFORT: r. Soierie / Zijdeweverijstraat 9\", \"fr\": \"Jusqu'en 2026, travaux. Tram 97 interrompu jusqu'\u00e0 WIELS. Arr\u00eat du T-bus vers ROCHEFORT: rue de la Soierie 9.\", \"nl\": \"Tot 2026, werken. Tram 97 onderbroken tot WIELS. Halte van de T-bus naar ROCHEFORT: Zijdeweverijstraat 9.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"97\"}]", "priority": 4, "points": "[{\"id\": \"5156F\"}]"},{"content": "[{\"text\": [{\"en\": \"Until 2026, works. As of Mar 11, tram 97 interrupted to DIEWEG. For GLOBE, tram 4 at CARR. STALLE via T-bus\", \"fr\": \"Jsq 2026,travaux. D\u00e8s le 11/3, tram 97 interrompu jsq DIEWEG. Pour GLOBE, tram 4 \u00e0 CARREFOUR STALLE via T-bus.\", \"nl\": \"Tot 2026, werken. Vanaf 11/3,T97 onderbroken tot DIEWEG. Voor GLOBE, neem T4 aan KRUISPUNT STALLE via T-bus.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"97\"}]", "priority": 4, "points": "[{\"id\": \"5163F\"}]"},{"content": "[{\"text\": [{\"en\": \"Until 2026, works. As of Mar 11, tram 97 interrupted btw WIELS and DIEWEG. Take tram 92 to go to DIEWEG\", \"fr\": \"Jsq 2026,travaux. D\u00e8s le 11/3, tram 97 interrompu entre WIELS et DIEWEG. Prenez le tram 92 pour rejoindre DIEWEG\", \"nl\": \"Tot 2026, werken. Vanaf 11/3,tram 97 onderbroken tss WIELS en DIEWEG. Neem tram 92 om naar DIEWEG te gaan\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"97\"}]", "priority": 4, "points": "[{\"id\": \"2765\"}, {\"id\": \"2764G\"}]"},{"content": "[{\"text\": [{\"en\": \"Until 2026, works. As of Mar 11, tram 97 operated only btw LOUISE and WIELS.T-bus to CARREFOUR STALLE at ROCHEFORT.\", \"fr\": \"Jsq 2026,travaux. D\u00e8s le 11/3, tram 97 circule uniquement entre LOUISE et WIELS.T-bus vers CARR STALLE \u00e0 ROCHEFORT.\", \"nl\": \"Tot 2026, werken. Vanaf 11/3 rijdt tram 97 enkel tussen LOUIZA en WIELS. T-bus naar KRUISPUNT STALLE aan ROCHEFORT.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"97\"}]", "priority": 5, "points": "[{\"id\": \"6078\"}, {\"id\": \"6428F\"}, {\"id\": \"5018F\"}, {\"id\": \"5016F\"}, {\"id\": \"2404F\"}, {\"id\": \"6314\"}, {\"id\": \"2336G\"}, {\"id\": \"6162\"}]"},{"content": "[{\"text\": [{\"en\": \"Until 2026, works. As of Mar 11, tram 97 interrupted btw WIELS and DIEWEG. Take T92 at MARLOW to go to DIEWEG\", \"fr\": \"Jsq 2026,travaux. D\u00e8s le 11/3, tram 97 interrompu entre WIELS et DIEWEG. Prenez le T92 \u00e0 MARLOW pour aller \u00e0 DIEWEG\", \"nl\": \"Tot 2026, werken. Vanaf 11/3,tram 97 onderbroken tss WIELS en DIEWEG. Neem tram 92 aan MARLOW om naar DIEWEG te gaan\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"97\"}]", "priority": 4, "points": "[{\"id\": \"1985G\"}]"},{"content": "[{\"text\": [{\"en\": \"From Mar 18, works. STOP NOT SERVED. stop of bus N08: avenue de l'Universit\u00e9 / Hogeschoollaan 4-10.\", \"fr\": \"D\u00e8s le 18/3, travaux. ARRET NON DESSERVI. Arr\u00eat du bus N08: avenue de l'Universit\u00e9 4-10.\", \"nl\": \"Vanaf 18/3, werken. HALTE NIET BEDIEND. Halte van bus N08: Hogeschoollaan 4-10.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"N08\"}]", "priority": 4, "points": "[{\"id\": \"3558\"}]"},{"content": "[{\"text\": [{\"en\": \"From Jan 15, works. STOP NOT SERVED. Stop of Noctis N09: boulevard du Souverain / Vorstlaan 159.\", \"fr\": \"D\u00e8s le 15/1, travaux. ARRET NON DESSERVI. Arr\u00eat des Noctis N09: boulevard du Souverain 159.\", \"nl\": \"Vanaf 15/1, werken. HALTE NIET BEDIEND. Halte van Noctis N09: Vorstlaan 159.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"N09\"}]", "priority": 4, "points": "[{\"id\": \"1731\"}]"},{"content": "[{\"text\": [{\"en\": \"From Jan 15, works. STOP NOT SERVED. Stop of Noctis N09: chauss\u00e9e de Wavre / Waversesteenweg 1303.\", \"fr\": \"D\u00e8s le 15/1, travaux. ARRET NON DESSERVI. Arr\u00eat du Noctis N09: chauss\u00e9e de Wavre 1303.\", \"nl\": \"Vanaf 15/1, werken. HALTE NIET BEDIEND. Halte van Noctis N09: Waversesteenweg 1303.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"N09\"}]", "priority": 4, "points": "[{\"id\": \"1718B\"}]"},{"content": "[{\"text\": [{\"en\": \"From Feb 15, subsidence. N10 diverted. Take the bus at the stop FLAGEY.\", \"fr\": \"D\u00e8s le 15/2, effondrement. N10 d\u00e9vi\u00e9. Prenez le bus \u00e0 l'arr\u00eat FLAGEY.\", \"nl\": \"Vanaf 15/2, wegverzakking. N10 omgeleid. Neem de bus aan de halte FLAGEY.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"N10\"}]", "priority": 4, "points": "[{\"id\": \"1986\"}, {\"id\": \"1977\"}]"},{"content": "[{\"text\": [{\"en\": \"From Feb 15, subsidence. N10 diverted. Take the bus at the previous stop, LEPOUTRE.\", \"fr\": \"D\u00e8s le 15/2, effondrement. N10 d\u00e9vi\u00e9. Prenez le bus \u00e0 l'arr\u00eat pr\u00e9c\u00e9dent, LEPOUTRE.\", \"nl\": \"Vanaf 15/2, wegverzakking. N10 omgeleid. Neem de bus aan de vorige halte, LEPOUTRE.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"N10\"}]", "priority": 4, "points": "[{\"id\": \"1976\"}]"},{"content": "[{\"text\": [{\"en\": \"Werken. 8/5, 21u-12/5, T-bus 19 diverted from GUILL. DE GREEF to DE WAND. HOP. BRUGMANN served by tram 51 93\", \"fr\": \"Travaux. 8/5, 21h-12/5, T-bus 19 d\u00e9vi\u00e9 depuis GUILL. DE GREEF vers DE WAND. HOP. BRUGMANN desservi par tram 51 93\", \"nl\": \"Werken. 8/5, 21u-12/5, T-bus 19 omgeleid vanaf GUILL. DE GREEF naar DE WAND. BRUGMANN-ZKH bediend door tram 51 93\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"T19\"}]", "priority": 5, "points": "[{\"id\": \"1767\"}, {\"id\": \"2515B\"}, {\"id\": \"6865\"}, {\"id\": \"6864\"}, {\"id\": \"1183\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. As of Apr 15, bus 12 diverted btw MEISER and LUXEMBOURG via MAELBEEK. Stop SCHUMAN moved rue Franklinstr.\", \"fr\": \"Travaux. D\u00e8s le 15/4, bus 12 d\u00e9vi\u00e9 entre MEISER et LUXEMBOURG via MAELBEEK. Arr\u00eat SCHUMAN d\u00e9plac\u00e9 rue Franklin.\", \"nl\": \"Werken. Vanaf 15/4, bus 12 omgeleid tss MEISER en LUXEMBURG via MAALBEEK. Halte SCHUMAN verplaatst Franklinstr.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"12\"}]", "priority": 6, "points": "[{\"id\": \"3017\"}, {\"id\": \"2695\"}, {\"id\": \"5048\"}, {\"id\": \"9600B\"}, {\"id\": \"2250\"}]"},{"content": "[{\"text\": [{\"en\": \"Bus 17: From Sep 5 6AM, works. Diversion between BRILLANT/BRILJANT and BEAULIEU via Michiels\", \"fr\": \"Bus 17: D\u00e8s le 5/9 6h, travaux. D\u00e9viation entre BRILLANT et BEAULIEU via Michiels\", \"nl\": \"Bus 17: Vanaf 5/9 6u, werken. Omleiding tussen BRILJANT en BEAULIEU via Michiels\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"17\"}]", "priority": 6, "points": "[{\"id\": \"9059\"}, {\"id\": \"4351\"}, {\"id\": \"4341\"}, {\"id\": \"1455\"}, {\"id\": \"4287\"}, {\"id\": \"4355\"}, {\"id\": \"4357\"}, {\"id\": \"4358\"}, {\"id\": \"4348\"}, {\"id\": \"4292\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. As of Mar 27, STOP MOVED. Stop of bus 17: rue des Thuyas / Thujastraat 5.\", \"fr\": \"Travaux. D\u00e8s le 27/3, ARRET DEPLACE. Arr\u00eat du bus 17: rue des Thuyas, 5.\", \"nl\": \"Werken. Vanaf 27/3, HALTE VERPLAATST. Halte van bus 17: Thujastraat 5.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"17\"}]", "priority": 4, "points": "[{\"id\": \"4310\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. Until mid-2024, T19 interrupted at this stop. Stop of T-bus 19: av. Jette 232 (next to this stop)\", \"fr\": \"Travaux. Jusque mi-2024, T19 interrompu \u00e0 cet arr\u00eat. Arr\u00eat du T-bus 19: av. de Jette, 232 (\u00e0 c\u00f4t\u00e9 de cet arr\u00eat).\", \"nl\": \"Werken. Tot midden 2024, T19 onderbroken aan deze halte. Halte van T-bus 19: Jetselaan 232 (naast deze halte)\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"19\"}]", "priority": 4, "points": "[{\"id\": \"6865F\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. May 8, 9PM-May 12, tram 19 replaced by a T-bus to SIMONIS. T-bus at the stop of bus 53 to WESTLAND SHOPPING.\", \"fr\": \"Travaux. 8/5, 21h-12/5, tram 19 remplac\u00e9 par des T-bus jsq SIMONIS. T-bus \u00e0 l'arr\u00eat du bus 53 vers WESTLAND SHOPPING.\", \"nl\": \"Werken. 8/5, 21u-12/5, tram 19 vervangen door T-bus tot SIMONIS. T-bus aan de halte van bus 53 naar WESTLAND SHOPPING.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"19\"}]", "priority": 4, "points": "[{\"id\": \"5001F\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. Until mid-2024, stop not served. T-bus at LEOPOLD I (bd de Smet de Naeyer 59), or T19 at MIROIR.\", \"fr\": \"Travaux, jusque mi-2024, arr\u00eat non desservi. T-bus \u00e0 LEOPOLD I (bd de Smet de Naeyer 59), ou T19 \u00e0 MIROIR.\", \"nl\": \"Werken. Tot midden 2024, halte niet bediend. T-bus aan LEOPOLD I (de Smet de Naeyerlaan 59), of T19 aan SPIEGEL.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"19\"}]", "priority": 4, "points": "[{\"id\": \"6804F\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. May 8, 9PM-May 12, STOP NOT SERVED. T-bus to SIMONIS at GUILLAUME DE GREEF (stop of bus 88 to UZ-VUB).\", \"fr\": \"Travaux. 8/5, 21h-12/5, ARRET NON DESSERVI. T-bus vers SIMONIS \u00e0 GUILL. DE GREEF (arr\u00eat du bus 88 vers UZ-VUB).\", \"nl\": \"Werken. 8/5, 21u-12/5, HALTE NIET BEDIEND. T-bus naar SIMONIS aan GUILL. DE GREEF (halte van bus 88 naar UZ-VUB).\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"19\"}]", "priority": 4, "points": "[{\"id\": \"5003\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. Until mid-2024, stop not served. T-bus at VERBEYST (bd de Smet de Naeyer 234, stop of bus 14 to UZ-VUB).\", \"fr\": \"Travaux. Jusque mi-2024, arr\u00eat non desservi. T-bus \u00e0 VERBEYST (bd de Smet de Naeyer 234, arr\u00eat B14 vers UZ-VUB).\", \"nl\": \"Werken. Tot midden 2024, halte niet bediend. T-bus aan VERBEYST (de Smet de Naeyerlaan 234, halte B14 naar UZ-VUB).\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"19\"}]", "priority": 4, "points": "[{\"id\": \"6867F\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. Until mid-2024, tram 19 replaced by T-bus btw DE WAND and MIROIR / SPIEGEL. Take T-bus at CIM. DE JETTE.\", \"fr\": \"Travaux. Jusque mi-2024, tram 19 remplac\u00e9 par des T-bus entre DE WAND et MIROIR. Prenez le T-bus \u00e0 CIMETIERE DE JETTE.\", \"nl\": \"Werken. Tot midden 2024, tram 19 vervangen door T-bus tss DE WAND en SPIEGEL. Neem de T-bus aan KERKHOF VAN JETTE\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"19\"}]", "priority": 4, "points": "[{\"id\": \"6800F\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. May 8, 9PM-May 12, tram 19 interrupted. T-bus to SIMONIS at the stop of bus 88 to UZ-VUB.\", \"fr\": \"Travaux. 8/5, 21h-12/5, tram 19 interrompu. T-bus vers SIMONIS \u00e0 l'arr\u00eat du bus 88 vers UZ-VUB.\", \"nl\": \"Werken. 8/5, 21u-12/5, tram 19 onderbroken. T-bus naar SIMONIS aan de halte van bus 88 naar UZ-VUB.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"19\"}]", "priority": 4, "points": "[{\"id\": \"5093F\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. May 8, 9PM-May 12, tram 19 replaced by a T-bus to DE WAND.T-bus at PR. LEOPOLD (stop of bus 88 to UZ-VUB).\", \"fr\": \"Travaux. 8/5, 21h-12/5, tram 19 remplac\u00e9 par des T-bus jsq DE WAND. T-bus \u00e0 PRINCE LEOPOLD (arr\u00eat du bus 88 vers UZ-VUB).\", \"nl\": \"Werken. 8/5, 21u-12/5, tram 19 vervangen door T-bus tot DE WAND. T-bus aan PRINS LEOPOLD (halte van bus 88 naar UZ-VUB)\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"19\"}]", "priority": 4, "points": "[{\"id\": \"4958F\"}]"},{"content": "[{\"text\": [{\"en\": \"From Dec 4, works. STOP NOT SERVED. Take bus 20 at the previous stop, GARE DU NORD / NOORDSTATION.\", \"fr\": \"D\u00e8s le 4/12, travaux. ARRET NON DESSERVI. Prenez le bus 20 \u00e0 l'arr\u00eat pr\u00e9c\u00e9dent, GARE DU NORD.\", \"nl\": \"Vanaf 4/12, werken. HALTE NIET BEDIEND. Neem bus 20 aan de vorige halte, NOORDSTATION.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"20\"}]", "priority": 4, "points": "[{\"id\": \"3400\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. As of Apr 15, bus 21 diverted btw TREVES and MICHEL-ANGE via MAELBEEK. Stop SCHUMAN moved rue Archim\u00e8de.\", \"fr\": \"Travaux. D\u00e8s le 15/4,bus 21 d\u00e9vi\u00e9 entre TREVES et MICHEL-ANGE via MAELBEEK. Arr\u00eat SCHUMAN d\u00e9plac\u00e9 rue Archim\u00e8de.\", \"nl\": \"Werken. Vanaf 15/4, bus 21 omgeleid tss TRIER en MICHELANGELO via MAALBEEK. Halte SCHUMAN verplaatst Archimedesstr\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"21\"}]", "priority": 6, "points": "[{\"id\": \"1132\"}, {\"id\": \"1262B\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. As of Apr 15, bus 21 diverted btw MICHEL- ANGE and TOULOUSE via MAELBEEK. Stop SCHUMAN moved rue Franklin.\", \"fr\": \"Travaux. D\u00e8s le 15/4,bus 21 d\u00e9vi\u00e9 entre MICHEL- ANGE et TOULOUSE via MAELBEEK. Arr\u00eat SCHUMAN d\u00e9plac\u00e9 rue Franklin.\", \"nl\": \"Werken. Vanaf 15/4, bus 21 omgeleid tss MICHELANGELO en TOULOUSE via MAALBEEK. SCHUMAN verplaatst Franklinstr.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"21\"}]", "priority": 6, "points": "[{\"id\": \"6454\"}, {\"id\": \"3199\"}, {\"id\": \"3361\"}, {\"id\": \"3904\"}, {\"id\": \"3905\"}, {\"id\": \"3425\"}, {\"id\": \"3458\"}, {\"id\": \"3707\"}, {\"id\": \"3204\"}, {\"id\": \"3468\"}, {\"id\": \"3203\"}, {\"id\": \"3214\"}, {\"id\": \"3367\"}, {\"id\": \"1464\"}, {\"id\": \"3466\"}, {\"id\": \"2695\"}, {\"id\": \"1463\"}, {\"id\": \"3201\"}, {\"id\": \"4500\"}, {\"id\": \"3911\"}, {\"id\": \"4505\"}, {\"id\": \"2924\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. As of Apr 15, STOP NOT SERVED. Stop of bus 21: rue Archim\u00e8de / Archimedesstraat 16.\", \"fr\": \"Travaux. D\u00e8s le 15/4, ARRET NON DESSERVI. Arr\u00eat du bus 21: rue Archim\u00e8de 16.\", \"nl\": \"Werken. Vanaf 15/4, HALTE NIET BEDIEND. Halte van bus 21: Archimedesstraat 16.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"21\"}]", "priority": 4, "points": "[{\"id\": \"2083\"}]"},{"content": "[{\"text\": [{\"en\": \"From Jan 18, works. STOP NOT SERVED. Temporary stop: Avenue de Roodebeeklaan 45.\", \"fr\": \"D\u00e8s le 18/1, travaux. ARRET NON DESSERVI. Arr\u00eat provisoire: Avenue de Roodebeek 45.\", \"nl\": \"Vanaf 18/1, werken. HALTE NIET BEDIEND. Tijdelijke halte: Roodebeeklaan 45.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"28\"}]", "priority": 4, "points": "[{\"id\": \"1404\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. STOP NOT OPERATED. Temporary stop: rue de Pavie / Paviastraat 53.\", \"fr\": \"Travaux. ARRET NON DESSERVI. Arr\u00eat provisoire: rue de Pavie 53.\", \"nl\": \"Werken. HALTE NIET BEDIEND. Tijdelijke halte: Paviastraat 53.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"29\"}]", "priority": 5, "points": "[{\"id\": \"1568\"}]"},{"content": "[{\"text\": [{\"en\": \"Bus 29: works. Stop CLOVIS not served. Temporary stop: rue de Pavie / Paviastraat 53.\", \"fr\": \"Bus 29 : travaux. Arr\u00eat CLOVIS non desservi. Arr\u00eat provisoire: rue de Pavie 53.\", \"nl\": \"Bus 29: werken. Halte CLOVIS niet bediend. Tijdelijke halte: Paviastraat 53.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"29\"}]", "priority": 6, "points": "[{\"id\": \"6454\"}, {\"id\": \"1561\"}, {\"id\": \"1550\"}, {\"id\": \"1385\"}, {\"id\": \"1560\"}, {\"id\": \"1558\"}, {\"id\": \"1557\"}, {\"id\": \"1567\"}, {\"id\": \"1578\"}, {\"id\": \"1566\"}, {\"id\": \"1554\"}, {\"id\": \"1565B\"}, {\"id\": \"1553\"}, {\"id\": \"3367\"}, {\"id\": \"1552\"}, {\"id\": \"3910\"}, {\"id\": \"1528\"}, {\"id\": \"1559\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. As of April 7th, stop served only by bus 66. Take bus 29, 63 or 65 at the stop of bus 71 to DELTA.\", \"fr\": \"Travaux. D\u00e8s le 7/4, arr\u00eat uniquement desservi par bus 66. Bus 29, 63 ou 65 \u00e0 l'arr\u00eat du bus 71 vers DELTA.\", \"nl\": \"Werken. Vanaf 7/4, halte enkel bediend door bus 66. Neem bus 29, 63 of 65 aan de halte van bus 71 naar DELTA.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"29\"}]", "priority": 4, "points": "[{\"id\": \"6445\"}]"},{"content": "[{\"text\": [{\"en\": \"From FEB 2, works. Stop SAINT-JOSSE moved, go to the temporary stop: chauss\u00e9e de Louvain 73.\", \"fr\": \"D\u00e8s le 26/2, travaux. Arr\u00eat SAINT-JOSSE d\u00e9plac\u00e9, allez \u00e0 l'arr\u00eat provisoire : chauss\u00e9e de Louvain 73.\", \"nl\": \"Vanaf 26/2, werken. Halte SINT-JOOST verplaatst, ga naar de tijdelijke halte: Leuvensesteenweg 73.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"29\"}]", "priority": 4, "points": "[{\"id\": \"1570\"}]"},{"content": "[{\"text\": [{\"en\": \"Jan 7, 9PM-Jun 28, works. Stop not served. Stop  T-bus to ESPLANADE : av. Croix du Feu, crossing r. Heembeek.\", \"fr\": \"7/1, 21h-28/6, travaux. Arr\u00eat non desservi.Arr\u00eat T-bus vers ESPLANADE:av. Croix du Feu, carrefour rue de Heembeek.\", \"nl\": \"7/1, 21u-28/6, werken. Halte niet bediend.Halte T-bus naar ESPLANADE : Vuurkruisenlaan, kruispunt Heembeeklaan.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"3\"}]", "priority": 4, "points": "[{\"id\": \"5771\"}]"},{"content": "[{\"text\": [{\"en\": \"Jan 7, 9PM-Jun 28, works.Tram 3 diverted to the stop DOCKS BRUXSEL of tram 7 and replaced by T-bus to ESPLANADE.\", \"fr\": \"7/1, 21h-28/6, travaux. Tram 3 d\u00e9vi\u00e9 vers l'arr\u00eat DOCKS BRUXSEL du tram 7 et remplac\u00e9 par des T-bus jsq ESPLANADE.\", \"nl\": \"7/1, 21u-28/6, werken. Tram 3 omgeleid naar de halte DOCKS BRUXSEL van tram 7 en vervangen door T-bus tot ESPLANADE.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"3\"}]", "priority": 4, "points": "[{\"id\": \"2337F\"}]"},{"content": "[{\"text\": [{\"en\": \"Jan 7, 9PM-Jun 28,works. Tram 3 and 7 replaced by T-bus to DOCKS BRUXSEL. T-bus at this stop.\", \"fr\": \"7/1, 21h-28/6, travaux. Tram 3 et 7 remplac\u00e9s par des T-bus jusqu'\u00e0 DOCKS BRUXSEL. T-bus \u00e0 cet arr\u00eat.\", \"nl\": \"7/1, 21u-28/6, werken. Tram 3 en 7 vervangen door T-bus tot DOCKS BRUXSEL. T-bus aan deze halte.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"3\"}]", "priority": 4, "points": "[{\"id\": \"5707\"}]"},{"content": "[{\"text\": [{\"en\": \"Jan 7, 9PM-Jun 28,works. Tram 3 interrupted btw ESPLANADE and DOCKS BRUXSEL. Stop of the T-bus: av. Araucarialn.\", \"fr\": \"7/1, 21h-28/6, travaux. Tram 3 interrompu entre ESPLANADE et DOCKS BRUXSEL. Arr\u00eat du T-bus: avenue de l'Araucaria.\", \"nl\": \"7/1, 21u-28/6, werken. Tram 3 onderbroken tss ESPLANADE en DOCKS BRUXSEL. Halte van de T-bus: Araucarialaan.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"3\"}]", "priority": 4, "points": "[{\"id\": \"5704F\"}]"},{"content": "[{\"text\": [{\"en\": \"From Jan 7 at 9PM to Jun 28, works. Tram 3 replaced by T-bus. Stop T-bus: av. Croix du Feu / Vuurkruisenln, 211-213\", \"fr\": \"Du 7/1 \u00e0 21h au 28/6, travaux. Tram 3 remplac\u00e9 par des T-bus. Arr\u00eat du T-bus: avenue des Croix du Feu, 211-213\", \"nl\": \"Van 7/1 om 21u tot en met 28/6, werken. Tram 3 vervangen door T-bus. Halte T-bus: Vuurkruisenlaan, 211-213\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"3\"}]", "priority": 4, "points": "[{\"id\": \"5773\"}]"},{"content": "[{\"text\": [{\"en\": \"From jan 15, works. STOP NOT SERVED. Take bus 34 at the stop CLESSE of bus 72 to ADEPS.\", \"fr\": \"D\u00e8s le 15/1, travaux. ARRET NON DESSERVI. Prenez le bus 34 \u00e0 l'arr\u00eat CLESSE du bus 72 vers ADEPS.\", \"nl\": \"Vanaf 15/1, werken. HALTE NIET BEDIEND. Neem bus 34 aan de halte CLESSE van bus 72 naar ADEPS.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"34\"}]", "priority": 4, "points": "[{\"id\": \"1719\"}]"},{"content": "[{\"text\": [{\"en\": \"From Apr 3 at 6AM, works. STOP NOT SERVED. Bus 38 at the stop LANGEVELD of bus 60 to UCCLE CALEVOET.\", \"fr\": \"D\u00e8s le 3/4 \u00e0 6h, travaux. ARRET NON DESSERVI. Bus 38 \u00e0 l'arr\u00eat LANGEVELD du bus 60 vers UCCLE CALEVOET.\", \"nl\": \"Vanaf 3/4 om 6u, werken. HALTE NIET BEDIEND. Bus 38 aan halte LANGEVELD van bus 60 naar UKKEL KALEVOET.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"38\"}]", "priority": 4, "points": "[{\"id\": \"1971\"}]"},{"content": "[{\"text\": [{\"en\": \"From Apr 3 at 6AM, works. STOP NOT SERVED. Bus 38 at the stop LANGEVELD of bus 60 to AMBIORIX.\", \"fr\": \"D\u00e8s le 3/4 \u00e0 6h, travaux. ARRET NON DESSERVI. Bus 38 \u00e0 l'arr\u00eat LANGEVELD du bus 60 vers AMBIORIX.\", \"nl\": \"Vanaf 3/4 om 6u, werken. HALTE NIET BEDIEND. Bus 38 aan halte LANGEVELD van bus 60 naar AMBIORIX.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"38\"}]", "priority": 4, "points": "[{\"id\": \"1919\"}]"},{"content": "[{\"text\": [{\"en\": \"From Apr 3 at 6AM, works. Bus 38 diverted between LONGCHAMP and HOUZEAU via rue Edith Cavellstraat.\", \"fr\": \"D\u00e8s le 3/4 \u00e0 6h, travaux. Bus 38 d\u00e9vi\u00e9 entre LONGCHAMP et HOUZEAU via rue Edith Cavell.\", \"nl\": \"Vanaf 3/4 om 6u, werken. Bus 38 omgeleid tussen LONGCHAMP en HOUZEAU via Edith Cavellstraat.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"38\"}]", "priority": 5, "points": "[{\"id\": \"1910\"}, {\"id\": \"3503\"}, {\"id\": \"1909\"}, {\"id\": \"1233\"}, {\"id\": \"6433\"}, {\"id\": \"3122\"}, {\"id\": \"1906\"}, {\"id\": \"1729\"}, {\"id\": \"1903\"}, {\"id\": \"1912\"}]"},{"content": "[{\"text\": [{\"fr\": \"Bon voyage sur nos lignes !\", \"nl\": \"Een goede reis op onze lijnen gewenst!\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"39\"}]", "priority": 9, "points": "[{\"id\": \"5519\"}]"},{"content": "[{\"text\": [{\"en\": \"From Apr 3 at 6AM, works. STOP NOT SERVED. Take bus 38 and 41 at the next stop, HOUZEAU.\", \"fr\": \"D\u00e8s le 3/4 \u00e0 6h, travaux. ARRET NON DESSERVI. Prenez les bus 38 et 41 \u00e0 l'arr\u00eat suivant, HOUZEAU.\", \"nl\": \"Vanaf 3/4 om 6u, werken. HALTE NIET BEDIEND. Neem bus 38 en 41 aan de volgende halte, HOUZEAU.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"41\"}]", "priority": 4, "points": "[{\"id\": \"1920\"}]"},{"content": "[{\"text\": [{\"en\": \"From Apr 3 at 6AM, works. STOP NOT SERVED. Take bus 38 and 41 at the previous stop, HOUZEAU.\", \"fr\": \"D\u00e8s le 3/4 \u00e0 6h, travaux. ARRET NON DESSERVI. Prenez les bus 38 et 41 \u00e0 l'arr\u00eat pr\u00e9c\u00e9dent, HOUZEAU.\", \"nl\": \"Vanaf 3/4 om 6u, werken. HALTE NIET BEDIEND. Neem bus 38 en 41 aan de vorige halte, HOUZEAU.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"41\"}]", "priority": 4, "points": "[{\"id\": \"1970\"}]"},{"content": "[{\"text\": [{\"en\": \"From Mar 4, works. Bus 43 and N11 diverted. Take the bus at GRIOTTES / NOORDKRIEKEN.\", \"fr\": \"D\u00e8s le 4/3, travaux. Bus 43 et N11 d\u00e9vi\u00e9s. Prenez le bus \u00e0 GRIOTTES.\", \"nl\": \"Vanaf 4/3, werken. Bus 43 en N11 omgeleid. Neem de bus aan NOORDKRIEKEN.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"43\"}]", "priority": 4, "points": "[{\"id\": \"1957B\"}, {\"id\": \"1933B\"}, {\"id\": \"1939\"}]"},{"content": "[{\"text\": [{\"en\": \"As from 21 Sept, works. Stop moved +-60m forwards.\", \"fr\": \"D\u00e8s le 21/9, travaux. Arr\u00eat avanc\u00e9 de +-60m.\", \"nl\": \"Vanaf 21/9, werken. Halte +-60m vooruitgebracht.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"45\"}]", "priority": 4, "points": "[{\"id\": \"3462\"}]"},{"content": "[{\"text\": [{\"en\": \"From Jan 22 at 7AM, works. STOP NOT SERVED. Stop of bus 46: rue de Laeken / Lakensestraat 34.\", \"fr\": \"D\u00e8s le 22/1 \u00e0 7h, travaux. ARRET NON DESSERVI. Arr\u00eat du bus 46: rue de Laeken 34.\", \"nl\": \"Van 22/1 om 7u, werken. HALTE NIET BEDIEND. Halte van bus 46: Lakensestraat 34.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"46\"}]", "priority": 4, "points": "[{\"id\": \"3469\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. Until end of August, bus 46 not operated btw WTC-GLIBERT and CENTRAL STATION. Walk to the center.\", \"fr\": \"Travaux. Jsq fin ao\u00fbt, bus 46 ne circule pas entre WTC-GLIBERT et GARE CENTRALE.Pour le centre, continuez \u00e0 pied\", \"nl\": \"Werken. Tot einde augustus rijdt bus 46 niet tss WTC-GLIBERT en CENTRAAL STATION. Voor het centrum, ga te voet.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"46\"}]", "priority": 5, "points": "[{\"id\": \"2835\"}]"},{"content": "[{\"text\": [{\"en\": \"Until Summer of 2024, works. As of Mar 3, STOP NOT SERVED. Stop of bus 47 57: ANTOON VAN OSS.\", \"fr\": \"Jusqu'\u00e0 l'\u00e9t\u00e9 2024, travaux. D\u00e8s le 4/3, ARRET NON DESSERVI. Arr\u00eat des bus 47 57 : ANTOON VAN OSS.\", \"nl\": \"Tot zomer 2024, werken. Vanaf 4/3, HALTE NIET BEDIEND. Halte van bus 47 57: ANTOON VAN OSS\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"47\"}]", "priority": 4, "points": "[{\"id\": \"1827\"}]"},{"content": "[{\"text\": [{\"en\": \"Until Summer of 2024, works. B47 diverted btw CHEMIN VERT and ANT VAN OSS. As of Mar 3, diverted to H. MILITAIRE\", \"fr\": \"Jsq \u00e9t\u00e9 2024, travaux. B47 d\u00e9vi\u00e9 entre CHEMIN VERT et ANTOON VAN OSS. D\u00e8s le 4/3, d\u00e9vi\u00e9 jsq HOPITAL MILITAIRE.\", \"nl\": \"Tot zomer 2024, werken. Bus 47 omgeleid tss GROENWEG en ANTOON VAN OSS. Vanaf 4/3, omgeleid tot MILITAIR HOSPITAAL\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"47\"}]", "priority": 5, "points": "[{\"id\": \"2314\"}]"},{"content": "[{\"text\": [{\"en\": \"From Jan 9th at 6AM, works. STOP UNSERVED. Go to the stop HOP. MILITAIR(E) HOSP. from B53.\", \"fr\": \"D\u00e8s le 9/1 \u00e0 6h, travaux. ARRET NON DESSERVI. Aller \u00e0 l'arr\u00eat HOP. MILITAIRE du B53.\", \"nl\": \"Vanaf 9/1 om 6u, werken. HALTE NIET BEDIEND. Ga naar de halte MILITAIR HOSP. van B53.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"47\"}]", "priority": 4, "points": "[{\"id\": \"3067\"}]"},{"content": "[{\"text\": [{\"en\": \"From Oct 7, works. STOP NOT OPERATED. Temporary stop: David Terniersstraat 115\", \"fr\": \"D\u00e8s le 7/10, travaux. ARRET NON DESSERVI. Arr\u00eat provisoire : David Terniersstraat 115\", \"nl\": \"Vanaf 7/10, werken. HALTE NIET BEDIEND. Tijdelijke halte: David Terniersstraat 115\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"47\"}]", "priority": 4, "points": "[{\"id\": \"9627\"}]"},{"content": "[{\"text\": [{\"en\": \"From Feb 7, works. STOP NOT SERVED. Temporary stop: Vlierkensstraat 174.\", \"fr\": \"D\u00e8s le 7/2, travaux. ARRET NON DESSERVI. Arr\u00eat provisoire: Vlierkensstraat 174.\", \"nl\": \"Vanaf 7/2, werken. HALTE NIET BEDIEND. Tijdelijke halte: Vlierkensstraat 174.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"47\"}]", "priority": 4, "points": "[{\"id\": \"9605\"}]"},{"content": "[{\"text\": [{\"en\": \"Until Summer of 2024, works. Stop not served. Stop of bus 47: VERGER / BOOMGAARD (av. Croix de Guerre/Oorlogskruisenln)\", \"fr\": \"Jusqu'\u00e0 l'\u00e9t\u00e9 2024, travaux. Arr\u00eat non desservi. Arr\u00eat du bus 47 : VERGER (avenue des Croix de Guerre).\", \"nl\": \"Tot zomer 2024, werken. Halte niet bediend. Halte van bus 47: BOOMGAARD (Oorlogskruisenlaan).\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"47\"}]", "priority": 4, "points": "[{\"id\": \"2312\"}, {\"id\": \"2363\"}]"},{"content": "[{\"text\": [{\"en\": \"Until Summer of 2024, works. Stop not served. Take bus 47 or 56 at ANTOON VAN OSS. For HOP MILITAIRE , walk.\", \"fr\": \"Jsq \u00e9t\u00e9 2024, travaux. Arr\u00eat non desservi. Bus 47 ou 56 \u00e0 ANTOON VAN OSS. Pour HOPITAL MILITAIRE, \u00e0 pied.\", \"nl\": \"Tot zomer 2024, werken. Halte niet bediend. Neem bus 47 of 56 aan ANTOON VAN OSS. Voor MILITAIR HOSPITAAL, ga te voet.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"47\"}]", "priority": 4, "points": "[{\"id\": \"1838\"}]"},{"content": "[{\"text\": [{\"en\": \"Until Summer of 2024, works. Stop not served. Stop of bus 47: CROIX DE GUERRE / OORLOGSKRUISEN.\", \"fr\": \"Jusqu'\u00e0 l'\u00e9t\u00e9 2024, travaux. Arr\u00eat non desservi. Arr\u00eat du bus 47 : CROIX DE GUERRE.\", \"nl\": \"Tot zomer 2024, werken. Halte niet bediend. Halte van bus 47: OORLOGSKRUISEN.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"47\"}]", "priority": 4, "points": "[{\"id\": \"1987\"}]"},{"content": "[{\"text\": [{\"en\": \"Until Summer of 2024, works. Bus 47 diverted btw VTM and RAMIER. As of Mar 18, stop HOPITAL MILITAIRE in rue Bruyn.\", \"fr\": \"Jsq \u00e9t\u00e9 2024, travaux. Bus 47 d\u00e9vi\u00e9 entre VTM et RAMIER. D\u00e8s le 18/3, arr\u00eat HOPITAL MILITAIRE rue Bruyn.\", \"nl\": \"Tot zomer 2024, werken. Bus 47 omgeleid tussen VTM en BOSDUIF. Vanaf 18/3,halte MILITAIR HOSP in de Bruynstraat.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"47\"}]", "priority": 5, "points": "[{\"id\": \"9634\"}, {\"id\": \"9784B\"}, {\"id\": \"9786\"}, {\"id\": \"9632\"}, {\"id\": \"9606\"}]"},{"content": "[{\"text\": [{\"en\": \"From Apr 22 at 12PM, works. STOP NOT SERVED. Stop of bus 50: avenue Paul Gilsonlaan, just before this stop.\", \"fr\": \"D\u00e8s 22/4 \u00e0 12h, travaux. ARRET NON DESSERVI. Arr\u00eat du bus 50: avenue Paul Gilson, peu avant cet arr\u00eat.\", \"nl\": \"Vanaf 22/4 om 12u, werken. HALTE NIET BEDIEND. Halte van bus 50: Paul Gilsonlaan, net voor deze halte.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"50\"}]", "priority": 4, "points": "[{\"id\": \"2609\"}]"},{"content": "[{\"text\": [{\"en\": \"Until 2026, works. Bus 50 diverted to FOREST CENTRE / VORST CENTRUM. Stop of bus 50: r. Abbesses / Abdissenstr.\", \"fr\": \"Jusqu'en 2026, travaux. Bus 50 d\u00e9vi\u00e9 jusqu'\u00e0 FOREST CENTRE. Arr\u00eat du bus 50: rue des Abbesses.\", \"nl\": \"Tot 2026, werken. Bus 50 omgeleid tot VORST CENTRUM. Halte van bus 50: Abdissenstraat.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"50\"}]", "priority": 4, "points": "[{\"id\": \"5152\"}]"},{"content": "[{\"text\": [{\"en\": \"Until Summer of 2024, works. Stop not served. Stop of bus 53: KRUIPWEG (rue du Paturage / Weilandstraat).\", \"fr\": \"Jusqu'\u00e0 l'\u00e9t\u00e9 2024, travaux. Arr\u00eat non desservi. Arr\u00eat du bus 53 : KRUIPWEG (rue du Paturage)\", \"nl\": \"Tot zomer 2024, werken. Halte niet bediend. Halte van bus 53: KRUIPWEG (Weilandstraat)\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"53\"}]", "priority": 4, "points": "[{\"id\": \"2312\"}, {\"id\": \"2363\"}]"},{"content": "[{\"text\": [{\"en\": \"From Apr 2, 2024 to June 2025, works. STOP NOT SERVED. To go to BERVOETS, take bus 50 or T-bus(stop: r. Abbesses)\", \"fr\": \"Du 2/4/2024 \u00e0 juin 2025, travaux. ARRET NON DESSERVI. Pour rejoindre BERVOETS,bus 50 ou T-bus (arr\u00eat: r. des Abbesses)\", \"nl\": \"Van 2/4/2024 tot juni 2025, werken. HALTE NIET BEDIEND. Voor BERVOETS, neem bus 50 of de T-bus (halte: Abdissenstraat)\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"54\"}]", "priority": 4, "points": "[{\"id\": \"5161\"}]"},{"content": "[{\"text\": [{\"en\": \"From Apr 2, 2024 to June 2025, works. STOP NOT SERVED. To go to BERVOETS, take bus 50 or T-bus at FOREST CENTRE.\", \"fr\": \"Du 2/4/2024 \u00e0 juin 2025, travaux. ARRET NON DESSERVI. Pour rejoindre BERVOETS, bus 50 ou T-bus \u00e0 FOREST CENTRE.\", \"nl\": \"Van 2/4/2024 tot juni 2025, werken. HALTE NIET BEDIEND. Voor BERVOETS, neem bus 50 of de T-bus aan VORST CENTRUM.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"54\"}]", "priority": 4, "points": "[{\"id\": \"5152\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. From Apr 2 until June 2025, STOP NOT SERVED. Take bus 54 at the previous stop, FOREST CENTRE.\", \"fr\": \"Travaux. Du 2/4 \u00e0 juin 2025, ARRET NON DESSERVI. Prenez le bus 54 \u00e0 l'arr\u00eat pr\u00e9c\u00e9dent, FOREST CENTRE.\", \"nl\": \"Werken. Vanaf 2/4 tot juni 2025, HALTE NIET BEDIEND. Neem bus 54 aan de vorige halte, VORST CENTRUM.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"54\"}]", "priority": 4, "points": "[{\"id\": \"5719\"}]"},{"content": "[{\"text\": [{\"en\": \"As of May 6, works. Bus 54 diverted between FERNAND COCQ and BAILLI / BALJUW via FLAGEY.\", \"fr\": \"D\u00e8s le 6/5, travaux. Bus 54 d\u00e9vi\u00e9 entre FERNAND COCQ et BAILLI via FLAGEY.\", \"nl\": \"Vanaf 6/5, werken. Bus 54 omgeleid tussen FERNAND COCQ en BALJUW via FLAGEY.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"54\"}]", "priority": 5, "points": "[{\"id\": \"1734\"}, {\"id\": \"1780\"}, {\"id\": \"2928\"}, {\"id\": \"3518B\"}, {\"id\": \"3506\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. As of Apr 15, bus 56 diverted from AMBIORIX to MAELBEEK. Connection metro at MAELBEEK / MAALBEEK.\", \"fr\": \"Travaux. D\u00e8s le 15/4, bus 56 d\u00e9vi\u00e9 depuis AMBIORIX vers MAELBEEK. Correspondance m\u00e9tro \u00e0 MAELBEEK.\", \"nl\": \"Werken. Vanaf 15/4, bus 56 omgeleid vanaf AMBIORIX naar MAALBEEK. Aansluiting metro aan MAALBEEK.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"56\"}]", "priority": 6, "points": "[{\"id\": \"2092\"}, {\"id\": \"6461\"}, {\"id\": \"5740\"}, {\"id\": \"2100\"}, {\"id\": \"2067\"}, {\"id\": \"6191\"}, {\"id\": \"9291\"}, {\"id\": \"2097\"}, {\"id\": \"2096\"}, {\"id\": \"2094\"}, {\"id\": \"1007\"}, {\"id\": \"2920\"}, {\"id\": \"3414\"}, {\"id\": \"2105\"}, {\"id\": \"2102\"}]"},{"content": "[{\"text\": [{\"en\": \"Until Summer 2024,works. B56 diverted btw P. BENOIT and VAN PRAET. As of Mar 18, bus 56 serves the stop MERCATOR.\", \"fr\": \"Jsq \u00e9t\u00e9 2024, travaux. Bus 56 d\u00e9vi\u00e9 entre P. BENOIT et VAN PRAET. D\u00e8s le 18/3, bus 56 dessert \u00e0 nouveau MERCATOR.\", \"nl\": \"Tot zomer 2024, werken. Bus 56 omgeleid tss P. BENOIT en VAN PRAET. Vanaf 18/3 bedient bus 56 opnieuw MERCATOR.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"56\"}]", "priority": 4, "points": "[{\"id\": \"2379\"}, {\"id\": \"1991\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. STOP NOT SERVED. Take bus 47 56 at the usual stop of trams 3 7 direction CHURCHILL / VANDERKINDERE.\", \"fr\": \"Travaux. ARRET NON DESSERVI. Prenez le bus 47 56 \u00e0 l'arr\u00eat habituel des trams 3 7 vers CHURCHILL/VANDERKINDERE.\", \"nl\": \"Werken. HALTE NIET BEDIEND. Neem bus 47 56 aan de gebruikelijke halte van tram 3 7 naar CHURCHILL/VANDERKINDERE.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"56\"}]", "priority": 4, "points": "[{\"id\": \"6368C\"}]"},{"content": "[{\"text\": [{\"en\": \"Until Summer of 2024, works. Bus 56 diverted. Stop of bus 56: avenue des Croix de l'Yser / IJzerkruisenlaan 36.\", \"fr\": \"Jusqu'\u00e0 l'\u00e9t\u00e9 2024, travaux. Bus 56 d\u00e9vi\u00e9. Arr\u00eat du bus 56 : avenue des Croix de l'Yser 36.\", \"nl\": \"Tot zomer 2024, werken. Bus 56 omgeleid. Halte van bus 56: IJzerkruisenlaan 36.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"56\"}]", "priority": 4, "points": "[{\"id\": \"2093\"}]"},{"content": "[{\"text\": [{\"en\": \"Until Summer of 2024, works. Bus 56 diverted. Take bus 56 at ANTOON VAN OSS.\", \"fr\": \"Jusqu'\u00e0 l'\u00e9t\u00e9 2024, travaux. Bus 56 d\u00e9vi\u00e9. Prenez le bus 56 \u00e0 ANTOON VAN OSS.\", \"nl\": \"Tot zomer 2024, werken. Bus 56 omgeleid. Neem bus 56 aan ANTOON VAN OSS.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"56\"}]", "priority": 4, "points": "[{\"id\": \"1827\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. STOP NOT SERVED. Temporary stop: avenue des Croix de Guerre 78\", \"fr\": \"Jusqu'\u00e0 l'\u00e9t\u00e9 2024, travaux. Arr\u00eat des bus 47 et 56 : avenue des Croix de Guerre 78.\", \"nl\": \"Tot zomer 2024, werken. Halte van bus 47 en 56: Oorlogskruisenlaan 78.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"56\"}]", "priority": 4, "points": "[{\"id\": \"2377\"}, {\"id\": \"2299\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. As of March 18, bus 56 operates normally between HOP. MILITAIRE / MILITAIR HOSP. and ANTOON VAN OSS.\", \"fr\": \"Travaux. D\u00e8s le 18/3, bus 56 circule \u00e0 nouveau normalement entre HOPITAL MILITAIRE et ANTOON VAN OSS.\", \"nl\": \"Werken. Vanaf 18/3 rijdt B56 opnieuw langs zijn gebruikelijke reisweg tss MILITAIR HOSPITAAL en ANTOON VAN OSS.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"56\"}]", "priority": 5, "points": "[{\"id\": \"2365\"}, {\"id\": \"2827\"}, {\"id\": \"1989\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. As of Apr 15, STOP NOT SERVED. Take bus 56 at AMBIORIX (stop of bus 64 to Bordet Station).\", \"fr\": \"Travaux. D\u00e8s le 15/4, ARRET NON DESSERVI. Prenez le bus 56 \u00e0 AMBIORIX (arr\u00eat du bus 64 vers Bordet Station).\", \"nl\": \"Werken. Vanaf 15/4, HALTE NIET BEDIEND. Neem bus 56 aan AMBIORIX (halte van bus 64 naar Bordet Station).\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"56\"}]", "priority": 4, "points": "[{\"id\": \"1474B\"}, {\"id\": \"2083\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. Bus 56 diverted between VERGER and VAN PRAET via avenue des Croix de Guerre\", \"fr\": \"Travaux. Bus 56 d\u00e9vi\u00e9 entre VERGER et VAN PRAET via avenue des Croix de Guerre\", \"nl\": \"Werken. Bus 56 omgeleid tussen BOOMGAARD en VAN PRAET via Oorlogskruisenlaan\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"56\"}]", "priority": 5, "points": "[{\"id\": \"2823B\"}, {\"id\": \"2766\"}]"},{"content": "[{\"text\": [{\"en\": \"Until Summer of 2024, works. Stop not served. Take bus 47 or 57 at ANTOON VAN OSS (stop of bus 56 to BUDA).\", \"fr\": \"Jsq \u00e9t\u00e9 2024, travaux. Arr\u00eat non desservi. Prenez le bus 47 ou 57 \u00e0 ANTOON VAN OSS (arr\u00eat du bus 56 vers BUDA).\", \"nl\": \"Tot zomer 2024, werken. Halte niet bediend. Neem bus 47 of 57 aan ANTOON VAN OSS (halte van bus 56 naar BUDA).\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"56\"}]", "priority": 4, "points": "[{\"id\": \"1837\"}]"},{"content": "[{\"text\": [{\"en\": \"From Dec 4, works. STOP NOT SERVED. Take bus 14 and 57 under the CCN building, at the terminus of bus 61.\", \"fr\": \"D\u00e8s le 4/12, travaux. ARRET NON DESSERVI. Prenez le bus 14 et 57 sous le b\u00e2timent CCN, au terminus du bus 61.\", \"nl\": \"Vanaf 4/12, werken. HALTE NIET BEDIEND. Neem bus 14 en 57 onder het CCN-gebouw, aan eindhalte bus 61.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"57\"}]", "priority": 4, "points": "[{\"id\": \"1082\"}]"},{"content": "[{\"text\": [{\"en\": \"Until Summer of 2024, works. Stop not served. Stop of bus 57: chauss\u00e9e de Vilvorde, in front of number 150.\", \"fr\": \"Jusqu'\u00e0 l'\u00e9t\u00e9 2024, travaux. Arr\u00eat non desservi. Arr\u00eat du bus 57: ch\u00e9e de Vilvorde, en face du num\u00e9ro 150.\", \"nl\": \"Tot zomer 2024, werken. Halte niet bediend. Halte van bus 57: Vilvoordsesteenweg, tegenover nummer 150.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"57\"}]", "priority": 4, "points": "[{\"id\": \"3063\"}]"},{"content": "[{\"text\": [{\"en\": \"Until Summer of 2024, works. As of Mar 18, stop served normally by bus 57.\", \"fr\": \"Jusqu'\u00e0 l'\u00e9t\u00e9 2024, travaux. D\u00e8s le 18/3, arr\u00eat \u00e0 nouveau desservi par les bus 57.\", \"nl\": \"Tot zomer 2024, werken. Vanaf 18/3, halte opnieuw bediend door bus 57.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"57\"}]", "priority": 4, "points": "[{\"id\": \"2352\"}]"},{"content": "[{\"text\": [{\"en\": \"Until Summer of 2024, works. Stop not served. Stop of bus 57: MARLY.\", \"fr\": \"Jsq \u00e9t\u00e9 2024, travaux. Arr\u00eat non desservi. Arr\u00eat du bus 57 : MARLY.\", \"nl\": \"Tot zomer 2024, werken. Halte niet bediend. Halte van bus 57: MARLY.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"57\"}]", "priority": 4, "points": "[{\"id\": \"2360\"}]"},{"content": "[{\"text\": [{\"en\": \"Until Summer of 2024, works. Stop not served. Take bus 47 or 56 at ANTOON VAN OSS. For HOP MILITAIRE , walk.\", \"fr\": \"Jsq \u00e9t\u00e9 2024, travaux. Arr\u00eat non desservi. Bus 47 ou 56 \u00e0 ANTOON VAN OSS. Pour HOPITAL MILITAIRE, \u00e0 pied.\", \"nl\": \"Tot zomer 2024, werken. Halte niet bediend. Neem bus 47 of 56 aan ANTOON VAN OSS. Voor MILITAIR HOSPITAAL, ga te voet.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"57\"}]", "priority": 4, "points": "[{\"id\": \"1838\"}]"},{"content": "[{\"text\": [{\"en\": \"From Dec 4, works. STOP NOT SERVED. Take bus 58 at the stop WTC of bus 14 direction UZ-VUB.\", \"fr\": \"D\u00e8s le 4/12, travaux. ARRET NON DESSERVI. Prenez le bus 58 \u00e0 l'arr\u00eat WTC du bus 14 direction UZ-VUB.\", \"nl\": \"Vanaf 4/12, werken. HALTE NIET BEDIEND. Neem bus 58 aan de halte WTC van bus 14 richting UZ-VUB.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"58\"}]", "priority": 4, "points": "[{\"id\": \"3400\"}]"},{"content": "[{\"text\": [{\"en\": \"From Oct 22, works. The stop is moved : Rue du Pavillon, 86. (Moved 20m forwards).\", \"fr\": \"A partir du 22/10, travaux. Arr\u00eat d\u00e9plac\u00e9 : rue du Pavillon, 86. (Avanc\u00e9 de 20m).\", \"nl\": \"Vanaf 22/10, werken. De halte is verplaatst : Palvijoenstraat, 86. (20m vooruitgebracht).\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"58\"}]", "priority": 4, "points": "[{\"id\": \"5741\"}]"},{"content": "[{\"text\": [{\"en\": \"From Dec 4, works. STOP NOT SERVED. Stop of bus 58 and 88 : rue du Progr\u00e8s, after crossing rue des Charbonniers.\", \"fr\": \"D\u00e8s le 4/12, travaux. ARRET NON DESSERVI. Arr\u00eat des bus 58 et 88 : rue du Progr\u00e8s, apr\u00e8s rue des Charbonniers.\", \"nl\": \"Vanaf 4/12, werken. HALTE NIET BEDIEND. Halte bus 58 en 88 : Vooruitgangstraat, na Koolbrandersstraat.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"58\"}]", "priority": 4, "points": "[{\"id\": \"1083\"}]"},{"content": "[{\"text\": [{\"en\": \"From Mar 5 at 9AM, works. STOP NOT SERVED. Temporary stop: avenue Jean & Pierre Carsoellaan 4.\", \"fr\": \"D\u00e8s le 5/3 \u00e0 9h, travaux. ARRET NON DESSERVI. Arr\u00eat provisoire: avenue Jean et Pierre Carsoel 4.\", \"nl\": \"Vanaf 5/3 om 9u, werken. HALTE NIET BEDIEND. Tijdelijke halte: Jean en Pierre Carsoellaan 4.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"60\"}]", "priority": 4, "points": "[{\"id\": \"6931B\"}]"},{"content": "[{\"text\": [{\"en\": \"From May 2 at 7AM, works. STOP NOT SERVED. Take bus 60 at the stop MUSEUM of bus 34 to PORTE DE NAMUR.\", \"fr\": \"D\u00e8s le 2/5 \u00e0 7h, travaux. ARRET NON DESSERVI. Prenez le bus 60 \u00e0 l'arr\u00eat MUSEUM du B34 vers PORTE DE NAMUR.\", \"nl\": \"Vanaf 2/5 om 7u, werken. HALTE NIET BEDIEND. Neem bus 60 aan de halte MUSEUM van bus 34 naar NAAMSEPOORT.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"60\"}]", "priority": 4, "points": "[{\"id\": \"1880\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. As of Apr 15, bus 60 diverted. Take bus 60 at the previous stop, at the St-Cyr house.\", \"fr\": \"Travaux. D\u00e8s le 15/4,bus 60 d\u00e9vi\u00e9. Prenez le bus 60 \u00e0 l'arr\u00eat pr\u00e9c\u00e9dent, devant la maison Saint-Cyr.\", \"nl\": \"Werken. Vanaf 15/4, bus 60 omgeleid. Neem bus 60 aan de vorige halte, voor het St-Cyr-huis.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"60\"}]", "priority": 4, "points": "[{\"id\": \"1273\"}]"},{"content": "[{\"text\": [{\"en\": \"From Mar 11, works. Bus 60 diverted between GROELSTVELD and DE WANSIJN via DIEWEG.\", \"fr\": \"D\u00e8s le 11/3, travaux. Bus 60 d\u00e9vi\u00e9 entre GROELSTVELD et DE WANSIJN via DIEWEG.\", \"nl\": \"Vanaf 11/3, werken. Bus 60 omgeleid tussen GROELSTVELD en DE WANSIJN via DIEWEG.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"60\"}]", "priority": 5, "points": "[{\"id\": \"2702\"}, {\"id\": \"2701\"}, {\"id\": \"1929\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. As of Apr 15, STOP NOT SERVED. Take bus 60 at the stop of bus 27 to LUXEMBOURG / LUXEMBURG.\", \"fr\": \"Travaux. D\u00e8s le 15/4, ARRET NON DESSERVI. Prenez le bus 60 \u00e0 l'arr\u00eat du bus 27 vers LUXEMBOURG.\", \"nl\": \"Werken. Vanaf 15/4, HALTE NIET BEDIEND. Neem bus 60 aan de halte van bus 27 naar LUXEMBURG.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"60\"}]", "priority": 4, "points": "[{\"id\": \"1416\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. As of April 7th, stop served only by bus 66. Take bus 29, 63 or 65 at the stop of bus 71 to DELTA.\", \"fr\": \"Travaux. D\u00e8s le 7/4, arr\u00eat uniquement desservi par bus 66. Bus 29, 63 ou 65 \u00e0 l'arr\u00eat du bus 71 vers DELTA.\", \"nl\": \"Werken. Vanaf 7/4, halte enkel bediend door bus 66. Neem bus 29, 63 of 65 aan de halte van bus 71 naar DELTA.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"65\"}]", "priority": 4, "points": "[{\"id\": \"6445\"}]"},{"content": "[{\"text\": [{\"en\": \"From Apr 14 at 7AM, works. STOP NOT SERVED. Take bus 66 at the drop off stop.\", \"fr\": \"D\u00e8s le 14/4 \u00e0 7h, travaux. ARRET NON DESSERVI. Prenez le bus 66 \u00e0 l'arr\u00eat de d\u00e9barquement.\", \"nl\": \"Vanaf 14/4 om 7u, werken. HALTE NIET BEDIEND. Neem bus 66 aan de afstaphalte.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"66\"}]", "priority": 4, "points": "[{\"id\": \"3284\"}]"},{"content": "[{\"text\": [{\"en\": \"Jan 8-Jun 28, works. Stop not served. Stop of tram 7: av. Croix du Feu in front of av. Pagodes.\", \"fr\": \"8/1-28/6, travaux. Arr\u00eat non desservi. Arr\u00eat du tram 7: avenue des Croix du Feu, \u00e0 hauteur de l'avenue des Pagodes.\", \"nl\": \"8/1-28/6, werken. Halte niet bediend. Halte van tram 7: Vuurkruisenlaan, ter hoogte van de Pagodenlaan.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"7\"}]", "priority": 5, "points": "[{\"id\": \"5771\"}]"},{"content": "[{\"text\": [{\"en\": \"Jan 7, 9PM-Jun 28,works. Stop not served. Stop T-bus to DOCKS BRUXSEL: av. Croix du Feu, crossing av. Pagodes.\", \"fr\": \"7/1, 21h-28/6, travaux. Arr\u00eat non desservi.Arr\u00eat du T-bus vers DOCKS BRUXSEL: av. Croix du Feu, carr. av. Pagodes.\", \"nl\": \"7/1, 21u-28/6, werken. Halte niet bediend.Halte van de T-bus naar DOCKS BRUXSEL: Vuurkruisenln, kruispt Pagodenln.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"7\"}]", "priority": 5, "points": "[{\"id\": \"5706\"}]"},{"content": "[{\"text\": [{\"en\": \"Jan 8-Jun 28, works. Tram 7 interrupted btw HEEMBEEK and DOCKS BXL. Stop of the T-bus to DOCKS BXL: av. Araucaria\", \"fr\": \"8/1-28/6, travaux. T7 interrompu de HEEMBEEK \u00e0 DOCKS BRUXSEL. Arr\u00eat du T-bus vers DOCKS BRUXSEL: av. Araucaria\", \"nl\": \"8/1-28/6, werken. T7 onderbroken tss HEEMBEEK en DOCKS BRUXSEL. Halte T-bus naar DOCKS BRUXSEL: Araucarialaan.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"7\"}]", "priority": 5, "points": "[{\"id\": \"5704F\"}]"},{"content": "[{\"text\": [{\"en\": \"Jan 8-Jun 28, works. Tram 7 replaced by T-bus between DOCKS BRUXSEL and HEEMBEEK. Info: stib-mivb.brussels\", \"fr\": \"8/1-28/6, travaux. Tram 7 remplac\u00e9 par des T-bus entre DOCKS BRUXSEL et HEEMBEEK. Info: stib. brussels.\", \"nl\": \"8/1-28/6, werken. Tram 7 vervangen door T-bus tussen DOCKS BRUXSEL en HEEMBEEK. info: mivb. brussels.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"7\"}]", "priority": 6, "points": "[{\"id\": \"5261\"}, {\"id\": \"5267\"}, {\"id\": \"5264F\"}, {\"id\": \"5256F\"}, {\"id\": \"5355F\"}, {\"id\": \"1048F\"}, {\"id\": \"5222F\"}, {\"id\": \"3480\"}, {\"id\": \"6456F\"}, {\"id\": \"5258\"}, {\"id\": \"0806\"}, {\"id\": \"5357\"}, {\"id\": \"0906\"}, {\"id\": \"5359\"}, {\"id\": \"0826\"}, {\"id\": \"5253\"}, {\"id\": \"5352\"}, {\"id\": \"5254\"}, {\"id\": \"5356\"}, {\"id\": \"5265F\"}, {\"id\": \"5221F\"}, {\"id\": \"5354H\"}, {\"id\": \"5255F\"}, {\"id\": \"5350G\"}, {\"id\": \"9963F\"}, {\"id\": \"0816\"}, {\"id\": \"2243F\"}]"},{"content": "[{\"text\": [{\"en\": \"Jan 8-Jun 28, works. Stop not served. T-bus to HEEMBEEK and DE WAND at the stop of bus 56 to BUDA.\", \"fr\": \"8/1-28/6, travaux. Arr\u00eat non desservi. T-bus vers HEEMBEEK et DE WAND \u00e0 l'arr\u00eat du bus 56 vers BUDA.\", \"nl\": \"8/1-28/6, werken. Halte niet bediend. T-bus naar HEEMBEEK en DE WAND aan de halte van bus 56 naar BUDA.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"7\"}]", "priority": 5, "points": "[{\"id\": \"5770F\"}]"},{"content": "[{\"text\": [{\"en\": \"Jan 8-Jun 28, works. Tram 7 interrupted btw HEEMBEEK and DOCKS BXL. Stop T-bus to DOCKS BXL: next to this stop.\", \"fr\": \"8/1-28/6, travaux. T7 interrompu de HEEMBEEK \u00e0 DOCKS BXL. Arr\u00eat du T-bus vers DOCKS BXL: \u00e0 c\u00f4t\u00e9 de cet arr\u00eat.\", \"nl\": \"8/1-28/6, werken. T7 onderbroken tss HEEMBEEK en DOCKS BXL. Halte T-bus naar DOCKS BXL: naast deze halte.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"7\"}]", "priority": 5, "points": "[{\"id\": \"5705\"}]"},{"content": "[{\"text\": [{\"en\": \"From Jan 8 to Jun 28, works. After CHURCHILL, tram 7 continues on line 3 direction ESPLANADE.\", \"fr\": \"Du 8/1 au 28/6, travaux. Apr\u00e8s CHURCHILL, tram 7 continue sur la ligne 3 direction ESPLANADE.\", \"nl\": \"Van 8/1 tot en met 28/6, werken. Na CHURCHILL rijdt tram 7 verder op lijn 3 richting ESPLANADE.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"7\"}]", "priority": 6, "points": "[{\"id\": \"5307H\"}, {\"id\": \"5317G\"}, {\"id\": \"5305G\"}, {\"id\": \"5220F\"}, {\"id\": \"5200F\"}, {\"id\": \"5266F\"}, {\"id\": \"3481\"}, {\"id\": \"0821\"}, {\"id\": \"0901\"}, {\"id\": \"2246F\"}, {\"id\": \"0801\"}, {\"id\": \"5306G\"}, {\"id\": \"5308F\"}, {\"id\": \"5210\"}, {\"id\": \"5211\"}, {\"id\": \"5758F\"}, {\"id\": \"5311\"}, {\"id\": \"5212\"}, {\"id\": \"5213\"}, {\"id\": \"5312\"}, {\"id\": \"1049F\"}, {\"id\": \"6457F\"}, {\"id\": \"5303\"}, {\"id\": \"5205\"}, {\"id\": \"5208\"}, {\"id\": \"9969F\"}, {\"id\": \"0811\"}]"},{"content": "[{\"text\": [{\"en\": \"From Mar 18, works. STOP NOT SERVED. Temporary stop: avenue de la Couronne / Kroonlaan 439-443.\", \"fr\": \"D\u00e8s le 18/3, travaux. ARRET NON DESSERVI. Arr\u00eat provisoire: avenue de la Couronne 439-443.\", \"nl\": \"Vanaf 18/3, werken. HALTE NIET BEDIEND. Tijdelijke halte: Kroonlaan 439-443.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"72\"}]", "priority": 4, "points": "[{\"id\": \"3558\"}]"},{"content": "[{\"text\": [{\"en\": \"From Apr 2, 2024 to June 2025, works. STOP NOT SERVED. Stop of bus 74: FOREST NATIONAL (av. du Globelaan 43)\", \"fr\": \"Du 2/4/2024 \u00e0 juin 2025, travaux. ARRET NON DESSERVI. Arr\u00eat du bus 74: FOREST NATIONAL (avenue du Globe 43).\", \"nl\": \"Van 2/4/2024 tot juni 2025, werken. HALTE NIET BEDIEND. Halte van bus 74: VORST NATIONAAL (Globelaan 43)\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"74\"}]", "priority": 4, "points": "[{\"id\": \"2952B\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. From Apr 2 until June 2025, STOP NOT SERVED. Take bus 74 at the previous stop, FOREST CENTRE.\", \"fr\": \"Travaux. Du 2/4 \u00e0 juin 2025, ARRET NON DESSERVI. Prenez le bus 74 \u00e0 l'arr\u00eat pr\u00e9c\u00e9dent, FOREST CENTRE.\", \"nl\": \"Werken. Vanaf 2/4 tot juni 2025, HALTE NIET BEDIEND. Neem bus 74 aan de vorige halte, VORST CENTRUM.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"74\"}]", "priority": 4, "points": "[{\"id\": \"5719\"}]"},{"content": "[{\"text\": [{\"en\": \"From Apr 2, 2024 to June 2025, works. STOP NOT SERVED. Stop of bus 74: FOREST NATIONAL (av. du Globelaan 8).\", \"fr\": \"Du 2/4/2024 \u00e0 juin 2025, travaux. ARRET NON DESSERVI. Arr\u00eat des bus 74: FOREST NATIONAL. (avenue du Globe 8).\", \"nl\": \"Van 2/4/2024 tot juni 2025, werken. HALTE NIET BEDIEND. Halte van bus 74: VORST NATIONAAL (Globelaan 8)\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"74\"}]", "priority": 4, "points": "[{\"id\": \"2939B\"}]"},{"content": "[{\"text\": [{\"en\": \"From Apr 2, 2024 to June 2025, works. STOP NOT SERVED. Stop of bus 74: av. du Globelaan 43.\", \"fr\": \"Du 2/4/2024 \u00e0 juin 2025, travaux. ARRET NON DESSERVI. Arr\u00eat du bus 74: avenue du Globe 43.\", \"nl\": \"Van 2/4/2024 tot juni 2025, werken. HALTE NIET BEDIEND. Halte van bus 74: Globelaan 43.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"74\"}]", "priority": 4, "points": "[{\"id\": \"2732\"}]"},{"content": "[{\"text\": [{\"en\": \"Subsidence. Bus 74 limited to DECROLY. Take bus 74 at DECROLY.\", \"fr\": \"Effondrement. Bus 74 limit\u00e9 \u00e0 DECROLY. Prenez le bus 74 \u00e0 DECROLY.\", \"nl\": \"Wegverzakking. Bus 74 beperkt tot DECROLY. Neem bus 74 aan DECROLY.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"74\"}]", "priority": 4, "points": "[{\"id\": \"2417\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. As of Apr 15, bus 79 diverted from MICHEL-ANGE to MAELBEEK. Stop SCHUMAN moved rue Franklin.\", \"fr\": \"Travaux. D\u00e8s le 15/4, bus 79 d\u00e9vi\u00e9 depuis MICHEL-ANGE vers MAELBEEK. Arr\u00eat SCHUMAN d\u00e9plac\u00e9 rue Franklin.\", \"nl\": \"Werken. Vanaf 15/4, bus 79 omgeleid vanaf MICHELANGELO naar MAALBEEK. Halte SCHUMAN verplaatst Franklinstr.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"79\"}]", "priority": 6, "points": "[{\"id\": \"6450\"}, {\"id\": \"6055\"}, {\"id\": \"9853\"}, {\"id\": \"1462\"}, {\"id\": \"2043\"}, {\"id\": \"2042\"}, {\"id\": \"2041\"}, {\"id\": \"3902\"}, {\"id\": \"3903\"}, {\"id\": \"3904\"}, {\"id\": \"2028\"}, {\"id\": \"3905\"}, {\"id\": \"1533\"}, {\"id\": \"1531\"}, {\"id\": \"1464\"}, {\"id\": \"1463\"}, {\"id\": \"1320\"}, {\"id\": \"3920\"}, {\"id\": \"3911\"}, {\"id\": \"1339\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. Until 2026, tram 82 and 97 interrupted. Stop of the T-bus and of bus 50: ch. de Neerstalsestwg 236.\", \"fr\": \"Travaux. Jsq 2026, tram 82 et 97 interrompus. Arr\u00eat du T-bus et du bus 50: chauss\u00e9e de Neerstalle 236\", \"nl\": \"Werken. Tot 2026, tram 82 en 97 onderbroken. Halte van de T-bus en van bus 50: Neerstalsesteenweg 236\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"82\"}]", "priority": 4, "points": "[{\"id\": \"5164F\"}]"},{"content": "[{\"text\": [{\"en\": \"Until 2026,works.Tram 82 replaced by T-bus btw FOREST CENTRE / VORST CENTRUM and DROGENBOS. More info: stib-mivb.be.\", \"fr\": \"Jusqu'en 2026, travaux. Tram 82 remplac\u00e9 par des T-bus entre FOREST CENTRE et DROGENBOS. Info: stib.brussels.\", \"nl\": \"Tot 2026, werken. Tram 82 wordt vervangen door T-bus tussen VORST CENTRUM en DROGENBOS. Info: mivb.brussels.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"82\"}]", "priority": 4, "points": "[{\"id\": \"5163F\"}]"},{"content": "[{\"text\": [{\"en\": \"Until 2026, works. T-bus 82/97 diverted. Stop T-bus 82/97: bd 2e Arm\u00e9e Britannique / Britse Tweedelegerlaan.\", \"fr\": \"Jsq 2026, travaux. T-bus 82/97 d\u00e9vi\u00e9. Arr\u00eat T-bus 82/97: bd 2e Arm\u00e9e Britannique, carrefour rue de la Station.\", \"nl\": \"Tot 2026, werken. T-bus 82/97 omgeleid. Halte T-bus 82/97: Britse Tweedelegerlaan, kruispunt Stationstraat.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"82\"}]", "priority": 4, "points": "[{\"id\": \"5719H\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. Until 2026, stop not served. Stop of the T-bus: Grote Baan 227 (stop of De Lijn to Anderlecht).\", \"fr\": \"Travaux. Jsq 2026, arr\u00eat non desservi. Arr\u00eat du T-bus: Grand'Route 227 (arr\u00eat des bus De Lijn vers Anderlecht).\", \"nl\": \"Werken. Tot 2026, halte niet bediend. Halte van de T-bus: Grote Baan 227 (halte van De Lijn naar Anderlecht).\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"82\"}]", "priority": 4, "points": "[{\"id\": \"5732F\"}]"},{"content": "[{\"text\": [{\"en\": \"Jan 22, 6AM-end of June, works. Bus 86 diverted between GARE DE L'OUEST/ WESTSTATION and SUZAN DANIEL via ETANGS NOIRS.\", \"fr\": \"Du 22/1 \u00e0 6h jusqu'\u00e0 fin juin, travaux. Bus 86 d\u00e9vi\u00e9 entre GARE DE L'OUEST et SUZAN DANIEL via ETANGS NOIRS.\", \"nl\": \"Van 22/1 om 6u tot eind juni, werken. Bus 86 omgeleid tussen WESTSTATION-SUZAN DANIEL via ZWARTE VIJVERS.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"86\"}]", "priority": 5, "points": "[{\"id\": \"3238\"}, {\"id\": \"3234\"}, {\"id\": \"3253\"}, {\"id\": \"3252\"}, {\"id\": \"3282\"}, {\"id\": \"3281\"}]"},{"content": "[{\"text\": [{\"en\": \"As of Nov 16 at 6AM, works. Stop moved to av. Port / Havenln, in front of number 100 (moved backward of +/- 120m)\", \"fr\": \"D\u00e8s le 16/11 \u00e0 6h, travaux. Arr\u00eat d\u00e9plac\u00e9 avenue du Port, en face du num\u00e9ro 100 (recul\u00e9 de +/- 120m).\", \"nl\": \"Vanaf 16/11 om 6u,werken Halte verplaatst naar de Havenlaan, tegenover nr 100 (achteruitgebracht van +/- 120m)\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"86\"}]", "priority": 4, "points": "[{\"id\": \"2305\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. As of Apr 22 at 9.30AM, bus 89 diverted btw TRIANGLE and QUATRE- VENTS. For DUCHESSE, T82 at TRIANGLE.\", \"fr\": \"Travaux. D\u00e8s le 22/4 \u00e0 9h30, bus 89 d\u00e9vi\u00e9 entre TRIANGLE et QUATRE- VENTS. Pour DUCHESSE, tram 82 \u00e0 TRIANGLE.\", \"nl\": \"Werken. Vanaf 22/4 om 9. 30u, bus 89 omgeleid tussen DRIEHOEK en VIER WINDEN. Voor HERTOGIN, tram 82 aan DRIEHOEK.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"89\"}]", "priority": 5, "points": "[{\"id\": \"1895\"}, {\"id\": \"3223B\"}, {\"id\": \"3222\"}, {\"id\": \"3221\"}]"},{"content": "[{\"text\": [{\"en\": \"From May 6, works. STOP NOT SERVED. Take bus 89 to NEERPEDE at the stop of bus 53 to WESTLAND SHOPPING.\", \"fr\": \"D\u00e8s le 6/5, travaux. ARRET NON DESSERVI. Bus 89 vers NEERPEDE \u00e0 l'arr\u00eat du bus 53 vers WESTLAND SHOPPING.\", \"nl\": \"Vanaf 6/5, werken. HALTE NIET BEDIEND. Neem bus 89 naar NEERPEDE aan de halte van bus 53 naar WESTLAND SHOPPING.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"89\"}]", "priority": 4, "points": "[{\"id\": \"1261\"}]"},{"content": "[{\"text\": [{\"en\": \"From May 6, works. Bus 89 extended to NEERPEDE. Stop WESTLAND SHOPPING relocated.\", \"fr\": \"D\u00e8s le 6/5, travaux. Bus 89 prolong\u00e9 jusqu'\u00e0 NEERPEDE. Arr\u00eat WESTLAND SHOPPING d\u00e9plac\u00e9.\", \"nl\": \"Vanaf 6/5, werken. Bus 89 verlengd tot NEERPEDE. Halte WESTLAND SHOPPING verplaatst.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"89\"}]", "priority": 5, "points": "[{\"id\": \"2779\"}, {\"id\": \"2768\"}, {\"id\": \"3638\"}, {\"id\": \"1117\"}, {\"id\": \"1257\"}, {\"id\": \"2750\"}, {\"id\": \"2783\"}, {\"id\": \"2781\"}, {\"id\": \"1260\"}, {\"id\": \"3636\"}]"},{"content": "[{\"text\": [{\"en\": \"From May 6, works. STOP NOT SERVED. Take bus 89 at the stop of bus 53 to HOPITAL MILITAIRE / MILITAIR HOSPITAAL.\", \"fr\": \"D\u00e8s le 6/5, travaux. ARRET NON DESSERVI. Prenez le bus 89 \u00e0 l'arr\u00eat du bus 53 vers HOPITAL MILITAIRE.\", \"nl\": \"Vanaf 6/5, werken. HALTE NIET BEDIEND. Neem bus 89 aan de halte van bus 53 naar MILITAIR HOSPITAAL.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"89\"}]", "priority": 4, "points": "[{\"id\": \"1203\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. As of Apr 22 at 9.30AM, bus 89 diverted btw TRIANGLE and QUATRE- VENTS. For DUCHESSE, T82 at TRIANGLE.\", \"fr\": \"Travaux. D\u00e8s le 22/4 \u00e0 9h30, bus 89 d\u00e9vi\u00e9 entre TRIANGLE et QUATRE- VENTS. Pour DUCHESSE, tram 82 \u00e0 TRIANGLE.\", \"nl\": \"Werken. Vanaf 22/4 om 9. 30u, bus 89 omgeleid tussen DRIEHOEK en VIER WINDEN. Voor HERTOGIN, tram 82 aan DRIEHOEK.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"89\"}]", "priority": 5, "points": "[{\"id\": \"3347\"}, {\"id\": \"2301\"}, {\"id\": \"2595\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. From Apr 26 at 9PM until May 12, tram 9 replaced by T-bus btw UZ BRUSSEL and ROI BAUDOUIN / KONING BOUDEWIJN.\", \"fr\": \"Travaux. Du 26/4 \u00e0 21h au 12/5, tram 9 remplac\u00e9 par des T-bus entre UZ BRUSSEL et ROI BAUDOUIN.\", \"nl\": \"Werken. Van 26/4 om 21u tot en met 12/5, tram 9 vervangen door T-bus tussen UZ BRUSSEL en KONING BOUDEWIJN.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"9\"}]", "priority": 5, "points": "[{\"id\": \"1681F\"}, {\"id\": \"1679F\"}, {\"id\": \"0470F\"}, {\"id\": \"6864F\"}, {\"id\": \"6865F\"}, {\"id\": \"1675F\"}, {\"id\": \"1677F\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. From Apr 26 at 9PM until May 12, stop not served. Take tram 9 at the next stop, UZ BRUSSEL.\", \"fr\": \"Travaux. Du 26/4 \u00e0 21h au 12/5, arr\u00eat non desservi. Prenez le tram 9 \u00e0 l'arr\u00eat suivant, UZ BRUSSEL.\", \"nl\": \"Werken. Van 26/4 om 21u tot en met 12/5, halte niet bediend. Neem tram 9 aan de volgende halte, UZ BRUSSEL.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"9\"}]", "priority": 4, "points": "[{\"id\": \"1684F\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. From Apr 26 at 9PM until May 12, stop not served. T-bus to ROI BAUDOUIN at the stop of bus 83 to VAL MARIA.\", \"fr\": \"Travaux. Du 26/4 \u00e0 21h au 12/5, arr\u00eat non desservi. T-bus vers ROI BAUDOUIN \u00e0 l'arr\u00eat du bus 83 vers VAL MARIA.\", \"nl\": \"Werken. 26/4, 21u-12/5, halte niet bediend.T-bus naar KONING BOUDEWIJN aan de halte van bus 83 naar MARIENDAAL.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"9\"}]", "priority": 4, "points": "[{\"id\": \"1691F\"}, {\"id\": \"1689F\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. Apr 26, 9PM-May 12, stop not served. Stop of the T-bus: PALFIJN (stop of bus 83 to GARE DE BERCHEM).\", \"fr\": \"Travaux. 26/4, 21h-12/5, arr\u00eat non desservi. Arr\u00eat du T-bus: PALFIJN (arr\u00eat du bus 83 vers GARE DE BERCHEM).\", \"nl\": \"Werken. 26/4, 21u-12/5, halte niet bediend. Halte van de T-bus: PALFIJN (halte van bus 83 naar STATION BERCHEM)\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"9\"}]", "priority": 4, "points": "[{\"id\": \"1692F\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. Apr 26, 9PM-May 12, stop not served. T-bus to UZ BRUSSEL at the stop of bus 83 to GARE DE BERCHEM.\", \"fr\": \"Travaux. Du 26/4 \u00e0 21h au 12/5, arr\u00eat non desservi. T-bus vers UZ BRUSSEL \u00e0 l'arr\u00eat du bus 83 vers GARE DE BERCHEM.\", \"nl\": \"Werken. 26/4, 21u-12/5, halte niet bediend.T-bus naar UZ BRUSSEL aan de halte van bus 83 naar STATION BERCHEM.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"9\"}]", "priority": 4, "points": "[{\"id\": \"1690F\"}, {\"id\": \"1695F\"}]"},{"content": "[{\"text\": [{\"en\": \"Until 2026, works. As of Mar 11, tram 97 interrupted between WIELS and DIEWEG. Take tram 4 to go to GLOBE.\", \"fr\": \"Jsq 2026,travaux. D\u00e8s le 11/3, tram 97 interrompu entre WIELS et DIEWEG. Prenez le tram 4 pour rejoindre GLOBE.\", \"nl\": \"Tot 2026, werken. Vanaf 11/3, tram 97 onderbroken tussen WIELS en DIEWEG. Neem tram 4 om naar GLOBE te gaan.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"97\"}]", "priority": 4, "points": "[{\"id\": \"5917F\"}]"},{"content": "[{\"text\": [{\"en\": \"Until 2026, works. As of Mar 11, tram 97 interrupted to DIEWEG. For GLOBE, tram 4 at CARR. STALLE via T-bus.\", \"fr\": \"Jsq 2026,travaux. D\u00e8s le 11/3, tram 97 interrompu jsq DIEWEG. Pour GLOBE, tram 4 \u00e0 CARREFOUR STALLE via T-bus.\", \"nl\": \"Tot 2026, werken. Vanaf 11/3,tram 97 onderbroken tot DIEWEG. Voor GLOBE, neem tram 4 aan KRUISPT STALLE via T-bus.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"97\"}]", "priority": 4, "points": "[{\"id\": \"5722F\"}]"},{"content": "[{\"text\": [{\"en\": \"Until 2026, works. Tram 97 interrupted to WIELS. Take tram 82 to go to WIELS.\", \"fr\": \"Jusqu'en 2026, travaux. Tram 97 interrompu jusqu'\u00e0 WIELS. Pour rejoindre WIELS, prenez le tram 82.\", \"nl\": \"Tot 2026, werken. Tram 97 onderbroken tot WIELS. Neem tram 82 om naar WIELS te gaan.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"97\"}]", "priority": 4, "points": "[{\"id\": \"5151\"}, {\"id\": \"2668\"}, {\"id\": \"5155\"}, {\"id\": \"2667F\"}]"},{"content": "[{\"text\": [{\"en\": \"Until 2026, works. Stop not served. Stop of the T-bus: rue de la Soierie / Zijdeweverijstraat 4.\", \"fr\": \"Jusqu'en 2026, travaux. Arr\u00eat non desservi. Arr\u00eat du T-bus: rue de la Soierie 4.\", \"nl\": \"Tot 2026, werken. Halte niet bediend. Halte van de T-bus: Zijdeweverijstraat 4.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"97\"}]", "priority": 4, "points": "[{\"id\": \"5154F\"}]"},{"content": "[{\"text\": [{\"en\": \"Until 2026, works. As of Mar 11, tram 97 interrupted between WIELS and DIEWEG. Take tram 4 to go to GLOBE.\", \"fr\": \"Jsq 2026,travaux. D\u00e8s le 11/3, tram 97 interrompu entre WIELS et DIEWEG. Prenez le tram 4 pour rejoindre GLOBE.\", \"nl\": \"Tot 2026, werken. Vanaf 11/3, tram 97 onderbroken tussen WIELS en DIEWEG. Neem tram 4 om naar GLOBE te gaan.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"97\"}]", "priority": 4, "points": "[{\"id\": \"5916F\"}]"},{"content": "[{\"text\": [{\"en\": \"Until 2026, works. As of Mar 11, tram 97 operated only btw LOUISE and WIELS. T-bus: av. Reine Marie-Henriette 1A\", \"fr\": \"Jsq 2026,travaux. D\u00e8s le 11/3, tram 97 circule uniquement entre LOUISE et WIELS. T-bus: av. Reine Marie-Henriette 1A\", \"nl\": \"Tot 2026, werken. Vanaf 11/3 rijdt tram 97 enkel tussen LOUIZA en WIELS. T-bus: Koningin Maria-Hendrikaln 1A\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"97\"}]", "priority": 5, "points": "[{\"id\": \"5115F\"}]"},{"content": "[{\"text\": [{\"en\": \"From Mar 18, works. STOP NOT SERVED. stop of N08: chauss\u00e9e de Boondael / Boondaalsesteenweg, before roundabout.\", \"fr\": \"D\u00e8s le 18/3, travaux. ARRET NON DESSERVI. Arr\u00eat du bus N08: chauss\u00e9e de Boondael, avant le rond-point.\", \"nl\": \"Vanaf 18/3, werken. HALTE NIET BEDIEND. Halte van bus N08: Boondaalsesteenweg, voor rondpunt.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"N08\"}]", "priority": 4, "points": "[{\"id\": \"3514\"}]"},{"content": "[{\"text\": [{\"en\": \"From Jan 15, works. Noctis N09 diverted between HANKAR and HERRMANN-DEBROUX via DEMEY.\", \"fr\": \"D\u00e8s le 15/1, travaux. Noctis N09 d\u00e9vi\u00e9 entre HANKAR et HERRMANN-DEBROUX via DEMEY.\", \"nl\": \"Vanaf 15/1, werken. Noctis N09 omgeleid tussen HANKAR en HERRMANN-DEBROUX via DEMEY.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"N09\"}]", "priority": 5, "points": "[{\"id\": \"4362\"}, {\"id\": \"4363\"}, {\"id\": \"6443\"}, {\"id\": \"3510B\"}, {\"id\": \"2397\"}, {\"id\": \"2595\"}, {\"id\": \"1376B\"}, {\"id\": \"1063\"}, {\"id\": \"3372\"}, {\"id\": \"1128\"}, {\"id\": \"2291B\"}, {\"id\": \"2578\"}, {\"id\": \"1895\"}, {\"id\": \"2301\"}, {\"id\": \"5611\"}, {\"id\": \"4369\"}, {\"id\": \"2928\"}, {\"id\": \"1716\"}, {\"id\": \"1726\"}, {\"id\": \"5407\"}, {\"id\": \"3518B\"}, {\"id\": \"3517\"}, {\"id\": \"3506\"}]"},{"content": "[{\"text\": [{\"en\": \"From Mar 5 at 9AM, works. STOP NOT SERVED. Temporary stop: avenue Jean & Pierre Carsoellaan 4.\", \"fr\": \"D\u00e8s le 5/3 \u00e0 9h, travaux. ARRET NON DESSERVI. Arr\u00eat provisoire: avenue Jean et Pierre Carsoel 4.\", \"nl\": \"Vanaf 5/3 om 9u, werken. HALTE NIET BEDIEND. Tijdelijke halte: Jean en Pierre Carsoellaan 4.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"N10\"}]", "priority": 4, "points": "[{\"id\": \"6931B\"}]"},{"content": "[{\"text\": [{\"en\": \"From May 6, works. STOP NOT SERVED. Take bus 89 at the stop of bus 53 to WESTLAND SHOPPING.\", \"fr\": \"D\u00e8s le 6/5, travaux. ARRET NON DESSERVI. Prenez le bus N13 \u00e0 l'arr\u00eat du bus 53 vers WESTLAND SHOPPING.\", \"nl\": \"Vanaf 6/5, werken. HALTE NIET BEDIEND. Neem bus N13 aan de halte van bus 53 naar WESTLAND SHOPPING.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"N13\"}]", "priority": 4, "points": "[{\"id\": \"1203\"}]"},{"content": "[{\"text\": [{\"en\": \"From May 3 to May 12, works. Bus N16 diverted. Temporary stop: boulevard Barth\u00e9l\u00e9my- laan, in front of nr. 3.\", \"fr\": \"Du 3/5 au 12/5, travaux. Bus N16 d\u00e9vi\u00e9. Arr\u00eat provisoire: boulevard Barth\u00e9l\u00e9my, face au num\u00e9ro 3.\", \"nl\": \"Van 3/5 tot 12/5, werken. Bus N16 omgeleid. Tijdelijke halte: Barth\u00e9l\u00e9mylaan, tegenover nummer 3.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"N16\"}]", "priority": 4, "points": "[{\"id\": \"3222\"}]"},{"content": "[{\"text\": [{\"en\": \"As of Oct 25, stop moved +/- 50m behind, side square Lain\u00e9square.\", \"fr\": \"D\u00e8s le 25/10, arr\u00eat recul\u00e9 de +/- 50m, c\u00f4t\u00e9 square Lain\u00e9\", \"nl\": \"Vanaf 25/10, werken. Halte achteruitgebracht van +/- 50m, kant Lain\u00e9square.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"T82\"}]", "priority": 4, "points": "[{\"id\": \"2023\"}]"},{"content": "[{\"text\": [{\"en\": \"Until 2026, works. Stop of T-bus 82/97: ch. de Neerstalsesteenweg in front of 348.\", \"fr\": \"Jusqu'en 2026, travaux. Arr\u00eat du T-bus 82/97: chauss\u00e9e de Neerstalle, en face du num\u00e9ro 348.\", \"nl\": \"Tot 2026, werken. Halte van T-bus 82/97: Neerstalsesteenweg, tegenover nummer 348.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"T82\"}]", "priority": 4, "points": "[{\"id\": \"3242\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. As of Apr 15, STOP NOT SERVED. Stop of bus 12: rue Franklinstraat 2a.\", \"fr\": \"Travaux. D\u00e8s le 15/4, ARRET NON DESSERVI. Arr\u00eat du bus 12: rue Franklin, 2a.\", \"nl\": \"Werken. Vanaf 15/4, HALTE NIET BEDIEND. Halte van bus 12: Franklinstraat 2a.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"12\"}]", "priority": 4, "points": "[{\"id\": \"1270B\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. As of Apr 15, B12 diverted btw LUXEMBOURG and MEISER via MAELBEEK. Stop SCHUMAN moved rue Archim\u00e8destr. 16.\", \"fr\": \"Travaux. D\u00e8s le 15/4,B12 d\u00e9vi\u00e9 entre LUXEMBOURG et MEISER via MAELBEEK. Arr\u00eat SCHUMAN d\u00e9plac\u00e9 rue Archim\u00e8de 16.\", \"nl\": \"Werken. Vanaf 15/4, bus 12 omgeleid ts LUXEMBURG en MEISER via MAALBEEK. Halte SCHUMAN verplaatst Archimedesstraat 16.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"12\"}]", "priority": 6, "points": "[{\"id\": \"6433\"}, {\"id\": \"1780\"}, {\"id\": \"1131B\"}]"},{"content": "[{\"text\": [{\"en\": \"From Dec 4, works. STOP NOT SERVED. Take bus 14 and 57 under the CCN building, at the terminus of bus 61.\", \"fr\": \"D\u00e8s le 4/12, travaux. ARRET NON DESSERVI. Prenez le bus 14 et 57 sous le b\u00e2timent CCN, au terminus du bus 61.\", \"nl\": \"Vanaf 4/12, werken. HALTE NIET BEDIEND. Neem bus 14 en 57 onder het CCN-gebouw, aan eindhalte bus 61.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"14\"}]", "priority": 4, "points": "[{\"id\": \"1082\"}]"},{"content": "[{\"text\": [{\"en\": \"From Sep 5 6AM, works. STOP NOT SERVED. Temporary stop: av. Charles Michiels across no. 205\", \"fr\": \"D\u00e8s le 5/9 6h, travaux. ARRET NON DESSERVI. Arr\u00eat provisoire : av. Charles Michiels face au num. 205\", \"nl\": \"Vanaf 5/9 6u, werken. HALTE NIET BEDIEND. Tijdelijke halte: Charles Michielslaan tegenover nr. 205\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"17\"}]", "priority": 4, "points": "[{\"id\": \"4294\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. May 8, 9PM-May 12, tram 19 replaced by a T-bus to DE WAND. T-bus at the stop of bus 88 to DE BROUCKERE.\", \"fr\": \"Travaux. 8/5, 21h-12/5, tram 19 remplac\u00e9 par des T-bus jusqu'\u00e0 DE WAND. T-bus \u00e0 l'arr\u00eat du bus 88 vers DE BROUCKERE.\", \"nl\": \"Werken. 8/5, 21u-12/5, tram 19 vervangen door T-bus tot DE WAND. T-bus aan de halte van bus 88 naar DE BROUCKERE.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"19\"}]", "priority": 4, "points": "[{\"id\": \"5092F\"}, {\"id\": \"5090F\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. From May 8 at 9PM until May 12, STOP NOT SERVED. T-bus to SIMONIS at DE WAND via tram 7.\", \"fr\": \"Travaux. Du 8/5 \u00e0 21h au 12/5, ARRET NON DESSERVI. T-bus vers SIMONIS \u00e0 DE WAND via tram 7.\", \"nl\": \"Werken. Van 8/5 om 21u tot 12/5, HALTE NIET BEDIEND. T-bus naar SIMONIS aan DE WAND via tram 7.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"19\"}]", "priority": 4, "points": "[{\"id\": \"2637F\"}]"},{"content": "[{\"text\": [{\"en\": \"Wroks. Until mid-2024, stop not served. T-bus at LEOPOLD I (bd de Smet de Naeyer 54, stop of bus 14 to UZ-VUB).\", \"fr\": \"Travaux. Jusque mi-2024, arr\u00eat non desservi. T-bus \u00e0 LEOPOLD I (bd de Smet de Naeyer 54, arr\u00eat du bus 14 vers UZ-VUB).\", \"nl\": \"Werken. Tot midden 2024, halte niet bediend. T-bus aan LEOPOLD I (de Smet de Naeyerlaan 54, halte B14 naar UZ-VUB).\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"19\"}]", "priority": 4, "points": "[{\"id\": \"6866F\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. As of Apr 15, bus 21 diverted. Take bus 21 at MAELBEEK / MAALBEEK (stop of bus 64 to PORTE DE NAMUR / NAAMSEPOORT).\", \"fr\": \"Travaux. D\u00e8s le 15/4, bus 21 d\u00e9vi\u00e9. Prenez le bus 21 \u00e0 MAELBEEK (arr\u00eat du bus 64 vers PORTE DE NAMUR).\", \"nl\": \"Werken. Vanaf 15/4, bus 21 omgeleid. Neem bus 21 aan MAALBEEK (halte van bus 64 naar NAAMSEPOORT) .\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"21\"}]", "priority": 4, "points": "[{\"id\": \"1476\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. As of April 7th, STOP NOT SERVED. To go to DE BROUCKERE, take metro lines 1 or 5.\", \"fr\": \"Travaux. D\u00e8s le 7/4, ARRET NON DESSERVI. Pour rejoindre DE BROUCKERE, prenez le m\u00e9tro 1 ou 5.\", \"nl\": \"Werken. Vanaf 7/4, HALTE NIET BEDIEND. Om naar DE BROUCKERE te gaan, neem metrolijn 1 of 5.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"29\"}]", "priority": 4, "points": "[{\"id\": \"6447\"}]"},{"content": "[{\"text\": [{\"en\": \"Jan 7, 9PM-Jun 28, works. Tram 3 replaced by T-bus. Stop T-bus: av. Croix du Feu, after rue De Wandstraat.\", \"fr\": \"7/1, 21h-28/6, travaux. Tram 3 remplac\u00e9 par des T-bus. Arr\u00eat du T-bus: avenue des Croix du Feu, apr\u00e8s la rue De Wand.\", \"nl\": \"7/1, 21u-28/6, werken. Tram 3 vervangen door T-bus. Halte T-bus: Vuurkruisenlaan, na de De Wandstraat.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"3\"}]", "priority": 4, "points": "[{\"id\": \"5806\"}]"},{"content": "[{\"text\": [{\"en\": \"Jan 7, 9PM-Jun 28, works. Tram 3 replaced by T-bus. Stop T-bus: av. Croix du Feu, crossing av. Buissonnets\", \"fr\": \"7/1, 21h-28/6, travaux. Tram 3 remplac\u00e9 par des T-bus. Arr\u00eat du T-bus: av. Croix du Feu, carrefour av.Buissonnets\", \"nl\": \"7/1, 21u-28/6, werken. Tram 3 vervangen door T- bus. Halte T-bus: Vuurkruisenlaan, kruispunt Braambosjesln.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"3\"}]", "priority": 4, "points": "[{\"id\": \"5772\"}]"},{"content": "[{\"text\": [{\"en\": \"Jan 7, 9PM-Jun 28,works. Stop not served. Stop T-bus to DOCKS BRUXSEL: av. Croix du Feu, crossing av. Pagodes.\", \"fr\": \"7/1, 21h-28/6, travaux. Arr\u00eat non desservi.Arr\u00eat du T-bus vers DOCKS BRUXSEL: av. Croix du Feu, carr. av. Pagodes.\", \"nl\": \"7/1, 21u-28/6, werken. Halte niet bediend.Halte van de T-bus naar DOCKS BRUXSEL: Vuurkruisenln, kruispt Pagodenln.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"3\"}]", "priority": 4, "points": "[{\"id\": \"5706\"}]"},{"content": "[{\"text\": [{\"en\": \"From Jan 8 to Jun 28, works. After CHURCHILL, tram 3 continues on line 7 direction HEYSEL / HEIZEL.\", \"fr\": \"Du 8/1 au 28/6, travaux. Apr\u00e8s CHURCHILL, tram 3 continue sur la ligne 7 direction HEYSEL.\", \"nl\": \"Van 8/1 tot en met 28/6, werken. Na CHURCHILL rijdt tram 3 verder op lijn 7 richting HEIZEL.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"3\"}]", "priority": 6, "points": "[{\"id\": \"6253\"}, {\"id\": \"6178\"}, {\"id\": \"2318G\"}, {\"id\": \"5221F\"}, {\"id\": \"0611\"}, {\"id\": \"0501\"}, {\"id\": \"0601\"}, {\"id\": \"0621\"}, {\"id\": \"0511\"}, {\"id\": \"0531\"}, {\"id\": \"2338F\"}, {\"id\": \"6422F\"}, {\"id\": \"0705\"}, {\"id\": \"0706\"}, {\"id\": \"0703\"}, {\"id\": \"5714\"}, {\"id\": \"2543F\"}, {\"id\": \"0704\"}, {\"id\": \"0702\"}]"},{"content": "[{\"text\": [{\"en\": \"From Jan 15, works. STOP NOT SERVED. Stop of bus 34: chauss\u00e9e de Wavre / Waversesteenweg 1303.\", \"fr\": \"D\u00e8s le 15/1, travaux. ARRET NON DESSERVI. Arr\u00eat du bus 34: chauss\u00e9e de Wavre 1303.\", \"nl\": \"Vanaf 15/1, werken. HALTE NIET BEDIEND. Halte van bus 34: Waversesteenweg 1303.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"34\"}]", "priority": 4, "points": "[{\"id\": \"1718B\"}]"},{"content": "[{\"text\": [{\"en\": \"From Mar 5 at 9AM, works. STOP NOT SERVED. Temporary stop: avenue Jean & Pierre Carsoellaan 4.\", \"fr\": \"D\u00e8s le 5/3 \u00e0 9h, travaux. ARRET NON DESSERVI. Arr\u00eat provisoire: avenue Jean et Pierre Carsoel 4.\", \"nl\": \"Vanaf 5/3 om 9u, werken. HALTE NIET BEDIEND. Tijdelijke halte: Jean en Pierre Carsoellaan 4.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"37\"}]", "priority": 4, "points": "[{\"id\": \"6931B\"}]"},{"content": "[{\"text\": [{\"en\": \"From Apr 3 at 6AM, works. STOP NOT SERVED. Take bus 38 and 41 at the next stop, HOUZEAU.\", \"fr\": \"D\u00e8s le 3/4 \u00e0 6h, travaux. ARRET NON DESSERVI. Prenez les bus 38 et 41 \u00e0 l'arr\u00eat suivant, HOUZEAU.\", \"nl\": \"Vanaf 3/4 om 6u, werken. HALTE NIET BEDIEND. Neem bus 38 en 41 aan de volgende halte, HOUZEAU.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"38\"}]", "priority": 4, "points": "[{\"id\": \"1920\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. As of April 7th, stop of bus 38 moved to the Cantersteen, at the stop of bus 52 to FOREST / VORST (BERVOETS)\", \"fr\": \"Travaux. D\u00e8s le 7/4, arr\u00eat du bus 38 d\u00e9plac\u00e9 Cantersteen, \u00e0 l'arr\u00eat du bus 52 vers FOREST (BERVOETS).\", \"nl\": \"Werken. Vanaf 7/4, halte van bus 38 verplaatst naar de Kantersteen, aan de halte van bus 52 naar VORST (BERVOETS).\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"38\"}]", "priority": 4, "points": "[{\"id\": \"6443\"}]"},{"content": "[{\"text\": [{\"en\": \"From Apr 3 at 6AM, works. STOP NOT SERVED. Temporary stop: avenue Winston Churchilllaan 202.\", \"fr\": \"D\u00e8s le 3/4 \u00e0 6h, travaux. ARRET NON DESSERVI. Arr\u00eat provisoire: avenue Winston Churchill 202.\", \"nl\": \"Vanaf 3/4 om 6u, werken. HALTE NIET BEDIEND. Tijdelijke halte: Winston Churchilllaan 202.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"38\"}]", "priority": 4, "points": "[{\"id\": \"1973\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. As of Apr 29, STOP NOT SERVED. Take bus 38 at the next stop, BASCULE.\", \"fr\": \"Travaux. D\u00e8s le 29/4, ARRET NON DESSERVI. Prenez le bus 38 \u00e0 l'arr\u00eat suivant, BASCULE.\", \"nl\": \"Werken. Vanaf 29/4, HALTE NIET BEDIEND. Neem bus 38 aan de volgende halte, BASCULE.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"38\"}]", "priority": 4, "points": "[{\"id\": \"1914\"}]"},{"content": "[{\"text\": [{\"en\": \"From Apr 3 at 6AM, works. Bus 38 diverted between HOUZEAU and LONGCHAMP via rue Edith Cavellstraat.\", \"fr\": \"D\u00e8s le 3/4 \u00e0 6h, travaux. Bus 38 d\u00e9vi\u00e9 entre HOUZEAU et LONGCHAMP via rue Edith Cavell.\", \"nl\": \"Vanaf 3/4 om 6u, werken. Bus 38 omgeleid tussen HOUZEAU en LONGCHAMP via Edith Cavellstraat.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"38\"}]", "priority": 5, "points": "[{\"id\": \"1943\"}, {\"id\": \"4076\"}, {\"id\": \"1969\"}, {\"id\": \"1968\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. As of Mar 27, STOP MOVED. Stop of bus 41: rue des C\u00e8dres / Cederlaan 5.\", \"fr\": \"Travaux. D\u00e8s le 27/3, ARRET DEPLACE. Arr\u00eat du bus 41: rue des C\u00e8dres, 5.\", \"nl\": \"Werken. Vanaf 27/3, HALTE VERPLAATST. Halte van bus 41: Cederlaan 5.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"41\"}]", "priority": 4, "points": "[{\"id\": \"4310\"}]"},{"content": "[{\"text\": [{\"en\": \"From Apr 3 at 6AM, works. Bus 41 diverted between HOUZEAU and VERT CHASSEUR / GROENE JAGER via rue Edith Cavell.\", \"fr\": \"D\u00e8s le 3/4 \u00e0 6h, travaux. Bus 41 d\u00e9vi\u00e9 entre HOUZEAU et VERT CHASSEUR via rue Edith Cavell.\", \"nl\": \"Vanaf 3/4 om 6u, werken. Bus 41 omgeleid tussen HOUZEAU en GROENE JAGER via Edith Cavellstraat.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"41\"}]", "priority": 5, "points": "[{\"id\": \"1943\"}, {\"id\": \"4076\"}, {\"id\": \"1969\"}, {\"id\": \"1968\"}]"},{"content": "[{\"text\": [{\"en\": \"From Mar 4, works. Bus 43 diverted between GRIOTTES and HOMBORCH. B43 HOMBORCH extended to BRAVES.\", \"fr\": \"D\u00e8s le 4/3, travaux. Bus 43 d\u00e9vi\u00e9 entre GRIOTTES et HOMBORCH. B43 barr\u00e9 HOMBORCH prolong\u00e9 jusqu'\u00e0 BRAVES.\", \"nl\": \"Vanaf 4/3, werken. Bus 43 omgeleid tussen NOORDKRIEKEN en HOMBORCH. B43 HOMBORCH rijdt tot DAPPEREN.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"43\"}]", "priority": 5, "points": "[{\"id\": \"2165\"}, {\"id\": \"1250\"}, {\"id\": \"1921\"}, {\"id\": \"1932\"}, {\"id\": \"1931\"}, {\"id\": \"1942\"}, {\"id\": \"5817\"}, {\"id\": \"1984B\"}, {\"id\": \"2355\"}, {\"id\": \"4854C\"}, {\"id\": \"1929\"}, {\"id\": \"1926B\"}, {\"id\": \"1937\"}]"},{"content": "[{\"text\": [{\"en\": \"From Mar 4, works. Bus 43 and N11 diverted. Take the bus at HOMBORCH (via B43 from this stop on weekdays or B37).\", \"fr\": \"D\u00e8s le 4/3, travaux. Bus 43 et N11 d\u00e9vi\u00e9s. Prenez le bus \u00e0 HOMBORCH (via B43 depuis cet arr\u00eat en semaine ou B37).\", \"nl\": \"Vanaf 4/3, werken. Bus 43 en N11 omgeleid. Neem de bus aan HOMBORCH (via B43 vanaf deze halte op weekdagen of B37).\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"43\"}]", "priority": 4, "points": "[{\"id\": \"1936\"}, {\"id\": \"1935\"}]"},{"content": "[{\"text\": [{\"en\": \"From Mar 4, works. Bus 43 and N11 diverted. Take the bus at HOMBORCH (via B43 at stop B43 VIVIER D'OIE or B37).\", \"fr\": \"D\u00e8s le 4/3, travaux. Bus 43 et N11 d\u00e9vi\u00e9s. Prenez le bus \u00e0 HOMBORCH (via B43 \u00e0 l'arr\u00eat du B43 VIVIER D'OIE ou B37).\", \"nl\": \"Vanaf 4/3, werken. Bus 43 en N11 omgeleid. Neem de bus aan HOMBORCH (via B43 aan halte B43 DIESDELLE of B37).\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"43\"}]", "priority": 4, "points": "[{\"id\": \"1954\"}]"},{"content": "[{\"text\": [{\"en\": \"From Mar 4, works. Bus 43 diverted between CABRIS / GEITJES and GRIOTTES / NOORDKRIEKEN.\", \"fr\": \"D\u00e8s le 4/3, travaux. Bus 43 d\u00e9vi\u00e9 entre CABRIS et GRIOTTES.\", \"nl\": \"Vanaf 4/3, werken. Bus 43 omgeleid tussen GEITJES en NOORDKRIEKEN.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"43\"}]", "priority": 5, "points": "[{\"id\": \"2144\"}, {\"id\": \"2142\"}, {\"id\": \"2140\"}, {\"id\": \"2161\"}, {\"id\": \"2109B\"}, {\"id\": \"1953\"}, {\"id\": \"2143B\"}, {\"id\": \"2168\"}, {\"id\": \"2157\"}, {\"id\": \"2146\"}, {\"id\": \"2147B\"}, {\"id\": \"2156\"}, {\"id\": \"2167\"}, {\"id\": \"2145\"}]"},{"content": "[{\"text\": [{\"en\": \"From Mar 4, works. Bus 43 diverted. Take the bus at HOMBORCH (via B43 from this stop on weekdays before 8PM).\", \"fr\": \"D\u00e8s le 4/3, travaux. Bus 43 d\u00e9vi\u00e9. Prenez le bus \u00e0 HOMBORCH (via B43 depuis cet arr\u00eat en semaine avant 20h).\", \"nl\": \"Vanaf 4/3, werken. Bus 43 omgeleid. Neem de bus aan HOMBORCH (via B43 vanaf deze halte op weekdagen voor 20u).\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"43\"}]", "priority": 4, "points": "[{\"id\": \"1944\"}]"},{"content": "[{\"text\": [{\"en\": \"From Mar 4, works. Bus 43 and N11 diverted. Take the bus at HOMBORCH (via B43 from this stop on weekdays or B37).\", \"fr\": \"D\u00e8s le 4/3, travaux. Bus 43 et N11 d\u00e9vi\u00e9s. Prenez le bus \u00e0 HOMBORCH (via B43 depuis cet arr\u00eat en semaine ou B37).\", \"nl\": \"Vanaf 4/3, werken. Bus 43 en N11 omgeleid. Neem de bus aan HOMBORCH (via B43 vanaf deze halte op weekdagen of B37).\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"43\"}]", "priority": 4, "points": "[{\"id\": \"1955\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. Until end of August, bus 46 not operated btw WTC-GLIBERT and CENTRAL STATION. Walk to WTC-GLIBERT\", \"fr\": \"Travaux. Jsq fin ao\u00fbt, bus 46 ne circule pas entre WTC-GLIBERT et GARE CENTRALE. Allez \u00e0 pied \u00e0 WTC-GLIBERT\", \"nl\": \"Werken. Tot einde augustus rijdt bus 46 niet tss WTC- GLIBERT en CENTRAAL STATION. Ga te voet naar WTC-GLIBERT.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"46\"}]", "priority": 5, "points": "[{\"id\": \"2269\"}, {\"id\": \"2587\"}, {\"id\": \"3075\"}]"},{"content": "[{\"text\": [{\"en\": \"Until end of August, works. Stop not served. Take bus 46 at the next stop, PORTE D'ANDERLECHT\", \"fr\": \"Jusque fin ao\u00fbt, travaux. Arr\u00eat non desservi. Prenez le bus 46 \u00e0 l'arr\u00eat suivant, PORTE D'ANDERLECHT.\", \"nl\": \"Tot einde augustus, werken. Halte niet bediend. Neem bus 46 aan de volgende halte, ANDERLECHTSEPOORT.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"46\"}]", "priority": 4, "points": "[{\"id\": \"2213\"}]"},{"content": "[{\"text\": [{\"en\": \"Until end August 2024, works. B46 diverted to ANNEESSENS. Stops between BUANDERIE and WTC-GLIBERT not served.\", \"fr\": \"Jsq fin ao\u00fbt 2024, travaux. Bus 46 d\u00e9vi\u00e9 vers ANNEESSENS. Arr\u00eats entre BUANDERIE et WTC- GLIBERT non desservis.\", \"nl\": \"Tot einde augustus 2024, werken. Bus 46 omgeleid naar ANNEESSENS. Haltes tussen WASHUIS en WTC-GLIBERT niet bediend\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"46\"}]", "priority": 5, "points": "[{\"id\": \"2405\"}, {\"id\": \"2259\"}, {\"id\": \"2264\"}, {\"id\": \"2262\"}, {\"id\": \"2261\"}, {\"id\": \"2260\"}]"},{"content": "[{\"text\": [{\"en\": \"As of Sep 13 at 6AM, works. Stop moved to rue de Laeken / Lakensestraat, next to numbers 57-59.\", \"fr\": \"D\u00e8s le 13/9 \u00e0 6h, travaux. Arr\u00eat d\u00e9plac\u00e9 rue de Laeken, \u00e0 hauteur des num\u00e9ros 57-59.\", \"nl\": \"Vanaf 13/9 om 6u, werken. Halte verplaatst naar de Lakensestraat, ter hoogte van huisnummer 57-59.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"46\"}]", "priority": 4, "points": "[{\"id\": \"3465\"}]"},{"content": "[{\"text\": [{\"en\": \"From Feb 6, works. STOP NOT SERVED. Temporary stop: Vlierkensstraat 94.\", \"fr\": \"D\u00e8s le 6/2, travaux. ARRET NON DESSERVI. Arr\u00eat provisoire: Vlierkensstraat 94.\", \"nl\": \"Vanaf 6/2, werken. HALTE NIET BEDIEND. Tijdelijke halte: Vlierkensstraat 94.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"47\"}]", "priority": 4, "points": "[{\"id\": \"2841\"}]"},{"content": "[{\"text\": [{\"en\": \"Until Summer of 2024, works. Stop not served. Take bus 47 at ANTOON VAN OSS (stop of bus 56 to BUDA).\", \"fr\": \"Jsq \u00e9t\u00e9 2024, travaux. Arr\u00eat non desservi. Prenez le bus 47 \u00e0 ANTOON VAN OSS (arr\u00eat du bus 56 vers BUDA).\", \"nl\": \"Tot zomer 2024, werken. Halte niet bediend. Neem bus 47 aan ANTOON VAN OSS (halte van bus 56 naar BUDA).\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"47\"}]", "priority": 4, "points": "[{\"id\": \"2359\"}]"},{"content": "[{\"text\": [{\"en\": \"Until Summer of 2024, works. Stop not served. Take bus 47 at ANTOON VAN OSS (stop of bus 56 to SCHUMAN).\", \"fr\": \"Jsq \u00e9t\u00e9 2024, travaux. Arr\u00eat non desservi. Prenez le bus 47 \u00e0 ANTOON VAN OSS (arr\u00eat du bus 56 vers SCHUMAN).\", \"nl\": \"Tot zomer 2024, werken. Halte niet bediend. Neem bus 47 aan ANTOON VAN OSS (halte van bus 56 naar SCHUMAN).\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"47\"}]", "priority": 4, "points": "[{\"id\": \"2316\"}]"},{"content": "[{\"text\": [{\"en\": \"Until Summer of 2024, works. Bus 47 diverted from RAMIER / BOSDUIF to DOCKS BRUXSEL via avenue des Croix de Guerre\", \"fr\": \"Jsq \u00e9t\u00e9 2024, travaux. Bus 47 d\u00e9vi\u00e9 depuis RAMIER vers DOCKS BRUXSEL via avenue des Croix de Guerre.\", \"nl\": \"Tot zomer 2024, werken. Bus 47 omgeleid vanaf BOSDUIF naar DOCKS BRUXSEL via Oorlogskruisenlaan.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"47\"}]", "priority": 5, "points": "[{\"id\": \"2361\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. STOP NOT SERVED. Bus 47-56 at the stop VERGER (avenue des Croix de Guerre)\", \"fr\": \"Travaux. ARRET NON DESSERVI. Bus 47-56 \u00e0 l'arr\u00eat VERGER (avenue des Croix de Guerre)\", \"nl\": \"Werken. HALTE NIET BEDIEND. Bus 47-56 aan de halte BOOMGAARD (Oorlogskruisenlaan)\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"47\"}]", "priority": 4, "points": "[{\"id\": \"1974\"}, {\"id\": \"1967\"}]"},{"content": "[{\"text\": [{\"en\": \"Until Summer of 2024, works. Stop not served. Stop of bus 47: av. Marlylaan, next to Verano.\", \"fr\": \"Jusqu'\u00e0 l'\u00e9t\u00e9 2024, travaux. Arr\u00eat non desservi. Arr\u00eat du bus 47: avenue du Marly, pr\u00e8s de Verano.\", \"nl\": \"Tot zomer 2024, werken. Halte niet bediend. Halte van bus 47: Marlylaan, naast Verano.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"47\"}]", "priority": 4, "points": "[{\"id\": \"2315\"}]"},{"content": "[{\"text\": [{\"en\": \"Until Summer of 2024, works. Stop not served. Take bus 47 at the stop of bus 56 to SCHUMAN.\", \"fr\": \"Jusqu'\u00e0 l'\u00e9t\u00e9 2024, travaux. Arr\u00eat non desservi. Prenez le bus 47 \u00e0 l'arr\u00eat du bus 56 vers SCHUMAN.\", \"nl\": \"Tot zomer 2024, werken. Halte niet bediend. Neem bus 47 aan de halte van bus 56 naar SCHUMAN.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"47\"}]", "priority": 4, "points": "[{\"id\": \"2317\"}]"},{"content": "[{\"text\": [{\"en\": \"Until Summer of 2024, works. Stop of bus 47 and 56: avenue des Croix de Guerre / Oorlogskruisenlaan 78.\", \"fr\": \"Jusqu'\u00e0 l'\u00e9t\u00e9 2024, travaux. Arr\u00eat des bus 47 et 56 : avenue des Croix de Guerre 78.\", \"nl\": \"Tot zomer 2024, werken. Halte van bus 47 en 56: Oorlogskruisenlaan 78.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"47\"}]", "priority": 4, "points": "[{\"id\": \"2299\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. Stop not served. As of May 6, stop of bus 49 and 74: chauss\u00e9e de Mons / Bergensesteenweg 814a\", \"fr\": \"Travaux. Arr\u00eat non desservi.  D\u00e8s le 6/5, arr\u00eat des bus 49 et 74: chauss\u00e9e de Mons, 814a.\", \"nl\": \"Werken.  Halte niet bediend. Vanaf 6/5, halte van bus 49 en 74: Bergensesteenweg 814a.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"49\"}]", "priority": 4, "points": "[{\"id\": \"2225\"}]"},{"content": "[{\"text\": [{\"en\": \"Until 2026, works. Bus 50 diverted. Stop of bus 50: rue des Abbesses / Abdissenstraat, in front of number 1.\", \"fr\": \"Jusqu'en 2026, travaux. Bus 50 d\u00e9vi\u00e9. Arr\u00eat du bus 50: rue des Abbesses, en face du num\u00e9ro 1.\", \"nl\": \"Tot 2026, werken. Bus 50 omgeleid. Halte van bus 50: Abdissenstraat, tegenover nummer 1.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"50\"}]", "priority": 4, "points": "[{\"id\": \"5161\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. Until 2026, stop not served. Stop of T-bus 82 and of bus 50: rue de la Soierie / Zijdeweverijstraat 9.\", \"fr\": \"Travaux. Jusqu'en 2026, arr\u00eat non desservi. Arr\u00eat du T-bus 82 et du bus 50 : rue de la Soierie 9.\", \"nl\": \"Werken. Tot 2026, halte niet bediend. Halte van T-bus 82 en van bus 50: Zijdeweverijstraat 9.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"50\"}]", "priority": 4, "points": "[{\"id\": \"3603\"}]"},{"content": "[{\"text\": [{\"en\": \"Until 2026, works. Stop not served. Stop of bus 50: rue de la Soierie / Zijdeweverijstraat 4.\", \"fr\": \"Jusqu'en 2026, travaux. Arr\u00eat non desservi. Arr\u00eat du bus 50: rue de la Soierie 4.\", \"nl\": \"Tot 2026, werken. Halte niet bediend. Halte van bus 50: Zijdeweverijstraat 4.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"50\"}]", "priority": 4, "points": "[{\"id\": \"3602\"}]"},{"content": "[{\"text\": [{\"en\": \"Until 2026, works. Bus 50 diverted between BEMPT and FOREST CENTRE/VORST CENTRUM.\", \"fr\": \"Jusqu'en 2026, travaux. Bus 50 d\u00e9vi\u00e9 entre BEMPT et FOREST CENTRE.\", \"nl\": \"Tot 2026, werken. Bus 50 omgeleid tussen BEMPT en VORST CENTRUM.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"50\"}]", "priority": 5, "points": "[{\"id\": \"9685\"}, {\"id\": \"9683\"}, {\"id\": \"9678\"}, {\"id\": \"9679\"}, {\"id\": \"9677\"}, {\"id\": \"2661\"}, {\"id\": \"9658\"}, {\"id\": \"2662B\"}, {\"id\": \"9659\"}, {\"id\": \"9682\"}, {\"id\": \"2659\"}, {\"id\": \"9680\"}]"},{"content": "[{\"text\": [{\"en\": \"From May 2 at 5AM, works. STOP NOT SERVED. Temporary stop: Karel Gilsonstraat, 2.\", \"fr\": \"D\u00e8s le 2/5 \u00e0 5h,travaux. ARRET NON DESSERVI. Arr\u00eat provisoire: Karel Gilsonstraat, 2.\", \"nl\": \"Vanaf 2/5 om 5u, werken. HALTE NIET BEDIEND. Tijdelijke halte: Karel Gilsonstraat, 2.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"50\"}]", "priority": 4, "points": "[{\"id\": \"9651\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. From May 8 at 9PM until May 12, T-bus 19 does not serve HOP. BRUGMANN. Connection to T-bus 19 at CIM. JETTE.\", \"fr\": \"Travaux. 8/5, 21h-12/5, T-bus 19 ne dessert pas HOPITAL BRUGMANN. Correspondance T-bus 19 \u00e0 CIMETIERE DE JETTE.\", \"nl\": \"8/5, 21u-12/5, werken. T-bus 19 bedient BRUGMANN-ZKH. niet. Aansluiting met T-bus 19 aan KERKHOF VAN JETTE.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"51\"}]", "priority": 4, "points": "[{\"id\": \"5402\"}, {\"id\": \"5399F\"}, {\"id\": \"1290\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. As of Apr 15 at 6AM, bus 53 diverted between PETER BENOIT and BEYSEGHEM / BEIZEGEM.\", \"fr\": \"Travaux. D\u00e8s le 15/4 \u00e0 6h, bus 53 d\u00e9vi\u00e9 entre PETER BENOIT et BEYSEGHEM.\", \"nl\": \"Werken. Vanaf 15/4 om 6u, bus 53 omgeleid tussen PETER BENOIT en BEIZEGEM.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"53\"}]", "priority": 5, "points": "[{\"id\": \"2823B\"}, {\"id\": \"2766\"}]"},{"content": "[{\"text\": [{\"en\": \"Until Summer of 2024, works. Bus 53 diverted. Stop of bus 53: rue Bruynstraat, after the military area.\", \"fr\": \"Jsq \u00e9t\u00e9 2024, travaux. Bus 53 d\u00e9vi\u00e9. Arr\u00eat du bus 53 : rue Bruyn, apr\u00e8s le domaine militaire.\", \"nl\": \"Tot zomer 2024, werken. Bus 53 omgeleid. Halte van bus 53: Bruynstraat, na het militair domein.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"53\"}]", "priority": 4, "points": "[{\"id\": \"2352\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. As of Apr 15 at 6AM, bus 53 diverted between PETER BENOIT and BEYSEGHEM / BEIZEGEM.\", \"fr\": \"Travaux. D\u00e8s le 15/4 \u00e0 6h, bus 53 d\u00e9vi\u00e9 entre PETER BENOIT et BEYSEGHEM.\", \"nl\": \"Werken. Vanaf 15/4 om 6u, bus 53 omgeleid tussen PETER BENOIT en BEIZEGEM.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"53\"}]", "priority": 5, "points": "[{\"id\": \"3001B\"}]"},{"content": "[{\"text\": [{\"en\": \"From May 6, works. STOP NOT SERVED. Take bus 54 at the next stop, BAILLI / BALJUW.\", \"fr\": \"D\u00e8s le 6/5, travaux. ARRET NON DESSERVI. Prenez le bus 54 \u00e0 l'arr\u00eat suivant, BAILLI.\", \"nl\": \"Vanaf 6/5, werken. HALTE NIET BEDIEND. Neem bus 54 aan de volgende halte, BAILLI.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"54\"}]", "priority": 4, "points": "[{\"id\": \"2929\"}]"},{"content": "[{\"text\": [{\"en\": \"Apr 2, 2024-June 2025, works. Bus 54 diverted btw FOREST NATIONAL and FOREST CENTRE. Info: stib-mivb.brussels\", \"fr\": \"Du 2/4/2024 \u00e0 juin 2025, travaux. Bus 54 d\u00e9vi\u00e9 entre FOREST NATIONAL et FOREST CENTRE. Info: stib.brussels.\", \"nl\": \"2/4/2024-juni 2025, werken. Bus 54 omgeleid tussen VORST NATIONAAL en VORST CENTRUM. Info: mivb.brussels\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"54\"}]", "priority": 5, "points": "[{\"id\": \"2932\"}, {\"id\": \"2934A\"}, {\"id\": \"2931\"}, {\"id\": \"2972\"}, {\"id\": \"2950\"}, {\"id\": \"2411B\"}, {\"id\": \"2937B\"}, {\"id\": \"2936\"}, {\"id\": \"2935\"}]"},{"content": "[{\"text\": [{\"en\": \"From Apr 2, 2024 to June 2025, works. STOP NOT SERVED. Stop of bus 54: FOREST NATIONAL (av. du Globelaan 8).\", \"fr\": \"Du 2/4/2024 \u00e0 juin 2025, travaux. ARRET NON DESSERVI. Arr\u00eat des bus 54: FOREST NATIONAL. (avenue du Globe 8).\", \"nl\": \"Van 2/4/2024 tot juni 2025, werken. HALTE NIET BEDIEND. Halte van bus 54: VORST NATIONAAL (Globelaan 8)\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"54\"}]", "priority": 4, "points": "[{\"id\": \"2939B\"}]"},{"content": "[{\"text\": [{\"en\": \"Until Summer of 2024, works. Stop of bus 47 and 56: av. Croix de Guerre, at the other side of Delhaize.\", \"fr\": \"Jusqu'\u00e0 l'\u00e9t\u00e9 2024, travaux. Arr\u00eat des bus 47 et 56 : avenue des Croix de Guerre, de l'autre c\u00f4t\u00e9 du Delhaize\", \"nl\": \"Tot zomer 2024, werken. Halte van bus 47 en 56: Oorlogskruisenlaan, aan de andere kant van de Delhaize.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"56\"}]", "priority": 4, "points": "[{\"id\": \"1974\"}, {\"id\": \"1967\"}]"},{"content": "[{\"text\": [{\"en\": \"Until Summer of 2024, works. Bus 56 diverted between VAN PRAET and PETER BENOIT via avenue des Croix de Guerre.\", \"fr\": \"Jusqu'\u00e0 l'\u00e9t\u00e9 2024, travaux. Bus 56 d\u00e9vi\u00e9 entre VAN PRAET et PETER BENOIT via avenue des Croix de Guerre.\", \"nl\": \"Tot zomer 2024, werken. Bus 56 omgeleid tussen VAN PRAET en PETER BENOIT via Oorlogskruisenlaan.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"56\"}]", "priority": 5, "points": "[{\"id\": \"2098\"}, {\"id\": \"3451\"}, {\"id\": \"6190\"}, {\"id\": \"9296\"}, {\"id\": \"2051\"}, {\"id\": \"6082\"}, {\"id\": \"2898\"}, {\"id\": \"2106\"}, {\"id\": \"1006\"}, {\"id\": \"2367\"}, {\"id\": \"3412\"}, {\"id\": \"2101\"}, {\"id\": \"6459\"}]"},{"content": "[{\"text\": [{\"en\": \"Until Summer of 2024, works. Stop not served. Stop of bus 56: place Peter Benoitplein 3\", \"fr\": \"Jusqu'\u00e0 l'\u00e9t\u00e9 2024, travaux. Arr\u00eat non desservi. Arr\u00eat du bus 56 : place Peter Benoit 3\", \"nl\": \"Tot zomer 2024, werken. Halte niet bediend. Halte van bus 56: Peter Benoitplein 3\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"56\"}]", "priority": 4, "points": "[{\"id\": \"1987\"}]"},{"content": "[{\"text\": [{\"en\": \"Until Summer of 2024, works. As of March 18, buses 56 and 57 serve this stop normally.\", \"fr\": \"Jusqu'\u00e0 l'\u00e9t\u00e9 2024, travaux. D\u00e8s le 18/3, les bus 56 et 57 desservent \u00e0 nouveau cet arr\u00eat.\", \"nl\": \"Tot zomer 2024, werken. Vanaf 18/3 bedienen bus 56 en 57 opnieuw deze halte.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"56\"}]", "priority": 5, "points": "[{\"id\": \"2829B\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. As of Apr 15, bus 56 diverted. Take bus 56 at the stop of bus 64 to BORDET STATION.\", \"fr\": \"Travaux. D\u00e8s le 15/4, bus 56 d\u00e9vi\u00e9. Prenez le bus 56 \u00e0 l'arr\u00eat du bus 64 vers BORDET STATION.\", \"nl\": \"Werken. Vanaf 15/4, bus 56 omgeleid. Neem bus 56 aan de halte van bus 64 naar BORDET STATION.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"56\"}]", "priority": 4, "points": "[{\"id\": \"2068\"}]"},{"content": "[{\"text\": [{\"en\": \"Until Summer of 2024, works. Stop not served. Stop of bus 57: chauss\u00e9e de Vilvorde, next to ropery Barrois\", \"fr\": \"Jsq \u00e9t\u00e9 2024, travaux. Arr\u00eat non desservi. Arr\u00eat du bus 57: ch\u00e9e de Vilvorde, le long de la corderie Barrois\", \"nl\": \"Tot zomer 2024, werken. Halte niet bediend. Halte B57: Vilvoordsestwg, naast de touwslagerij Barrois\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"57\"}]", "priority": 4, "points": "[{\"id\": \"3003\"}]"},{"content": "[{\"text\": [{\"en\": \"Until Summer of 2024, works. Stop not served. Take bus 47 or 57 at ANTOON VAN OSS (stop of bus 56 to BUDA).\", \"fr\": \"Jsq \u00e9t\u00e9 2024, travaux. Arr\u00eat non desservi. Prenez le bus 47 ou 57 \u00e0 ANTOON VAN OSS (arr\u00eat du bus 56 vers BUDA).\", \"nl\": \"Tot zomer 2024, werken. Halte niet bediend. Neem bus 47 of 57 aan ANTOON VAN OSS (halte van bus 56 naar BUDA).\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"57\"}]", "priority": 4, "points": "[{\"id\": \"1837\"}]"},{"content": "[{\"text\": [{\"en\": \"Until Summer of 2024, works. Stop not served. Stop of bus 57: MARLY (moved to ch. Vilvorde, next to number 150)\", \"fr\": \"Jsq \u00e9t\u00e9 2024, travaux. Arr\u00eat non desservi.Arr\u00eat du bus 57: MARLY (d\u00e9plac\u00e9 ch. Vilvorde, en face du num\u00e9ro 150)\", \"nl\": \"Tot zomer 2024, werken. Halte niet bediend. Halte van bus 57:MARLY (verplaatst Vilvoordsest tegenover nr. 150)\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"57\"}]", "priority": 4, "points": "[{\"id\": \"2315\"}]"},{"content": "[{\"text\": [{\"en\": \"Until Summer 2024,works. B57 divtd btw MARLY and ANT VAN OSS. As of Oct 16, B57 divtd btw MARLY and HOP. MILITAIRE\", \"fr\": \"Jsq \u00e9t\u00e9 2024, travaux. Bus 57 d\u00e9vi\u00e9 entre MARLY et ANT VAN OSS. D\u00e8s le 16/10, B57 d\u00e9vi\u00e9 entre MARLY et HOP MILITAIRE.\", \"nl\": \"Tot zomer 2024, werken. Bus 57 omgeleid ts MARLY en ANT VAN OSS. Vanaf 16/10, B57 omgeleid tss MARLY en MILITAIR HOSP.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"57\"}]", "priority": 5, "points": "[{\"id\": \"1090\"}, {\"id\": \"2327\"}, {\"id\": \"2305\"}, {\"id\": \"2326\"}, {\"id\": \"1356\"}, {\"id\": \"3058\"}, {\"id\": \"1052\"}, {\"id\": \"1051\"}, {\"id\": \"2308\"}, {\"id\": \"2868\"}, {\"id\": \"3061\"}]"},{"content": "[{\"text\": [{\"en\": \"Until Summer of 2024, works. Stop not served. Take bus 57 at ANTOON VAN OSS (stop of bus 56 to SCHUMAN).\", \"fr\": \"Jsq \u00e9t\u00e9 2024, travaux. Arr\u00eat non desservi. Prenez le bus 57 \u00e0 ANTOON VAN OSS (arr\u00eat du bus 56 vers SCHUMAN).\", \"nl\": \"Tot zomer 2024, werken. Halte niet bediend. Neem bus 57 aan ANTOON VAN OSS (halte van bus 56 naar SCHUMAN).\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"57\"}]", "priority": 4, "points": "[{\"id\": \"2316\"}]"},{"content": "[{\"text\": [{\"en\": \"Until Summer of 2024, works. Stop not served. Take bus 57 at ANTOON VAN OSS (stop of bus 56 to BUDA).\", \"fr\": \"Jsq \u00e9t\u00e9 2024, travaux. Arr\u00eat non desservi. Prenez le bus 57 \u00e0 ANTOON VAN OSS (arr\u00eat du bus 56 vers BUDA).\", \"nl\": \"Tot zomer 2024, werken. Halte niet bediend. Neem bus 57 aan ANTOON VAN OSS (halte van bus 56 naar BUDA).\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"57\"}]", "priority": 4, "points": "[{\"id\": \"2359\"}]"},{"content": "[{\"text\": [{\"en\": \"From Feb 8, works. STOP NOT SERVED. Temporary stop: Place de Houffalizeplein 2-6.\", \"fr\": \"D\u00e8s le 8/2, travaux. ARRET NON DESSERVI. Arr\u00eat provisoire: Place de Houffalize 2-6.\", \"nl\": \"Vanaf 8/2, werken. HALTE NIET BEDIEND. Tijdelijke halte: Houffalizeplein 2-6.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"59\"}]", "priority": 4, "points": "[{\"id\": \"3110\"}]"},{"content": "[{\"text\": [{\"en\": \"From May 2 at 7AM, works. STOP NOT SERVED. Take bus 60 at the stop BLYCKAERTS of bus 38 to HEROS / HELDEN.\", \"fr\": \"D\u00e8s le 2/5 \u00e0 7h, travaux. ARRET NON DESSERVI. Prenez le bus 60 \u00e0 l'arr\u00eat BLYCKAERTS du bus 38 vers HEROS.\", \"nl\": \"Vanaf 2/5 om 7u, werken. HALTE NIET BEDIEND. Neem bus 60 aan de halte BLYCKAERTS van bus 38 naar HELDEN.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"60\"}]", "priority": 4, "points": "[{\"id\": \"1881\"}]"},{"content": "[{\"text\": [{\"en\": \"From Mar 11, works. Bus 60 diverted. Temporary stop: chauss\u00e9e de Saint- Job/Sint-Jobsesteenweg, in front of nr. 390.\", \"fr\": \"D\u00e8s le 11/3, travaux. Bus 60 d\u00e9vi\u00e9. Arr\u00eat provisoire: chauss\u00e9e de Saint-Job, face au num\u00e9ro 390.\", \"nl\": \"Vanaf 11/3, werken. Bus 60 omgeleid. Tijdelijke halte: Sint-Jobsesteenweg, tegenover nr. 390.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"60\"}]", "priority": 4, "points": "[{\"id\": \"1738\"}, {\"id\": \"2705\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. As of Apr 15, STOP NOT SERVED. Walk to AMBIORIX.\", \"fr\": \"Travaux. D\u00e8s le 15/4, ARRET NON DESSERVI. Pour rejoindre AMBIORIX, continuez \u00e0 pied.\", \"nl\": \"Werken. Vanaf 15/4, HALTE NIET BEDIEND. Ga te voet verder om naar AMBIORIX te gaan.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"60\"}]", "priority": 4, "points": "[{\"id\": \"1418B\"}]"},{"content": "[{\"text\": [{\"en\": \"From Mar 11, works. Bus 60 diverted. Temporary stop: chauss\u00e9e de Saint- Job/Sint-Jobsesteenweg 265.\", \"fr\": \"D\u00e8s le 11/3, travaux. Bus 60 d\u00e9vi\u00e9. Arr\u00eat provisoire: chauss\u00e9e de Saint-Job 265.\", \"nl\": \"Vanaf 11/3, werken. Bus 60 omgeleid. Tijdelijke halte: Sint-Jobsesteenweg 265.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"60\"}]", "priority": 4, "points": "[{\"id\": \"2704\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. As of April 7th, stop served only by bus 66. Take bus 29, 63 or 65 at the stop of bus 71 to DELTA.\", \"fr\": \"Travaux. D\u00e8s le 7/4, arr\u00eat uniquement desservi par bus 66. Bus 29, 63 ou 65 \u00e0 l'arr\u00eat du bus 71 vers DELTA.\", \"nl\": \"Werken. Vanaf 7/4, halte enkel bediend door bus 66. Neem bus 29, 63 of 65 aan de halte van bus 71 naar DELTA.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"63\"}]", "priority": 4, "points": "[{\"id\": \"6445\"}]"},{"content": "[{\"text\": [{\"en\": \"Risk of subsidence. Stop of bus 65, 66 and N04 moved to chauss\u00e9e de Haecht/Haachtsesteenweg, next to number 162\", \"fr\": \"Risque d'effondrement. Arr\u00eat des bus 65, 66 et N04 d\u00e9plac\u00e9 chauss\u00e9e de Haecht, \u00e0 hauteur du num\u00e9ro 162.\", \"nl\": \"Risico op instorting. Halte van bus 65, 66 en N04 verplaatst naar de Haachtsesteenweg, ter hoogte van nummer 162.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"65\"}]", "priority": 4, "points": "[{\"id\": \"6418\"}]"},{"content": "[{\"text\": [{\"en\": \"Jan 7, 9PM-Jun 28,works. Tram 3 and 7 replaced by T-bus to DOCKS BRUXSEL. T-bus at this stop.\", \"fr\": \"7/1, 21h-28/6, travaux. Tram 3 et 7 remplac\u00e9s par des T-bus jusqu'\u00e0 DOCKS BRUXSEL. T-bus \u00e0 cet arr\u00eat.\", \"nl\": \"7/1, 21u-28/6, werken. Tram 3 en 7 vervangen door T-bus tot DOCKS BRUXSEL. T-bus aan deze halte.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"7\"}]", "priority": 5, "points": "[{\"id\": \"5707\"}]"},{"content": "[{\"text\": [{\"en\": \"Jan 8-Jun 28, works. Tram 7 interrupted btw HEEMBEEK and DOCKS BXL. T-bus to DOCKS BXL at stop of B83 to VAL MARIA\", \"fr\": \"8/1-28/6, travaux. T7 interrompu de HEEMBEEK \u00e0 DOCKS BXL. T-bus vers DOCKS BXL \u00e0 l'arr\u00eat du B83 vers VAL MARIA.\", \"nl\": \"8/1-28/6, werken. T7 onderbroken tss HEEMBEEK en DOCKS BRUXSEL. T-bus naar DOCKS BRUXSEL aan halte B83 naar MARI\u00cbND.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"7\"}]", "priority": 5, "points": "[{\"id\": \"5700G\"}]"},{"content": "[{\"text\": [{\"en\": \"Jan 7, 9PM-Jun 28, works. Stop not served. To continue to HEYSEL / HEIZEL, take tram 3 direction CHURCHILL.\", \"fr\": \"7/1, 21h-28/6, travaux. Arr\u00eat non desservi. Pour continuer vers HEYSEL, prenez le tram 3 direction CHURCHILL.\", \"nl\": \"7/1, 21u-28/6, werken. Halte niet bediend. Om naar HEIZEL te reizen, neem tram 3 richting CHURCHILL.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"7\"}]", "priority": 4, "points": "[{\"id\": \"6421F\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. As of April 7th, STOP NOT SERVED. To go to DE BROUCKERE, take metro lines 1 or 5.\", \"fr\": \"Travaux. D\u00e8s le 7/4, ARRET NON DESSERVI. Pour rejoindre DE BROUCKERE, prenez le m\u00e9tro 1 ou 5.\", \"nl\": \"Werken. Vanaf 7/4, HALTE NIET BEDIEND. Om naar DE BROUCKERE te gaan, neem metrolijn 1 of 5.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"71\"}]", "priority": 4, "points": "[{\"id\": \"6447\"}]"},{"content": "[{\"text\": [{\"en\": \"From Mar 18, works. STOP NOT SERVED. Temporary stop: avenue de la Couronne / Kroonlaan 439-443.\", \"fr\": \"D\u00e8s le 18/3, travaux. ARRET NON DESSERVI. Arr\u00eat provisoire: avenue de la Couronne 439-443.\", \"nl\": \"Vanaf 18/3, werken. HALTE NIET BEDIEND. Tijdelijke halte: Kroonlaan 439-443.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"71\"}]", "priority": 4, "points": "[{\"id\": \"3558\"}]"},{"content": "[{\"text\": [{\"en\": \"From Mar 18, works. STOP NOT SERVED. stop of bus 72: avenue de l'Universit\u00e9 / Hogeschoollaan 4-10.\", \"fr\": \"D\u00e8s le 18/3, travaux. ARRET NON DESSERVI. Arr\u00eat du bus 72: avenue de l'Universit\u00e9 4-10.\", \"nl\": \"Vanaf 18/3, werken. HALTE NIET BEDIEND. Halte van bus 72: Hogeschoollaan 4-10.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"72\"}]", "priority": 4, "points": "[{\"id\": \"3514\"}]"},{"content": "[{\"text\": [{\"en\": \"Works.From May 10 at 10PM to May 12, STOP NOT SERVED. Take bus 73 at VETERINAIRES.\", \"fr\": \"Travaux. Du 10/5 \u00e0 22h au 12/5, ARRET NON DESSERVI. Prenez le bus 73 \u00e0 VETERINAIRES.\", \"nl\": \"Werken. 10/5, 22u - 12/5, HALTE NIET BEDIEND. Neem bus 73 aan VEEARTSEN.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"73\"}]", "priority": 4, "points": "[{\"id\": \"3800\"}]"},{"content": "[{\"text\": [{\"en\": \"Subsidence. Bus 74 limited to DECROLY. Take bus 74 at DECROLY.\", \"fr\": \"Effondrement. Bus 74 limit\u00e9 \u00e0 DECROLY. Prenez le bus 74 \u00e0 DECROLY.\", \"nl\": \"Wegverzakking. Bus 74 beperkt tot DECROLY. Neem bus 74 aan DECROLY.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"74\"}]", "priority": 4, "points": "[{\"id\": \"2452\"}]"},{"content": "[{\"text\": [{\"en\": \"Subsidence. Bus 74 limited to DECROLY. Walk to UCCLE-STALLE / UKKEL-STALLE.\", \"fr\": \"Effondrement. Bus 74 limit\u00e9 \u00e0 DECROLY. Continuez \u00e0 pied jusqu'\u00e0 UCCLE STALLE.\", \"nl\": \"Wegverzakking. Bus 74 beperkt tot DECROLY. Ga te voet tot UKKEL-STALLE.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"74\"}]", "priority": 4, "points": "[{\"id\": \"2416\"}, {\"id\": \"2415\"}, {\"id\": \"2414\"}]"},{"content": "[{\"text\": [{\"en\": \"From Apr 2, 2024 to June 2025, works. STOP NOT SERVED. Stop of bus 74: chauss\u00e9e de Bruxelles / Brusselsesteenweg 84.\", \"fr\": \"Du 2/4/2024 \u00e0 juin 2025, travaux. ARRET NON DESSERVI. Arr\u00eat du bus 74: chauss\u00e9e de Bruxelles 84.\", \"nl\": \"Van 2/4/2024 tot juni 2025, werken. HALTE NIET BEDIEND. Halte van bus 74: Brusselsesteenweg 84.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"74\"}]", "priority": 4, "points": "[{\"id\": \"5152\"}, {\"id\": \"5161\"}]"},{"content": "[{\"text\": [{\"en\": \"Subsidence. Bus 74 limited to DECROLY. Walk from DECROLY to UCCLE-STALLE / UKKEL-STALLE.\", \"fr\": \"Effondrement. Bus 74 limit\u00e9 \u00e0 DECROLY. Continuez \u00e0 pied depuis DECROLY jusqu'\u00e0 UCCLE STALLE.\", \"nl\": \"Wegverzakking. Bus 74 beperkt tot DECROLY. Ga te voet van DECROLY tot UKKEL-STALLE.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"74\"}]", "priority": 5, "points": "[{\"id\": \"3682\"}, {\"id\": \"3074\"}, {\"id\": \"5915\"}, {\"id\": \"2614\"}, {\"id\": \"2602\"}, {\"id\": \"2601\"}, {\"id\": \"2600\"}, {\"id\": \"2226\"}, {\"id\": \"2523\"}, {\"id\": \"2555\"}, {\"id\": \"2599\"}, {\"id\": \"1015\"}, {\"id\": \"2598\"}, {\"id\": \"2607\"}, {\"id\": \"2606\"}, {\"id\": \"2605\"}]"},{"content": "[{\"text\": [{\"en\": \"Until 2026, works. Stop not served. Stop of the T-bus: rue de la Soierie / Zijdeweverijstraat 4.\", \"fr\": \"Jusqu'en 2026, travaux. Arr\u00eat non desservi. Arr\u00eat du T-bus: rue de la Soierie 4.\", \"nl\": \"Tot 2026, werken. Halte niet bediend. Halte van de T-bus: Zijdeweverijstraat 4.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"82\"}]", "priority": 4, "points": "[{\"id\": \"5154F\"}]"},{"content": "[{\"text\": [{\"en\": \"Until 2026, works. Tram 82 replaced by T-bus to FOREST CENTRE. T-bus at this stop.\", \"fr\": \"Jusqu'en 2026, travaux. Tram 82 remplac\u00e9 par des T-bus jusqu'\u00e0 FOREST CENTRE. T-bus \u00e0 cet arr\u00eat.\", \"nl\": \"Tot 2026, werken. Tram 82 vervangen door T-bus tot VORST CENTRUM. T-bus aan deze halte.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"82\"}]", "priority": 4, "points": "[{\"id\": \"5756F\"}, {\"id\": \"1258G\"}]"},{"content": "[{\"text\": [{\"en\": \"Until 2026, works. Tram 82 interrupted. Take tram 82 at the stop in the other direction.\", \"fr\": \"Jusqu'en 2026, travaux. Tram 82 interrompu. Prenez le tram 82 \u00e0 l'arr\u00eat dans l'autre sens.\", \"nl\": \"Tot 2026, werken. Tram 82 onderbroken. Neem tram 82 aan de halte in de andere richting.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"82\"}]", "priority": 4, "points": "[{\"id\": \"5161F\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. Until 2026, tram 82 replaced by T-bus btw FOREST CENTRE / VORST CENTRUM and DROGENBOS. T-bus at this stop.\", \"fr\": \"Travaux. Jusqu'en 2026, tram 82 remplac\u00e9 par des T-bus entre FOREST CENTRE et DROGENBOS. T-bus \u00e0 cet arr\u00eat.\", \"nl\": \"Werken. Tot 2026, tram 82 vervangen door T-bus tussen VORST CENTRUM en DROGENBOS. T-bus aan deze halte.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"82\"}]", "priority": 4, "points": "[{\"id\": \"5722F\"}, {\"id\": \"5723G\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. Until 2026, tram 82 replaced by T-bus between DROGENBOS and FOREST CENTRE / VORST CENTRUM.\", \"fr\": \"Travaux. Jusqu'en 2026, tram 82 remplac\u00e9 par des T-bus entre DROGENBOS et FOREST CENTRE. T-bus \u00e0 cet arr\u00eat.\", \"nl\": \"Werken. Tot 2026, tram 82 vervangen door T-bus tussen DROGENBOS en VORST CENTRUM. T-bus aan deze halte.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"82\"}]", "priority": 4, "points": "[{\"id\": \"5753F\"}, {\"id\": \"5751\"}, {\"id\": \"5754\"}]"},{"content": "[{\"text\": [{\"en\": \"Until 2026, works. Tram 82 interrupted. T-bus to DROGENBOS at the stop of bus 54 to TRONE/TROON.\", \"fr\": \"Jusqu'en 2026, travaux. Tram 82 interrompu. T-bus vers DROGENBOS \u00e0 l'arr\u00eat du bus 54 vers TRONE.\", \"nl\": \"Tot 2026, werken. Tram 82 onderbroken. T-bus naar DROGENBOS aan de halte van bus 54 naar TROON.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"82\"}]", "priority": 4, "points": "[{\"id\": \"5121F\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. Until 2026, stop not served. Stop of T-bus 82 and of bus 50: rue de la Soierie / Zijdeweverijstraat 9.\", \"fr\": \"Travaux. Jusqu'en 2026, arr\u00eat non desservi. Arr\u00eat du T-bus 82 et du bus 50 : rue de la Soierie 9.\", \"nl\": \"Werken. Tot 2026, halte niet bediend. Halte van T-bus 82 en van bus 50: Zijdeweverijstraat 9.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"82\"}]", "priority": 4, "points": "[{\"id\": \"5156F\"}]"},{"content": "[{\"text\": [{\"en\": \"Until 2026, works. Tram 82 replaced by T-bus between FOREST CENTRE / VORST CENTRUM and DROGENBOS.\", \"fr\": \"Jusqu'en 2026, travaux. Tram 82 remplac\u00e9 par des T-bus entre FOREST CENTRE et DROGENBOS. Info: stib.brussels.\", \"nl\": \"Tot 2026, werken. Tram 82 vervangen door T-bus tussen VORST CENTRUM en DROGENBOS. Info: mivb. brussels.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"82\"}]", "priority": 5, "points": "[{\"id\": \"2603\"}, {\"id\": \"5718\"}, {\"id\": \"0631\"}, {\"id\": \"5120\"}, {\"id\": \"2539F\"}, {\"id\": \"5123\"}, {\"id\": \"2548F\"}, {\"id\": \"2604F\"}, {\"id\": \"2544F\"}, {\"id\": \"5119\"}]"},{"content": "[{\"text\": [{\"en\": \"From Jan 22 at 6AM to end of June, works. Bus 86 diverted. B86 at the stop RIBAUCOURT of bus 20 to GARE DU NORD.\", \"fr\": \"Du 22/1 \u00e0 6h jusqu'\u00e0 fin juin, travaux. Bus 86 d\u00e9vi\u00e9. Bus 86 \u00e0 l'arr\u00eat RIBAUCOURT du bus 20 vers GARE DU NORD.\", \"nl\": \"Van 22/1 om 6u tot eind juni, werken. Bus 86 omgeleid. Bus 86 aan de halte RIBAUCOURT van bus 20 naar NOORDSTATION.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"86\"}]", "priority": 4, "points": "[{\"id\": \"4253\"}]"},{"content": "[{\"text\": [{\"en\": \"From Jan 22 at 6AM to end of June, works. Bus 86 diverted. Take the bus at the previous stop GARE DE L'OUEST.\", \"fr\": \"Du 22/1 \u00e0 6h jusqu'\u00e0 fin juin, travaux. Bus 86 d\u00e9vi\u00e9. Prenez le bus \u00e0 l'arr\u00eat pr\u00e9c\u00e9dent GARE DE  L'OUEST.\", \"nl\": \"Van 22/1 om 6u tot eind juni, werken. Bus 86 omgeleid. Neem de bus aan vorige halte WESTSTATION.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"86\"}]", "priority": 4, "points": "[{\"id\": \"3257\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. From Apr 23 until Jun 2, bus 13 and 88 diverted. Take bus 13 or 88 at the stop of bus 820 to UZ Brussel.\", \"fr\": \"Travaux; Du 23/4 au 2/6, bus 13 et 88 d\u00e9vi\u00e9s. Prenez le bus 13 ou 88 \u00e0 l'arr\u00eat du bus 820 vers UZ Brussel.\", \"nl\": \"Werken. Van 23/4 tot en met 2/6, bus 13 en 88 omgeleid. Neem bus 13 of 88 aan de halte van bus 820 naar UZ Brussel.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"88\"}]", "priority": 4, "points": "[{\"id\": \"1721\"}, {\"id\": \"1328\"}]"},{"content": "[{\"text\": [{\"en\": \"From Feb 2 7AM, works. STOP NOT SERVED. Temporary halte: Boulevard Emile Jacqmainlaan 82-94.\", \"fr\": \"D\u00e8s le 8/2 7h, travaux. ARRET NON DESSERVI. Arr\u00eat provisoire: Boulevard Emile Jacqmain 82-94.\", \"nl\": \"Vanaf 8/2 7u, werken. HALTE NIET BEDIEND. Tijdelijke halte: Emile Jacqmainlaan 82-94.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"88\"}]", "priority": 4, "points": "[{\"id\": \"2070\"}]"},{"content": "[{\"text\": [{\"en\": \"Until end of August, works. Bus 89 diverted. To continue to CENTRAL STATION, take bus 29 71\", \"fr\": \"Jusque fin ao\u00fbt, travaux. Bus 89 d\u00e9vi\u00e9. Pour continuer vers GARE CENTRALE, prenez le bus 29 ou 71.\", \"nl\": \"Tot einde augustus, werken. Bus 89 omgeleid. Om verder naar CENTRAAL STATION te reizen, neem bus 29 of 71.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"89\"}]", "priority": 5, "points": "[{\"id\": \"1820\"}, {\"id\": \"2296\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. As of Apr 22 at 9.30AM, bus 89 diverted. Stop of bus 89: rue des Quatre-Vents / Vier Windenstraat 141\", \"fr\": \"Travaux. D\u00e8s le 22/4 \u00e0 9h30, bus 89 d\u00e9vi\u00e9. Arr\u00eat du bus 89: rue des Quatre-Vents, 141.\", \"nl\": \"Werken. Vanaf 22/4 om 9. 30u, bus 89 omgeleid. Halte van bus 89: Vier Windenstraat 141\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"89\"}]", "priority": 4, "points": "[{\"id\": \"4594\"}]"},{"content": "[{\"text\": [{\"en\": \"Until end of August, works. Bus 89 diverted. For the city center, take metro 1 or 5 at COMTE DE FLANDRE.\", \"fr\": \"Jusque fin ao\u00fbt, travaux. Bus 89 d\u00e9vi\u00e9. Pour le centre-ville, prenez le m\u00e9tro 1 ou 5 \u00e0 COMTE DE FLANDRE.\", \"nl\": \"Tot einde augustus, werken. Bus 89 omgeleid. Om naar het stadscentrum te gaan, neem M 1 5 aan GRAAF VAN VLAANDEREN.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"89\"}]", "priority": 4, "points": "[{\"id\": \"3259C\"}, {\"id\": \"3260\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. As of Apr 22 at 9.30AM, bus 89 diverted. Stop of bus 89: rue Delaunoystraat 15.\", \"fr\": \"Travaux. D\u00e8s le 22/4 \u00e0 9h30, bus 89 d\u00e9vi\u00e9. Arr\u00eat du bus 89: rue Delaunoy, 15.\", \"nl\": \"Werken. Vanaf 22/4 om 9. 30u, bus 89 omgeleid. Halte van bus 89: Delaunoystraat 15.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"89\"}]", "priority": 4, "points": "[{\"id\": \"3228\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. From Apr 26 at 9PM until May 12, stop not served. T-bus to ROI BAUDOUIN at the stop of bus 13 to ETANGS NOIRS.\", \"fr\": \"Travaux. Du 26/4 \u00e0 21h au 12/5, arr\u00eat non desservi. T-bus vers ROI BAUDOUIN \u00e0 l'arr\u00eat du bus 13 vers ETANGS NOIRS\", \"nl\": \"Werken. 26/4, 21u-12/5, halte niet bediend.T-bus naar KONING BOUDEWIJN aan de halte van bus 13 naar ZWARTE VIJVERS.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"9\"}]", "priority": 4, "points": "[{\"id\": \"1683F\"}, {\"id\": \"1685F\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. From May 8 at 9PM until May 12, T-bus 19 does not serve HOP. BRUGMANN. Connection to T-bus 19 at CIM. JETTE.\", \"fr\": \"Travaux. 8/5, 21h-12/5, T-bus 19 ne dessert pas HOPITAL BRUGMANN. Correspondance T-bus 19 \u00e0 CIMETIERE DE JETTE.\", \"nl\": \"8/5, 21u-12/5, werken. T-bus 19 bedient BRUGMANN-ZKH. niet. Aansluiting met T-bus 19 aan KERKHOF VAN JETTE.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"93\"}]", "priority": 4, "points": "[{\"id\": \"5400\"}, {\"id\": \"5402\"}, {\"id\": \"5399F\"}]"},{"content": "[{\"text\": [{\"en\": \"As of September 21, works. Stop moved to av. de la Fauconnerie / Valkerijlaan, next to number 53a.\", \"fr\": \"D\u00e8s le 21/9, travaux. Arr\u00eat d\u00e9plac\u00e9 avenue de la Fauconnerie, \u00e0 hauteur du num\u00e9ro 53a.\", \"nl\": \"Vanaf 21/9, werken. Halte verplaatst naar de Valkerijlaan, ter hoogte van huisnummer 53a.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"95\"}]", "priority": 4, "points": "[{\"id\": \"4314\"}]"},{"content": "[{\"text\": [{\"en\": \"From Mar 25 until Jun 30, works. Bus 95 diverted btw CIMETIERE D'IXELLES and ETTERBEEK GARE\", \"fr\": \"Du 25/3 au 30/6, travaux. Bus 95 d\u00e9vi\u00e9 entre CIMETIERE D'IXELLES et  ETTERBEEK GARE.\", \"nl\": \"Van 25/3 tot en met 30/6, werken. Bus 95 omgeleid tussen BEGRAAFPLAATS VAN ELSENE en ETTERBEEK STATION.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"95\"}]", "priority": 5, "points": "[{\"id\": \"4360\"}, {\"id\": \"4351\"}, {\"id\": \"1455\"}, {\"id\": \"4355\"}, {\"id\": \"4357\"}, {\"id\": \"4358\"}, {\"id\": \"4359\"}, {\"id\": \"4348\"}]"},{"content": "[{\"text\": [{\"en\": \"Mar 25-Jun 30, works. STOP NOT SERVED. Stop of bus 95: CIMETIERE D'IXELLES / BEGR. VAN ELSENE.\", \"fr\": \"25/3-30/6,travaux. ARRET NON DESSERVI. Arr\u00eat du bus 95: CIM. D'IXELLES (ch\u00e9e de Boondael, avant le rond-point).\", \"nl\": \"25/3-30/6, werken. HALTE NIET BEDIEND. Halte van bus 95: BEGR. VAN ELSENE (Boondaalsestwg, voor de rotonde)\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"95\"}]", "priority": 4, "points": "[{\"id\": \"4362\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. As of Mar 27, STOP MOVED. Stop of bus 95: rue des Thuyas / Thujastraat 5.\", \"fr\": \"Travaux. D\u00e8s le 27/3, ARRET DEPLACE. Arr\u00eat du bus 95: rue des Thuyas, 5.\", \"nl\": \"Werken. Vanaf 27/3, HALTE VERPLAATST. Halte van bus 95: Thujastraat 5.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"95\"}]", "priority": 4, "points": "[{\"id\": \"4310\"}]"},{"content": "[{\"text\": [{\"en\": \"From Mar 25 until Jun 30, works. STOP NOT SERVED. Stop of bus 95: av. Couronne / Kroonln, in front of number 384\", \"fr\": \"Du 25/3 au 30/6, travaux. ARRET NON DESSERVI. Arr\u00eat du bus 95: av. de la Couronne, en face du num\u00e9ro 384.\", \"nl\": \"Van 25/3 tot en met 30/6, werken. HALTE NIET BEDIEND. Halte van bus 95: Kroonlaan, tegenover nummer 384\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"95\"}]", "priority": 4, "points": "[{\"id\": \"4306\"}]"},{"content": "[{\"text\": [{\"en\": \"Until 2026, works. As of Mar 11, T97 interrupted btw DIEWEG and WIELS. Take T4 to CARR. STALLE, and then the T-bus.\", \"fr\": \"Jsq 2026,travaux. D\u00e8s le 11/3, T97 interrompu entre DIEWEG et WIELS. T4 jsq CARREFOUR STALLE, et ensuite le T-bus.\", \"nl\": \"Tot 2026,werken. Vanaf 11/3, T97 onderbroken tss DIEWEG en WIELS. Neem T4 tot KRUISPUNT STALLE, en de T-bus.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"97\"}]", "priority": 4, "points": "[{\"id\": \"2708G\"}, {\"id\": \"5952F\"}, {\"id\": \"2709F\"}, {\"id\": \"2710G\"}, {\"id\": \"1984G\"}]"},{"content": "[{\"text\": [{\"en\": \"Until 2026, works. Tram 97 interrupted to WIELS. Stop of the T-bus to ROCHEFORT: r. Abbesses / Abdissenstr.\", \"fr\": \"Jusqu'en 2026, travaux. Tram 97 interrompu jusqu'\u00e0 WIELS. Arr\u00eat du T-bus vers ROCHEFORT: rue des Abbesses.\", \"nl\": \"Tot 2026, werken. Tram 97 onderbroken tot WIELS. Halte van de T-bus naar ROCHEFORT: Abdissenstraat.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"97\"}]", "priority": 4, "points": "[{\"id\": \"5152G\"}]"},{"content": "[{\"text\": [{\"en\": \"Until 2026, works. T-bus 82/97 diverted. Stop T-bus 82/97: bd 2e Arm\u00e9e Britannique / Britse Tweedelegerlaan.\", \"fr\": \"Jsq 2026, travaux. T-bus 82/97 d\u00e9vi\u00e9. Arr\u00eat T-bus 82/97: bd 2e Arm\u00e9e Britannique, carrefour rue de la Station.\", \"nl\": \"Tot 2026, werken. T-bus 82/97 omgeleid. Halte T-bus 82/97: Britse Tweedelegerlaan, kruispunt Stationstraat.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"97\"}]", "priority": 4, "points": "[{\"id\": \"5719H\"}]"},{"content": "[{\"text\": [{\"en\": \"From May 18, 5AM, works. STOP NOT SERVED. Stop of tram 97: avenue du Parc / Parklaan 26, in front of number 26.\", \"fr\": \"D\u00e8s le 18/5, 5h, travaux. ARRET NON DESSERVI. Arr\u00eat du tram 97: avenue du Parc, en face du num\u00e9ro 26.\", \"nl\": \"Vanaf 18/5, 5u, werken. HALTE NIET BEDIEND. Halte van tram 97: Parklaan, tegenover nummer 26.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"97\"}]", "priority": 4, "points": "[{\"id\": \"2334F\"}]"},{"content": "[{\"text\": [{\"en\": \"Until 2026, works. Tram 97 interrupted to WIELS. Stop of the T-bus to ROCHEFORT: ch. Neerstalsestwg 236\", \"fr\": \"Jsq 2026, travaux. Tram 97 interrompu jsq WIELS. Arr\u00eat du T-bus vers ROCHEFORT: chauss\u00e9e de Neerstalle, 236\", \"nl\": \"Tot 2026, werken. Tram 97 onderbroken tot WIELS. Halte van de T-bus naar ROCHEFORT: Neerstalsesteenweg,236\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"97\"}]", "priority": 4, "points": "[{\"id\": \"5164F\"}]"},{"content": "[{\"text\": [{\"en\": \"Until 2026, works. Tram 97 interrupted between CARREFOUR STALLE en WIELS. T-bus to ROCHEFORT at this stop.\", \"fr\": \"Jusqu'en 2026, travaux. Tram 97 interrompu entre CARREFOUR STALLE et WIELS. T-bus vers ROCHEFORT \u00e0 cet arr\u00eat.\", \"nl\": \"Tot 2026, werken. T97 onderbroken tussen KRUISPT STALLE en WIELS. T-bus naar ROCHEFORT aan deze halte.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"97\"}]", "priority": 4, "points": "[{\"id\": \"5756F\"}, {\"id\": \"1258G\"}]"},{"content": "[{\"text\": [{\"en\": \"Until 2026, works. T97 interrupted to WIELS. T97 at WIELS via T82, or at ROCHEFORT via T-bus (stop: r. Abbesses)\", \"fr\": \"Jsq 2026, travaux. T97 interrompu jsq WIELS. T97 \u00e0 WIELS via T82, ou \u00e0 ROCHEFORT via T-bus (arr\u00eat: r. Abbesses).\", \"nl\": \"Tot 2026, werken. T97 onderbroken tot WIELS. T97 aan WIELS via T82, of aan ROCHEFORT via T-bus, halte: Abdissenst\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"97\"}]", "priority": 4, "points": "[{\"id\": \"5161F\"}]"},{"content": "[{\"text\": [{\"en\": \"From Jan 15, works. STOP NOT SERVED. Take Noctis N09 at the stop CLESSE of bus 72 to ADEPS.\", \"fr\": \"D\u00e8s le 15/1, travaux. ARRET NON DESSERVI. Prenez le Noctis N09 \u00e0 l'arr\u00eat CLESSE du bus 72 vers ADEPS.\", \"nl\": \"Vanaf 15/1, werken. HALTE NIET BEDIEND. Neem Noctis N09 aan de halte CLESSE van bus 72 naar ADEPS.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"N09\"}]", "priority": 4, "points": "[{\"id\": \"1719\"}]"},{"content": "[{\"text\": [{\"en\": \"From Jan 15, works. STOP NOT SERVED. Noctis N09 at the stop      RO(O) DENBERG of bus 72 to ADEPS.\", \"fr\": \"D\u00e8s le 15/1, travaux. ARRET NON DESSERVI. Prenez le Noctis N09 \u00e0 l'arr\u00eat ROODENBERG du bus 72 vers ADEPS.\", \"nl\": \"Vanaf 15/1, werken. HALTE NIET BEDIEND. Neem Noctis N09 aan de halte RODENBERG van bus 72 naar ADEPS.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"N09\"}]", "priority": 4, "points": "[{\"id\": \"1720B\"}]"},{"content": "[{\"text\": [{\"en\": \"From Mar 18, works. STOP NOT SERVED. stop of N09: chauss\u00e9e de Boondael / Boondaalsesteenweg, before roundabout.\", \"fr\": \"D\u00e8s le 18/3, travaux. ARRET NON DESSERVI. Arr\u00eat du bus N09: chauss\u00e9e de Boondael, avant le rond-point.\", \"nl\": \"Vanaf 18/3, werken. HALTE NIET BEDIEND. Halte van bus N09: Boondaalsesteenweg, voor rondpunt.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"N09\"}]", "priority": 4, "points": "[{\"id\": \"3514\"}]"},{"content": "[{\"text\": [{\"en\": \"From Mar 18, works. STOP NOT SERVED. stop of bus N09: avenue de l'Universit\u00e9 / Hogeschoollaan 4-10.\", \"fr\": \"D\u00e8s le 18/3, travaux. ARRET NON DESSERVI. Arr\u00eat du bus N09: avenue de l'Universit\u00e9 4-10.\", \"nl\": \"Vanaf 18/3, werken. HALTE NIET BEDIEND. Halte van bus N09: Hogeschoollaan 4-10.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"N09\"}]", "priority": 4, "points": "[{\"id\": \"3558\"}]"},{"content": "[{\"text\": [{\"en\": \"From Feb 15, subsidence. N10 diverted between LEPOUTRE and FLAGEY.\", \"fr\": \"D\u00e8s le 15/2, effondrement. N10 d\u00e9vi\u00e9 entre LEPOUTRE et FLAGEY.\", \"nl\": \"Vanaf 15/2, wegverzakking. N10 omgeleid tussen LEPOUTRE en FLAGEY.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"N10\"}]", "priority": 4, "points": "[{\"id\": \"2133\"}, {\"id\": \"5053B\"}, {\"id\": \"2132\"}, {\"id\": \"2131\"}, {\"id\": \"1250\"}, {\"id\": \"4857B\"}, {\"id\": \"4804B\"}, {\"id\": \"2150\"}, {\"id\": \"6956B\"}, {\"id\": \"2002\"}, {\"id\": \"2134\"}, {\"id\": \"6406\"}, {\"id\": \"2847\"}]"},{"content": "[{\"text\": [{\"en\": \"From Feb 15, subsidence. N10 diverted. Temporary stop: place Albert Leemansplein 6.\", \"fr\": \"D\u00e8s le 15/2, effondrement. N10 d\u00e9vi\u00e9. Arr\u00eat provisoire: place Albert Leemans 6.\", \"nl\": \"Vanaf 15/2, wegverzakking. N10 omgeleid. Tijdelijke halte: Albert Leemansplein 6.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"N10\"}]", "priority": 4, "points": "[{\"id\": \"4705\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. STOP NOT SERVED. Stop of bus N18: rue de Laeken / Lakensestraat 57-59.\", \"fr\": \"Travaux. ARRET NON DESSERVI. Arr\u00eat du bus N18: rue de Laeken 57-59.\", \"nl\": \"Werken. HALTE NIET BEDIEND. Halte van bus N18: Lakensestraat 57-59.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"N18\"}]", "priority": 4, "points": "[{\"id\": \"3465\"}]"},{"content": "[{\"text\": [{\"en\": \"Works.From May 8 at 9PM until May 12, STOP NOT SERVED. T-bus to SIMONIS at CIM. / KERKH. JETTE, via tram 51 or 93.\", \"fr\": \"Travaux. Du 8/5 \u00e0 21h au 12/5, ARRET NON DESSERVI. T-bus vers SIMONIS \u00e0 CIM. DE JETTE, via tram 51 ou 93.\", \"nl\": \"Werken. Van 8/5 om 21u tot 12/5, HALTE NIET BEDIEND. T-bus naar SIMONIS aan KERKHOF VAN JETTE, via tram 51 of 93\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"T19\"}]", "priority": 4, "points": "[{\"id\": \"2802\"}]"},{"content": "[{\"text\": [{\"en\": \"Until 2026, works. Bus 50 and T-bus diverted between FOREST CENTRE / VORST CENTRUM and BEMPT.\", \"fr\": \"Jusqu'en 2026, travaux. Bus 50 et T-bus d\u00e9vi\u00e9s entre FOREST CENTRE et BEMPT.\", \"nl\": \"Tot 2026, werken. Bus 50 en T-bus omgeleid tussen VORST CENTRUM en BEMPT.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"T82\"}]", "priority": 5, "points": "[{\"id\": \"3196\"}]"},{"content": "[{\"text\": [{\"en\": \"Until 2026, works. T-bus 82/97 diverted between BEMPT and FOREST CENTRE/VORST CENTRUM.\", \"fr\": \"Jusqu'en 2026, travaux. T-bus 82/97 d\u00e9vi\u00e9 entre BEMPT et FOREST CENTRE.\", \"nl\": \"Tot 2026, werken. Bus T-bus 82/97 omgeleid tussen BEMPT en VORST CENTRUM.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"T82\"}]", "priority": 5, "points": "[{\"id\": \"3405\"}, {\"id\": \"7472\"}, {\"id\": \"7474\"}, {\"id\": \"7465\"}, {\"id\": \"3255\"}, {\"id\": \"5755\"}, {\"id\": \"5756\"}]"}]
+[
+    {
+        "content": "[{\"text\": [{\"en\": \"Rescue service interv.: T81 is not operated between MEIR and ZUIDSTATION\", \"fr\": \"Interv. serv. de secours : T81 ne circule pas entre MEIR et GARE DU MIDI\", \"nl\": \"Interventie hulpdiensten: T81 rijdt niet tussen MEIR en ZUIDSTATION\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"81\"}]",
+        "priority": 2,
+        "points": "[{\"id\": \"6153\"}, {\"id\": \"6078\"}, {\"id\": \"3611F\"}, {\"id\": \"3123\"}, {\"id\": \"6858G\"}, {\"id\": \"2286G\"}, {\"id\": \"6705F\"}, {\"id\": \"1805F\"}, {\"id\": \"6106\"}, {\"id\": \"6155F\"}, {\"id\": \"6109\"}, {\"id\": \"6462F\"}, {\"id\": \"2331F\"}, {\"id\": \"6120\"}, {\"id\": \"6166\"}, {\"id\": \"6165\"}, {\"id\": \"3610F\"}, {\"id\": \"2539F\"}, {\"id\": \"3371F\"}, {\"id\": \"6808G\"}, {\"id\": \"6162\"}, {\"id\": \"2671F\"}, {\"id\": \"6427F\"}, {\"id\": \"2380F\"}, {\"id\": \"6117\"}, {\"id\": \"2259F\"}, {\"id\": \"6463F\"}, {\"id\": \"6156F\"}, {\"id\": \"2336G\"}, {\"id\": \"3608\"}, {\"id\": \"6175\"}, {\"id\": \"6099\"}, {\"id\": \"6121F\"}, {\"id\": \"6113F\"}, {\"id\": \"3613F\"}, {\"id\": \"6809F\"}, {\"id\": \"1042\"}, {\"id\": \"3370F\"}, {\"id\": \"3572F\"}, {\"id\": \"2220F\"}, {\"id\": \"2260F\"}, {\"id\": \"6799F\"}, {\"id\": \"6860G\"}, {\"id\": \"6157F\"}, {\"id\": \"2931F\"}, {\"id\": \"6009\"}, {\"id\": \"6008\"}, {\"id\": \"2971F\"}, {\"id\": \"6077F\"}, {\"id\": \"3612F\"}, {\"id\": \"6068\"}, {\"id\": \"6114F\"}, {\"id\": \"2218F\"}, {\"id\": \"2285G\"}, {\"id\": \"0631\"}, {\"id\": \"6425F\"}, {\"id\": \"6810\"}, {\"id\": \"2217F\"}, {\"id\": \"6158H\"}, {\"id\": \"6856\"}, {\"id\": \"6811\"}, {\"id\": \"3508F\"}, {\"id\": \"2257G\"}, {\"id\": \"6857\"}, {\"id\": \"3609F\"}, {\"id\": \"6792F\"}, {\"id\": \"2960F\"}, {\"id\": \"2972F\"}, {\"id\": \"0636\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"T81 is operated again between MEIR and ZUIDSTATION\", \"fr\": \"T81 circule \u00e0 nouveau entre MEIR et GARE DU MIDI\", \"nl\": \"T81 wordt weer bediend tussen MEIR en ZUIDSTATION\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"81\"}]",
+        "priority": 2,
+        "points": "[{\"id\": \"6153\"}, {\"id\": \"6078\"}, {\"id\": \"3611F\"}, {\"id\": \"3123\"}, {\"id\": \"6858G\"}, {\"id\": \"2286G\"}, {\"id\": \"6705F\"}, {\"id\": \"1805F\"}, {\"id\": \"6106\"}, {\"id\": \"6155F\"}, {\"id\": \"6109\"}, {\"id\": \"6462F\"}, {\"id\": \"2331F\"}, {\"id\": \"6120\"}, {\"id\": \"6166\"}, {\"id\": \"6165\"}, {\"id\": \"3610F\"}, {\"id\": \"2539F\"}, {\"id\": \"3371F\"}, {\"id\": \"6808G\"}, {\"id\": \"6162\"}, {\"id\": \"2671F\"}, {\"id\": \"6427F\"}, {\"id\": \"2380F\"}, {\"id\": \"6117\"}, {\"id\": \"2259F\"}, {\"id\": \"6463F\"}, {\"id\": \"6156F\"}, {\"id\": \"2336G\"}, {\"id\": \"3608\"}, {\"id\": \"6175\"}, {\"id\": \"6099\"}, {\"id\": \"6121F\"}, {\"id\": \"6113F\"}, {\"id\": \"3613F\"}, {\"id\": \"6809F\"}, {\"id\": \"1042\"}, {\"id\": \"3370F\"}, {\"id\": \"3572F\"}, {\"id\": \"2220F\"}, {\"id\": \"2260F\"}, {\"id\": \"6799F\"}, {\"id\": \"6860G\"}, {\"id\": \"6157F\"}, {\"id\": \"2931F\"}, {\"id\": \"6009\"}, {\"id\": \"6008\"}, {\"id\": \"2971F\"}, {\"id\": \"6077F\"}, {\"id\": \"3612F\"}, {\"id\": \"6068\"}, {\"id\": \"6114F\"}, {\"id\": \"2218F\"}, {\"id\": \"2285G\"}, {\"id\": \"0631\"}, {\"id\": \"6425F\"}, {\"id\": \"6810\"}, {\"id\": \"2217F\"}, {\"id\": \"6158H\"}, {\"id\": \"6856\"}, {\"id\": \"6811\"}, {\"id\": \"3508F\"}, {\"id\": \"2257G\"}, {\"id\": \"6857\"}, {\"id\": \"3609F\"}, {\"id\": \"6792F\"}, {\"id\": \"2960F\"}, {\"id\": \"2972F\"}, {\"id\": \"0636\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. As of Apr 15, STOP NOT SERVED. Stop of bus 12: rue Archim\u00e8de / Archimedesstraat 16.\", \"fr\": \"Travaux. D\u00e8s le 15/4, ARRET NON DESSERVI. Arr\u00eat du bus 12: rue Archim\u00e8de 16.\", \"nl\": \"Werken. Vanaf 15/4, HALTE NIET BEDIEND. Halte van bus 12: Archimedesstraat 16.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"12\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"1418B\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. From Apr 23 until Jun 2, bus 13 and 88 diverted. Take bus 13 or 88 at the stop of bus 820 to UZ Brussel.\", \"fr\": \"Travaux; Du 23/4 au 2/6, bus 13 et 88 d\u00e9vi\u00e9s. Prenez le bus 13 ou 88 \u00e0 l'arr\u00eat du bus 820 vers UZ Brussel.\", \"nl\": \"Werken. Van 23/4 tot en met 2/6, bus 13 en 88 omgeleid. Neem bus 13 of 88 aan de halte van bus 820 naar UZ Brussel.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"13\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"1721\"}, {\"id\": \"1328\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Sep 5 6AM, works. STOP NOT SERVED. Temporary stop: rue du Brillant (across stop towards Heiligenborre)\", \"fr\": \"D\u00e8s le 5/9 6h, travaux. ARRET NON DESSERVI. Arr\u00eat provisoire: rue du Brillant (face \u00e0 l'arr\u00eat vers Heiligenborre)\", \"nl\": \"Vanaf 5/9 6u, werken. HALTE NIET BEDIEND. Tijdelijke halte: Briljantstraat (tgnover halte > Heiligenborre)\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"17\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"4293\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Sep 5 6AM, works. STOP NOT SERVED. Bus 17 diverted between BRILLANT and BEAULIEU via Michiels\", \"fr\": \"D\u00e8s le 5/9 6h, travaux. ARRET NON DESSERVI. Bus 17 d\u00e9vi\u00e9 entre BRILLANT et BEAULIEU via Michiels\", \"nl\": \"Vanaf 5/9 6u, werken. HALTE NIET BEDIEND. Bus 17 omgeleid tussen BRILJANT en BEAULIEU via Michiels\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"17\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"4295\"}, {\"id\": \"4296\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. Until mid-2024, T19 replaced by T-bus between MIROIR and CIMETIERE DE JETTE.\", \"fr\": \"Travaux. Jusque mi-2024, tram 19 remplac\u00e9 par des T-bus entre MIROIR et CIMETIERE DE JETTE.\", \"nl\": \"Werken. Tot midden 2024, tram 19 vervangen door T-bus tussen SPIEGEL en KERKHOF VAN JETTE.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"19\"}]",
+        "priority": 5,
+        "points": "[{\"id\": \"1306F\"}, {\"id\": \"5105F\"}, {\"id\": \"1094F\"}, {\"id\": \"1111\"}, {\"id\": \"5104F\"}, {\"id\": \"5103\"}, {\"id\": \"5102F\"}, {\"id\": \"1064\"}, {\"id\": \"5108\"}, {\"id\": \"5109\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. Until mid-2024, T19 interrupted at MIROIR. Stop of T-bus 19: av. Jette 126 (next to this stop)\", \"fr\": \"Travaux. Jusque mi-2024, T19 interrompu \u00e0 MIROIR. Arr\u00eat du T-bus 19: av. de Jette, 126 (\u00e0 c\u00f4t\u00e9 de cet arr\u00eat).\", \"nl\": \"Werken. Tot midden 2024, T19 onderbroken aan SPIEGEL. Halte van T-bus 19: Jetselaan 126 (naast deze halte)\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"19\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"6864F\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. Until mid-2024, T19 replaced by T-bus btw MIROIR and CIMETIERE DE JETTE. T-bus at stop of bus 13 to UZ-VUB.\", \"fr\": \"Travaux. Jsq mi-2024, T19 remplac\u00e9 par T-bus entre MIROIR et CIM. JETTE. T-bus \u00e0 l'arr\u00eat du bus 13 vers UZ-VUB.\", \"nl\": \"Werken. Tot midden 2024, T19 vervangen door T-bus tss SPIEGEL en KERKH. JETTE.  T-bus aan halte van B13 naar UZ-VUB.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"19\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"0471\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. From May 8 at 9PM until May 12, tram 19 does not serve this stop. To go to DE WAND, take tram 7.\", \"fr\": \"Travaux. Du 8/5 \u00e0 21h au 12/5, tram 19 ne dessert pas cet arr\u00eat. Pour DE WAND, prenez le tram 7.\", \"nl\": \"Werken. Van 8/5 om 21u tot 12/5 bedient tram 19 deze halte niet. Om naar DE WAND te gaan, neem tram 7.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"19\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"2636F\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. Until mid-2024, stop not served. Take tram 19 at CIMETIERE DE JETTE / KERKHOF VAN JETTE.\", \"fr\": \"Travaux. Jusque mi-2024, arr\u00eat non desservi. Prenez le tram 19 \u00e0 CIMETIERE DE JETTE.\", \"nl\": \"Werken. Tot midden 2024, halte niet bediend. Neem tram 19 aan KERKHOF VAN JETTE.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"19\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"6869G\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. May 8, 9PM-May 12, tram 19 replaced by a T-bus to DE WAND.T-bus at PR. LEOPOLD (stop of bus 88 to UZ-VUB).\", \"fr\": \"Travaux. 8/5, 21h-12/5, tram 19 remplac\u00e9 par des T-bus jsq DE WAND. T-bus \u00e0 PRINCE LEOPOLD (arr\u00eat du bus 88 vers UZ-VUB).\", \"nl\": \"Werken. 8/5, 21u-12/5, tram 19 vervangen door T-bus tot DE WAND. T-bus aan PRINS LEOPOLD (halte van bus 88 naar UZ-VUB)\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"19\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"5082\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. Until mid-2024, stop not served. T-bus at VERBEYST (bd de Smet de Naeyer 211, stop of bus 14 to GARE DU NORD).\", \"fr\": \"Travaux, jusque mi-2024, arr\u00eat non desservi.T-bus \u00e0 VERBEYST (bd de Smet de Naeyer 211, arr\u00eat B14 vers GARE DU NORD).\", \"nl\": \"Werken. Tot midden 2024, halte niet bediend. T-bus aan VERBEYST (de Smet de Naeyerlaan 211, halte B14 naar NOORDST.)\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"19\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"6803F\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. May 8, 9PM-May 12, STOP NOT SERVED. T-bus to SIMONIS at CIM. / KERKH. JETTE, via bus 88 from PR. LEOPOLD.\", \"fr\": \"Travaux. 8/5, 21h-12/5, ARRET NON DESSERVI. T-bus vers SIMONIS \u00e0 CIM. JETTE, via bus 88 depuis PRINCE LEOPOLD.\", \"nl\": \"Werken. 8/5, 21u-12/5, HALTE NIET BEDIEND. T-bus naar SIMONIS aan KERKH. JETTE, via bus 88 vanaf PRINS LEOPOLD.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"19\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"4955F\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. As of Apr 15, STOP NOT SERVED. Stop of bus 21: rue Franklinstraat 2a.\", \"fr\": \"Travaux. D\u00e8s le 15/4, ARRET NON DESSERVI. Arr\u00eat du bus 21: rue Franklin, 2a.\", \"nl\": \"Werken. Vanaf 15/4, HALTE NIET BEDIEND. Halte van bus 21: Franklinstraat 2a.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"21\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"1270B\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. As of Apr 15, bus 21 diverted. Take bus 21 at the stop of bus 64 to BORDET STATION.\", \"fr\": \"Travaux. D\u00e8s le 15/4, bus 21 d\u00e9vi\u00e9. Prenez le bus 21 \u00e0 l'arr\u00eat du bus 64 vers BORDET STATION.\", \"nl\": \"Werken. Vanaf 15/4, bus 21 omgeleid. Neem bus 21 aan de halte van bus 64 naar BORDET STATION.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"21\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"1133\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. As of Apr 15, STOP NOT SERVED. Take bus 21 at MAELBEEK / MAALBEEK (stop of bus 64 to BORDET STATION).\", \"fr\": \"Travaux. D\u00e8s le 15/4, ARRET NON DESSERVI. Prenez le bus 21 \u00e0 MAELBEEK (halte van bus 64 naar BORDET STATION).\", \"nl\": \"Werken. Vanaf 15/4, HALTE NIET BEDIEND. Neem bus 21 aan MAALBEEK (arr\u00eat du bus 64 vers BORDET STATION).\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"21\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"1416\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Jan 7 at 9PM to Jun 28, works. Terminus not served. Stop of the T-bus: av. de Meysse, in front of number 125.\", \"fr\": \"Du 7/1 \u00e0 21h au 28/6, travaux. Terminus non desservi. Arr\u00eat du T-bus: avenue de Meysse, en face du num\u00e9ro 125.\", \"nl\": \"7/1, 21u-28/6, werken. Eindpunt niet bediend. Halte van de T-bus: Meiseselaan, tegenover nummer 125.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"3\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"5701\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Jan 7, 9PM-Jun 28, works. Stop not served. T-bus to ESPLANADE at the stop of bus 56 to BUDA.\", \"fr\": \"7/1, 21h-28/6, travaux. Arr\u00eat non desservi. T-bus vers ESPLANADE \u00e0 l'arr\u00eat du bus 56 vers BUDA.\", \"nl\": \"7/1, 21u-28/6, werken. Halte niet bediend. T-bus naar ESPLANADE aan de halte van bus 56 naar BUDA.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"3\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"5770F\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Jan 7, 9PM-Jun 28,works. Tram 3 interrupted btw ESPLANADE and DOCKS BRUXSEL. Stop of the T-bus: next to this stop\", \"fr\": \"7/1, 21h-28/6, travaux. Tram 3 interrompu entre ESPLANADE et DOCKS BRUXSEL. Arr\u00eat du T-bus: \u00e0 c\u00f4t\u00e9 de cet arr\u00eat.\", \"nl\": \"7/1, 21u-28/6, werken. Tram 3 onderbroken tss ESPLANADE en DOCKS BRUXSEL. Halte van de T-bus: naast deze halte.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"3\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"5705\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Jan 7, 9PM-Jun 28,works. Tram 3 interrupted btw ESPLANADE and DOCKS BRUXSEL. T-bus at stop of bus 83 to VAL MARIA\", \"fr\": \"7/1, 21h-28/6, travaux. Tram 3 interrompu entre ESPLANADE et DOCKS BRUXSEL. T-bus \u00e0 l'arr\u00eat du bus 83 vers VAL MARIA\", \"nl\": \"7/1, 21u-28/6, werken. Tram 3 onderbroken tss ESPLANADE en DOCKS BRUXSEL. T-bus halte van bus 83 naar MARI\u00cbNDAAL.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"3\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"5700G\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Jan 7, 9PM-Jun 28, works. Tram 3 replaced by T-bus between DOCKS BRUXSEL and ESPLANADE. Info: stib-mivb.brussels\", \"fr\": \"7/1, 21h-28/6, travaux. Tram 3 remplac\u00e9 par des T-bus entre DOCKS BRUXSEL et ESPLANADE. Info: stib.brussels.\", \"nl\": \"7/1, 21u-28/6, werken. Tram 3 vervangen door T-bus tussen DOCKS BRUXSEL en ESPLANADE. info: mivb.brussels.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"3\"}]",
+        "priority": 5,
+        "points": "[{\"id\": \"5219F\"}, {\"id\": \"6179\"}, {\"id\": \"2537F\"}, {\"id\": \"0722\"}, {\"id\": \"9986F\"}, {\"id\": \"6424F\"}, {\"id\": \"0606\"}, {\"id\": \"6177F\"}, {\"id\": \"0626\"}, {\"id\": \"0516\"}, {\"id\": \"6209\"}, {\"id\": \"0725\"}, {\"id\": \"0726\"}, {\"id\": \"0616\"}, {\"id\": \"0506\"}, {\"id\": \"2200F\"}, {\"id\": \"0723\"}, {\"id\": \"0526\"}, {\"id\": \"0724\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Jan 15, works. STOP NOT SERVED. Take bus 34 at the stop RO(O)DENBERG of bus 72 to ADEPS.\", \"fr\": \"D\u00e8s le 15/1, travaux. ARRET NON DESSERVI. Prenez le bus 34 \u00e0 l'arr\u00eat ROODENBERG du bus 72 vers ADEPS.\", \"nl\": \"Vanaf 15/1, werken. HALTE NIET BEDIEND. Neem bus 34 aan de halte RODENBERG van bus 72 naar ADEPS.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"34\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"1720B\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Jan 15, works. STOP NOT SERVED. Stop of bus 34: boulevard du Souverain / Vorstlaan 159.\", \"fr\": \"D\u00e8s le 15/1, travaux. ARRET NON DESSERVI. Arr\u00eat du bus 34: boulevard du Souverain 159.\", \"nl\": \"Vanaf 15/1, werken. HALTE NIET BEDIEND. Halte van bus 34: Vorstlaan 159.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"34\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"1731\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Jan 15, works. Bus 34 diverted between HANKAR and BERGOJE via DEMEY.\", \"fr\": \"D\u00e8s le 15/1, travaux. Bus 34 d\u00e9vi\u00e9 entre HANKAR et BERGOJE via DEMEY.\", \"nl\": \"Vanaf 15/1, werken. Bus 34 omgeleid tussen HANKAR en BERGOJE via DEMEY.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"34\"}]",
+        "priority": 5,
+        "points": "[{\"id\": \"6433\"}, {\"id\": \"1712\"}, {\"id\": \"1733\"}, {\"id\": \"2291B\"}, {\"id\": \"1233\"}, {\"id\": \"1729\"}, {\"id\": \"1728\"}, {\"id\": \"1706\"}, {\"id\": \"1716\"}, {\"id\": \"1715\"}, {\"id\": \"1714\"}, {\"id\": \"1824\"}, {\"id\": \"1713\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Apr 3 at 6AM, works. Bus 38 diverted between LONGCHAMP and HOUZEAU via rue Edith Cavellstraat.\", \"fr\": \"D\u00e8s le 3/4 \u00e0 6h, travaux. Bus 38 d\u00e9vi\u00e9 entre LONGCHAMP et HOUZEAU via rue Edith Cavell.\", \"nl\": \"Vanaf 3/4 om 6u, werken. Bus 38 omgeleid tussen LONGCHAMP en HOUZEAU via Edith Cavellstraat.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"38\"}]",
+        "priority": 5,
+        "points": "[{\"id\": \"1916\"}, {\"id\": \"1915\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Apr 3 at 6AM, works. STOP NOT SERVED. Bus 38 at GOSSART (avenue Winston Churchilllaan 187).\", \"fr\": \"D\u00e8s le 3/4 \u00e0 6h, travaux. ARRET NON DESSERVI. Bus 38 \u00e0 GOSSART (avenue Winston Churchill 187).\", \"nl\": \"Vanaf 3/4 om 6u, werken. HALTE NIET BEDIEND. Bus 38 aan GOSSART (Winston Churchilllaan 187).\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"38\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"1972\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. As of April 7th, bus 38 diverted. Take bus 38 at the next stop, ROYALE / KONING.\", \"fr\": \"Travaux. D\u00e8s le 7/4, bus 38 d\u00e9vi\u00e9. Prenez le bus 38 \u00e0 l'arr\u00eat suivant, ROYALE.\", \"nl\": \"Werken. Vanaf 7/4, bus 38 omgeleid. Neem bus 38 aan de volgende halte, KONING.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"38\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"3502\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. As of Apr 29, STOP NOT SERVED. Stop of bus 38: WASHINGTON (stop of bus 60 to UCCLE CALEVOET).\", \"fr\": \"Travaux. D\u00e8s le 29/4, ARRET NON DESSERVI. Arr\u00eat du bus 38: WASHINGTON (arr\u00eat du bus 60 vers UCCLE CALEVOET)\", \"nl\": \"Werken. Vanaf 29/4,HALTE NIET BEDIEND. Halte van bus 38: WASHINGTON (halte van bus 60 naar UKKEL KALEVOET)\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"38\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"1913\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Apr 3 at 6AM, works. STOP NOT SERVED. Take bus 38 and 41 at the previous stop, HOUZEAU.\", \"fr\": \"D\u00e8s le 3/4 \u00e0 6h, travaux. ARRET NON DESSERVI. Prenez les bus 38 et 41 \u00e0 l'arr\u00eat pr\u00e9c\u00e9dent, HOUZEAU.\", \"nl\": \"Vanaf 3/4 om 6u, werken. HALTE NIET BEDIEND. Neem bus 38 en 41 aan de vorige halte, HOUZEAU.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"38\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"1970\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Apr 3 at 6AM, works. STOP NOT SERVED. Bus 38 at GOSSART (avenue Winston Churchilllaan 202).\", \"fr\": \"D\u00e8s le 3/4 \u00e0 6h, travaux. ARRET NON DESSERVI. Bus 38 \u00e0 GOSSART (avenue Winston Churchill 202).\", \"nl\": \"Vanaf 3/4 om 6u, werken. HALTE NIET BEDIEND. Bus 38 aan GOSSART (Winston Churchilllaan 202).\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"38\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"1918\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Apr 3 at 6AM, works. STOP NOT SERVED. Temporary stop: chauss\u00e9e de Waterloosesteenweg 803, stop De Fr\u00e9 of TEC.\", \"fr\": \"D\u00e8s 3/4 \u00e0 6h, travaux. ARRET NON DESSERVI. Arr\u00eat provisoire: ch. de Waterloo 803, arr\u00eat De Fr\u00e9 des TEC.\", \"nl\": \"Vanaf 3/4 om 6u, werken. HALTE NIET BEDIEND. Tijdelijke halte: Waterloosesteenweg 803, halte De Fr\u00e9 van TEC.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"41\"}]",
+        "priority": 5,
+        "points": "[{\"id\": \"2763\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Apr 3 at 6AM, works. STOP NOT SERVED. Temporary stop: chauss\u00e9e de Waterloosesteenweg 965, stop of TEC.\", \"fr\": \"D\u00e8s le 3/4 \u00e0 6h, travaux. ARRET NON DESSERVI. Arr\u00eat provisoire: chauss\u00e9e de Waterloo 965, arr\u00eat TEC.\", \"nl\": \"Vanaf 3/4 om 6u, werken. HALTE NIET BEDIEND. Tijdelijke halte: Waterloosesteenweg 965, halte van TEC.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"41\"}]",
+        "priority": 5,
+        "points": "[{\"id\": \"2714\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Apr 3 at 6AM, works. Bus 41 diverted between VERT CHASSEUR / GROENE JAGER and HOUZEAU via rue Edith Cavell.\", \"fr\": \"D\u00e8s le 3/4 \u00e0 6h, travaux. Bus 41 d\u00e9vi\u00e9 entre VERT CHASSEUR et HOUZEAU via rue Edith Cavell.\", \"nl\": \"Vanaf 3/4 om 6u, werken. Bus 41 omgeleid tussen GROENE JAGER en HOUZEAU via Edith Cavellstraat.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"41\"}]",
+        "priority": 5,
+        "points": "[{\"id\": \"5451\"}, {\"id\": \"4452\"}, {\"id\": \"4454\"}, {\"id\": \"2107\"}, {\"id\": \"2018\"}, {\"id\": \"1754\"}, {\"id\": \"1753\"}, {\"id\": \"2016\"}, {\"id\": \"1752\"}, {\"id\": \"2762\"}, {\"id\": \"2079\"}, {\"id\": \"4455\"}, {\"id\": \"4456\"}, {\"id\": \"6468\"}, {\"id\": \"5458\"}, {\"id\": \"4358\"}, {\"id\": \"5459\"}, {\"id\": \"6439\"}, {\"id\": \"4449\"}, {\"id\": \"1725\"}, {\"id\": \"4407\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Mar 4, works. Bus 43 and N11 diverted. Weekdays before 8PM: B43 at BRAVES. Otherwise: bus at GRIOTTES.\", \"fr\": \"D\u00e8s le 4/3, travaux. Bus 43 et N11 d\u00e9vi\u00e9s. En semaine avant 20h: B43 \u00e0 BRAVES. Autres moments: bus \u00e0 GRIOTTES.\", \"nl\": \"Vanaf 4/3, werken. Bus 43 en N11 omgeleid. Weekdagen voor 20u: B43 aan DAPPEREN. Anders: bus aan NOORDKRIEKEN.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"43\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"1963\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Enjoy your trip on our lines !\", \"fr\": \"Bon voyage sur nos lignes !\", \"nl\": \"Geniet van uw reis op onze lijnen !\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"44\"}]",
+        "priority": 9,
+        "points": "[{\"id\": \"9552\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Until end of August 2024, works. Stop not served. Walk to WTC-GLIBERT.\", \"fr\": \"Jusque fin ao\u00fbt 2024, travaux. Arr\u00eat non desservi. Continuez \u00e0 pied pour WTC-GLIBERT.\", \"nl\": \"Tot einde augustus 2024, werken. halte niet bediend. Ga te voet verder om naar WTC-GLIBERT te gaan.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"46\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"1894\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Until end of August, works. Bus 46 interrupted. Take bus 46 at ANNEESSENS (via bus 33).\", \"fr\": \"Jusque fin ao\u00fbt, travaux. Bus 46 interrompu. Prenez le bus 46 \u00e0 ANNEESSENS (via bus 33).\", \"nl\": \"Tot einde augustus, werken. Bus 46 onderbroken. Neem bus 46 aan ANNEESSENS (via bus 33).\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"46\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"1895\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. Until end of August, B46 not operated btw WTC-GLIBERT and PTE ANDERLECHT. For the center, bus 88 at WTC.\", \"fr\": \"Travaux. Jsq fin ao\u00fbt, B46 ne circule pas entre WTC-GLIBERT et PORTE D'ANDERLECHT. Pour le centre, bus 88 \u00e0 WTC.\", \"nl\": \"Werken. Tot einde augustus rijdt bus 46 niet tss WTC-GLIBERT en ANDERLECHTSEPT. Voor het centrum,neem B88 aan WTC\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"46\"}]",
+        "priority": 5,
+        "points": "[{\"id\": \"9025\"}, {\"id\": \"1896\"}, {\"id\": \"2209\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Until Summer of 2024, works. Stop not served. Take bus 47 at the stop of bus 56 to BUDA.\", \"fr\": \"Jusqu'\u00e0 l'\u00e9t\u00e9 2024, travaux. Arr\u00eat non desservi. Prenez le bus 47 \u00e0 l'arr\u00eat du bus 56 vers BUDA.\", \"nl\": \"Tot zomer 2024, werken. Halte niet bediend. Neem bus 47 aan de halte van bus 56 naar BUDA.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"47\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"2358\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Oct 18 9.30AM, stop not served. Go to the previous stop : HELDENPLEIN.\", \"fr\": \"A partir du 18/10 9h30, arr\u00eat non desservi. Rejoignez l'arr\u00eat pr\u00e9c\u00e9dent : HELDENPLEIN.\", \"nl\": \"Vanaf 18/10 9u30, halte niet bediend. Ga naar de vorige halte HELDENPLEIN.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"47\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"9787\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Until Summer of 2024, works. As of Mar 4, stop of bus 47: Military Area, stop of bus 57 to GARE DU NORD.\", \"fr\": \"Jsq \u00e9t\u00e9 2024, travaux. D\u00e8s le 4/3, arr\u00eat du bus 47 : Domaine Militaire, arr\u00eat du bus 57 vers GARE DU NORD.\", \"nl\": \"Tot zomer 2024, werken. Vanaf 4/3, halte van bus 47: Militair Domein, halte van bus 57 naar NOORDSTATION..\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"47\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"3068\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Until Summer of 2024, works. Stop of bus 47: rue de Ransbeekstraat 201.\", \"fr\": \"Jusqu'\u00e0 l'\u00e9t\u00e9 2024, travaux. Arr\u00eat du bus 47: rue de Ransbeek 201.\", \"nl\": \"Tot zomer 2024, werken. Halte van bus 47: Ransbeekstraat 201.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"47\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"2360\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. STOP NOT SERVED. B47: at the stop CROIX DE GUERRE of B56 (av. des Croix de Guerre)\", \"fr\": \"Travaux. ARRET NON DESSERVI. B47 : \u00e0 l'arr\u00eat CROIX DE GUERRE du B56 (av. des Croix de Guerre)\", \"nl\": \"Werken. HALTE NIET BEDIEND. B47: aan de halte OORLOGSKRUISEN van B56 (Oorlogskruisenlaan)\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"47\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"2362B\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Until Summer of 2024, works. Stop not served. Take bus 47 or 57 at ANTOON VAN OSS (stop of bus 56 to BUDA).\", \"fr\": \"Jsq \u00e9t\u00e9 2024, travaux. Arr\u00eat non desservi. Prenez le bus 47 ou 57 \u00e0 ANTOON VAN OSS (arr\u00eat du bus 56 vers BUDA).\", \"nl\": \"Tot zomer 2024, werken. Halte niet bediend. Neem bus 47 of 57 aan ANTOON VAN OSS (halte van bus 56 naar BUDA).\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"47\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"1837\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. Until 2026, tram 82 and 97 interrupted. Stop of the T-bus and of bus 50: ch. de Neerstalsestwg 236.\", \"fr\": \"Travaux. Jsq 2026, tram 82 et 97 interrompus. Arr\u00eat du T-bus et du bus 50: chauss\u00e9e de Neerstalle 236\", \"nl\": \"Werken. Tot 2026, tram 82 en 97 onderbroken. Halte van de T-bus en van bus 50: Neerstalsesteenweg 236\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"50\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"3604\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Until 2026, works. Bus 50 and T-bus diverted between FOREST CENTRE / VORST CENTRUM and BEMPT.\", \"fr\": \"Jusqu'en 2026, travaux. Bus 50 et T-bus d\u00e9vi\u00e9s entre FOREST CENTRE et BEMPT.\", \"nl\": \"Tot 2026, werken. Bus 50 en T-bus omgeleid tussen VORST CENTRUM en BEMPT.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"50\"}]",
+        "priority": 5,
+        "points": "[{\"id\": \"5915\"}, {\"id\": \"2548\"}, {\"id\": \"2546\"}, {\"id\": \"2544\"}, {\"id\": \"2555\"}, {\"id\": \"1015\"}, {\"id\": \"2553\"}, {\"id\": \"3211\"}, {\"id\": \"2539\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Until 2026, works. Bus 50 diverted. Stop bus 50: bd 2e Arm\u00e9e Britannique / Britse Tweedelegerlaan.\", \"fr\": \"Jsq 2026, travaux. Bus 50 d\u00e9vi\u00e9. Arr\u00eat bus 50: bd 2e Arm\u00e9e Britannique, carrefour rue de la Station.\", \"nl\": \"Tot 2026, werken. Bus 50 omgeleid. Halte bus 50: Britse Tweedelegerlaan, kruispunt Stationstraat.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"50\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"5719\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From May 18, 5AM, works. STOP NOT SERVED. Stop of bus 52: avenue du Parc / Parklaan 26, in front of number 26.\", \"fr\": \"D\u00e8s le 18/5, 5h, travaux. ARRET NON DESSERVI. Arr\u00eat du bus 52: avenue du Parc, en face du num\u00e9ro 26.\", \"nl\": \"Vanaf 18/5, 5u, werken. HALTE NIET BEDIEND. Halte van bus 52: Parklaan, tegenover nummer 26.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"52\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"2334B\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. As of Apr 15 at 6AM, STOP NOT SERVED. Take bus 53 at BEYSEGHEM / BEIZEGEM.\", \"fr\": \"Travaux. D\u00e8s le 15/4 \u00e0 6h, ARRET NON DESSERVI. Prenez le bus 53 \u00e0 BEYSEGHEM.\", \"nl\": \"Werken. Vanaf 15/4 om 6u, HALTE NIET BEDIEND. Neem bus 53 aan BEIZEGEM.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"53\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"2819\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Until Summer of 2024, works. Stop not served. Stop of bus 53: place Peter Benoitplein 3\", \"fr\": \"Jusqu'\u00e0 l'\u00e9t\u00e9 2024, travaux. Arr\u00eat non desservi. Arr\u00eat du bus 53 : place Peter Benoit 3\", \"nl\": \"Tot zomer 2024, werken. Halte niet bediend. Halte van bus 53: Peter Benoitplein 3\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"53\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"2362B\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. As of Apr 15 at 6AM, STOP NOT SERVED. Take bus 53 at BEYSEGHEM / BEIZEGEM.\", \"fr\": \"Travaux. D\u00e8s le 15/4 \u00e0 6h, ARRET NON DESSERVI. Prenez le bus 53 \u00e0 BEYSEGHEM.\", \"nl\": \"Werken. Vanaf 15/4 om 6u, HALTE NIET BEDIEND. Neem bus 53 aan BEIZEGEM.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"53\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"2852\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. As of Apr 15 at 6AM, bus 53 diverted between BEYSEGHEM / BEIZEGEM and PETER BENOIT.\", \"fr\": \"Travaux. D\u00e8s le 15/4 \u00e0 6h, bus 53 d\u00e9vi\u00e9 entre BEYSEGHEM et PETER BENOIT.\", \"nl\": \"Werken. Vanaf 15/4 om 6u, bus 53 omgeleid tussen BEIZEGEM en PETER BENOIT.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"53\"}]",
+        "priority": 5,
+        "points": "[{\"id\": \"2813B\"}, {\"id\": \"2815B\"}, {\"id\": \"2566B\"}, {\"id\": \"2572\"}, {\"id\": \"2571\"}, {\"id\": \"2570\"}, {\"id\": \"3085\"}, {\"id\": \"2171\"}, {\"id\": \"2647\"}, {\"id\": \"2569\"}, {\"id\": \"2547\"}, {\"id\": \"2568\"}, {\"id\": \"2567\"}, {\"id\": \"4132B\"}, {\"id\": \"2565\"}, {\"id\": \"2564\"}, {\"id\": \"2809\"}, {\"id\": \"2573B\"}, {\"id\": \"2648\"}, {\"id\": \"2824\"}, {\"id\": \"3637\"}, {\"id\": \"1767\"}, {\"id\": \"2811\"}, {\"id\": \"1204\"}, {\"id\": \"2810\"}, {\"id\": \"2575\"}, {\"id\": \"2817\"}, {\"id\": \"2816\"}, {\"id\": \"2814\"}, {\"id\": \"3605\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Apr 2, 2024 to June 2025, works. STOP NOT SERVED. Stop of bus 54 and 74: avenue du Globelaan 8.\", \"fr\": \"Du 2/4/2024 \u00e0 juin 2025, travaux. ARRET NON DESSERVI. Arr\u00eat des bus 54 et 74: avenue du Globe 8.\", \"nl\": \"Van 2/4/2024 tot juni 2025, werken. HALTE NIET BEDIEND. Halte van bus 54 en 74: Globelaan 8.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"54\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"2616B\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Apr 2, 2024-June 2025, works. Bus 54 diverted btw FOREST CENTRE and FOREST NATIONAL. Info: stib-mivb.brussels.\", \"fr\": \"Du 2/4/2024 \u00e0 juin 2025, travaux. Bus 54 d\u00e9vi\u00e9 entre FOREST CENTRE et FOREST NATIONAL. Info: stib.brussels.\", \"nl\": \"2/4/2024-juni 2025, werken. Bus 54 omgeleid tussen VORST CENTRUM en VORST NATIONAAL. Info: mivb.brussels.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"54\"}]",
+        "priority": 5,
+        "points": "[{\"id\": \"5915\"}, {\"id\": \"1015\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Apr 2, 2024-June 2025, works. Bus 54 diverted btw FOREST CENTRE and FOREST NATIONAL. Info: stib-mivb.brussels.\", \"fr\": \"Du 2/4/2024 \u00e0 juin 2025, travaux. Bus 54 d\u00e9vi\u00e9 entre FOREST CENTRE et FOREST NATIONAL. Info: stib.brussels.\", \"nl\": \"2/4/2024-juni 2025, werken. Bus 54 omgeleid tussen VORST CENTRUM en VORST NATIONAAL. Info: mivb.brussels.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"54\"}]",
+        "priority": 5,
+        "points": "[{\"id\": \"3243\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Apr 2, 2024 to June 2025, works. STOP NOT SERVED. Take bus 54 at the next stop, FOREST NATIONAL.\", \"fr\": \"Du 2/4/2024 \u00e0 juin 2025, travaux. ARRET NON DESSERVI. Prenez le bus 54 \u00e0 l'arr\u00eat suivant, FOREST NATIONAL.\", \"nl\": \"Van 2/4/2024 tot juni 2025, werken. HALTE NIET BEDIEND. Neem bus 54 aan de volgende halte, VORST NATIONAAL.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"54\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"2952B\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Until Summer of 2024, works. As of March 18, buses 56 and 57 serve this stop normally.\", \"fr\": \"Jusqu'\u00e0 l'\u00e9t\u00e9 2024, travaux. D\u00e8s le 18/3, les bus 56 et 57 desservent \u00e0 nouveau cet arr\u00eat.\", \"nl\": \"Tot zomer 2024, werken. Vanaf 18/3 bedienen bus 56 en 57 opnieuw deze halte.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"56\"}]",
+        "priority": 5,
+        "points": "[{\"id\": \"1839\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. As of Apr 15, bus 56 diverted. Take bus 56 at the previous stop, at the St-Cyr house.\", \"fr\": \"Travaux. D\u00e8s le 15/4, bus 56 d\u00e9vi\u00e9. Prenez le bus 56 \u00e0 l'arr\u00eat pr\u00e9c\u00e9dent, devant la maison Saint-Cyr.\", \"nl\": \"Werken. Vanaf 15/4, bus 56 omgeleid. Neem bus 56 aan de vorige halte, voor het St-Cyr-huis.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"56\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"1273\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"As of Nov 14, stop moved to avenue Van Praetlaan, after Van Praet bridge.\", \"fr\": \"D\u00e8s le 14/11, arr\u00eat d\u00e9plac\u00e9 avenue Van Praet, apr\u00e8s le pont Van Praet.\", \"nl\": \"Vanaf 14/11, halte verplaatst naar de Van Praetlaan, na het Van Praetbrug.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"56\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"6370\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Until Summer of 2024, works. As of Mar 18, stop served normally by bus 56.\", \"fr\": \"Jusqu'\u00e0 l'\u00e9t\u00e9 2024, travaux. D\u00e8s le 18/3, arr\u00eat \u00e0 nouveau desservi par les bus 56.\", \"nl\": \"Tot zomer 2024, werken. Vanaf 18/3, halte opnieuw bediend door bus 56.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"56\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"2352\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Until Summer of 2024, works. Stop not served. Take bus 47 or 56 at ANTOON VAN OSS. For HOP MILITAIRE , walk.\", \"fr\": \"Jsq \u00e9t\u00e9 2024, travaux. Arr\u00eat non desservi. Bus 47 ou 56 \u00e0 ANTOON VAN OSS. Pour HOPITAL MILITAIRE, \u00e0 pied.\", \"nl\": \"Tot zomer 2024, werken. Halte niet bediend. Neem bus 47 of 56 aan ANTOON VAN OSS. Voor MILITAIR HOSPITAAL, ga te voet.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"56\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"1838\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Until Summer of 2024, works. Stop not served. Take bus 57 at the stop of bus 56 to SCHUMAN.\", \"fr\": \"Jusqu'\u00e0 l'\u00e9t\u00e9 2024, travaux. Arr\u00eat non desservi. Prenez le bus 57 \u00e0 l'arr\u00eat du bus 56 vers SCHUMAN.\", \"nl\": \"Tot zomer 2024, werken. Halte niet bediend. Neem bus 57 aan de halte van bus 56 naar SCHUMAN.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"57\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"2317\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Until Summer of 2024, works. Bus 57 diverted. Take bus 57 at ANTOON VAN OSS (stop of bus 56 to BUDA)\", \"fr\": \"Jusqu'\u00e0 l'\u00e9t\u00e9 2024, travaux. Bus 57 d\u00e9vi\u00e9. Prenez le bus 57 \u00e0 ANTOON VAN OSS (arr\u00eat du bus 56 vers BUDA).\", \"nl\": \"Tot zomer 2024, werken. Bus 57 omgeleid. Neem bus 57 aan ANTOON VAN OSS (halte van bus 56 naar BUDA).\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"57\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"1827\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Until Summer of 2024, works. Stop not served. Take bus 57 at the stop of bus 56 to BUDA.\", \"fr\": \"Jusqu'\u00e0 l'\u00e9t\u00e9 2024, travaux. Arr\u00eat non desservi. Prenez le bus 57 \u00e0 l'arr\u00eat du bus 56 vers BUDA.\", \"nl\": \"Tot zomer 2024, werken. Halte niet bediend. Neem bus 57 aan de halte van bus 56 naar BUDA.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"57\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"2358\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. As of Apr 15, STOP NOT SERVED. Take bus 60 at MAELBEEK / MAALBEEK.\", \"fr\": \"Travaux. D\u00e8s le 15/4, ARRET NON DESSERVI. Prenez le bus 60 \u00e0 MAELBEEK.\", \"nl\": \"Werken. Vanaf 15/4, HALTE NIET BEDIEND. Neem bus 60 aan MAALBEEK.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"60\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"1270B\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From May 2 at 7AM, works. Bus 60 diverted between JOURDAN and MALIBRAN.\", \"fr\": \"D\u00e8s le 2/5 \u00e0 7h, travaux. Bus 60 d\u00e9vi\u00e9 entre JOURDAN et MALIBRAN.\", \"nl\": \"Vanaf 2/5 om 7u, werken. Bus 60 omgeleid tussen JOURDAN en MALIBRAN.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"60\"}]",
+        "priority": 5,
+        "points": "[{\"id\": \"1425\"}, {\"id\": \"2920\"}, {\"id\": \"3921\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. As of Apr 15, bus 60 diverted between JOURDAN and AMBIORIX via MAELBEEK. Connection metro at MAELBEEK.\", \"fr\": \"Travaux. D\u00e8s le 15/4, bus 60 d\u00e9vi\u00e9 entre JOURDAN et AMBIORIX via MAELBEEK. Correspondance m\u00e9tro \u00e0 MAELBEEK.\", \"nl\": \"Werken. Vanaf 15/4, bus 60 omgeleid tussen JOURDAN en AMBIORIX via MAALBEEK. Aansluiting metro aan MAALBEEK.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"60\"}]",
+        "priority": 6,
+        "points": "[{\"id\": \"3158B\"}, {\"id\": \"6453\"}, {\"id\": \"6112\"}, {\"id\": \"2133\"}, {\"id\": \"2132\"}, {\"id\": \"2131\"}, {\"id\": \"1250\"}, {\"id\": \"4857B\"}, {\"id\": \"4804B\"}, {\"id\": \"6956B\"}, {\"id\": \"3160\"}, {\"id\": \"1976\"}, {\"id\": \"1986\"}, {\"id\": \"1884\"}, {\"id\": \"1653\"}, {\"id\": \"1883\"}, {\"id\": \"1980\"}, {\"id\": \"2134\"}, {\"id\": \"1739\"}, {\"id\": \"6406\"}, {\"id\": \"2847\"}, {\"id\": \"1977\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. As of Apr 15, STOP NOT SERVED. Take bus 60 at PARC LEOPOLD (ch. Etterbeek, in front of number 166).\", \"fr\": \"Travaux. D\u00e8s le 15/4, ARRET NON DESSERVI. Bus 60 \u00e0 PARC LEOPOLD (chauss\u00e9e d'Etterbeek, en face du num\u00e9ro 166).\", \"nl\": \"Werken. Vanaf 15/4, HALTE NIET BEDIEND. Neem bus 60 aan LEOPOLDSPARK (Etterbeeksesteenweg, tegenover nummer 166)\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"60\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"1271B\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Risk of subsidence. Stop of bus 65, 66 and N04 moved to chauss\u00e9e de Haecht/Haachtsesteenweg, next to number 162\", \"fr\": \"Risque d'effondrement. Arr\u00eat des bus 65, 66 et N04 d\u00e9plac\u00e9 chauss\u00e9e de Haecht, \u00e0 hauteur du num\u00e9ro 162.\", \"nl\": \"Risico op instorting. Halte van bus 65, 66 en N04 verplaatst naar de Haachtsesteenweg, ter hoogte van nummer 162.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"66\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"6418\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Jan 7 at 9PM to Jun 28, works. Tram 7 does not serve this stop. Take tram 3 to go to VANDERKINDERE.\", \"fr\": \"Du 7/1 \u00e0 21h au 28/6, travaux. Tram 7 ne dessert pas cet arr\u00eat. Prenez le tram 3 pour rejoindre VANDERKINDERE.\", \"nl\": \"Van 7/1 om 21u tot en met 28/6, werken. Tram 7 bedient deze halte niet. Neem tram 3 om naar VANDERKINDERE te gaan.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"7\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"5219F\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Jan 8-Jun 28, works. Tram 7 replaced by T-bus between DOCKS BRUXSEL and HEEMBEEK. Info: stib-mivb.brussels\", \"fr\": \"8/1-28/6, travaux. Tram 7 remplac\u00e9 par des T-bus entre DOCKS BRUXSEL et HEEMBEEK. Info: stib. brussels.\", \"nl\": \"8/1-28/6, werken. Tram 7 vervangen door T-bus tussen DOCKS BRUXSEL en HEEMBEEK. info: mivb. brussels.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"7\"}]",
+        "priority": 5,
+        "points": "[{\"id\": \"2636F\"}, {\"id\": \"9056F\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Jan 8 to Jun 28, works. Tram 7 interrupted to HEEMBEEK. T-bus at the stop of bus 56 to BUDA.\", \"fr\": \"Du 8/1 au 28/6, travaux. Tram 7 interrompu jusqu'\u00e0 HEEMBEEK. T-bus \u00e0 l'arr\u00eat du bus 56 vers BUDA.\", \"nl\": \"8/1-28/6, werken. Tram 7 onderbroken tot HEEMBEEK. T-bus aan de halte van bus 56 naar BUDA.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"7\"}]",
+        "priority": 5,
+        "points": "[{\"id\": \"5759F\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Mar 18, works. STOP NOT SERVED. stop of bus 71: avenue de l'Universit\u00e9 / Hogeschoollaan 4-10.\", \"fr\": \"D\u00e8s le 18/3, travaux. ARRET NON DESSERVI. Arr\u00eat du bus 71: avenue de l'Universit\u00e9 4-10.\", \"nl\": \"Vanaf 18/3, werken. HALTE NIET BEDIEND. Halte van bus 71: Hogeschoollaan 4-10.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"71\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"3514\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works.From May 10 at 10PM to May 12, bus 73 diverted between GARE DU MIDI and VETERINAIRES.\", \"fr\": \"Travaux. Du 10/5 \u00e0 22h au 12/5, bus 73 d\u00e9vi\u00e9 entre GARE DU MIDI et VETERINAIRES.\", \"nl\": \"Werken. Van 10/5 om 22u tot en met 12/5, bus 73 omgeleid tussen ZUIDSTATION en VEEARTSEN.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"73\"}]",
+        "priority": 5,
+        "points": "[{\"id\": \"1664\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Apr 2, 2024-June 2025, works. Bus 74 diverted between FOREST NATIONAL and FOREST CENTRE. Info: stib-mivb.brussels\", \"fr\": \"Du 2/4/2024 \u00e0 juin 2025, travaux. Bus 74 d\u00e9vi\u00e9 entre FOREST NATIONAL et FOREST CENTRE. Info: stib.brussels.\", \"nl\": \"2/4/2024-juni 2025, werken. Bus 74 omgeleid tussen VORST NATIONAAL en VORST CENTRUM. Info: mivb.brussels\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"74\"}]",
+        "priority": 5,
+        "points": "[{\"id\": \"2632\"}, {\"id\": \"2453\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Apr 2, 2024 to June 2025, works. STOP NOT SERVED. Stop of bus 54 and 74: avenue du Globelaan 8.\", \"fr\": \"Du 2/4/2024 \u00e0 juin 2025, travaux. ARRET NON DESSERVI. Arr\u00eat des bus 54 et 74: avenue du Globe 8.\", \"nl\": \"Van 2/4/2024 tot juni 2025, werken. HALTE NIET BEDIEND. Halte van bus 54 en 74: Globelaan 8.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"74\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"2616B\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Subsidence. Bus 74 limited to DECROLY. Walk from DECROLY to UCCLE-STALLE / UKKEL-STALLE.\", \"fr\": \"Effondrement. Bus 74 limit\u00e9 \u00e0 DECROLY. Continuez \u00e0 pied depuis DECROLY jusqu'\u00e0 UCCLE STALLE.\", \"nl\": \"Wegverzakking. Bus 74 beperkt tot DECROLY. Ga te voet van DECROLY tot UKKEL-STALLE.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"74\"}]",
+        "priority": 5,
+        "points": "[{\"id\": \"2631\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. Stop not served. As of May 6, stop of bus 49 and 74: chauss\u00e9e de Mons / Bergensesteenweg 814a.\", \"fr\": \"Travaux. Arr\u00eat non desservi.  D\u00e8s le 6/5, arr\u00eat des bus 49 et 74: chauss\u00e9e de Mons, 814a.\", \"nl\": \"Werken.  Halte niet bediend. Vanaf 6/5, halte van bus 49 en 74: Bergensesteenweg 814a.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"74\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"2225\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. As of Apr 15, STOP NOT SERVED. Stop of bus 79: rue Archim\u00e8de / Archimedesstraat 16.\", \"fr\": \"Travaux. D\u00e8s le 15/4, ARRET NON DESSERVI. Arr\u00eat du bus 79: rue Archim\u00e8de 16.\", \"nl\": \"Werken. Vanaf 15/4, HALTE NIET BEDIEND. Halte van bus 79: Archimedesstraat 16.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"79\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"1474B\"}, {\"id\": \"2083\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Jan 18, works. STOP NOT SERVED. Temporary stop: Avenue de Roodebeeklaan 45.\", \"fr\": \"D\u00e8s le 18/1, travaux. ARRET NON DESSERVI. Arr\u00eat provisoire: Avenue de Roodebeek 45.\", \"nl\": \"Vanaf 18/1, werken. HALTE NIET BEDIEND. Tijdelijke halte: Roodebeeklaan 45.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"79\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"1404\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. Until 2026, stop not served. T-bus 82 to DROGENBOS at the previous stop, CARREFOUR STALLE.\", \"fr\": \"Travaux. Jusqu'en 2026, arr\u00eat non desservi. T-bus 82 vers DROGENBOS \u00e0 l'arr\u00eat pr\u00e9c\u00e9dent, CARREFOUR STALLE.\", \"nl\": \"Werken. Tot 2026, halte niet bediend. T-bus 82 naar DROGENBOS aan de vorige halte, KRUISPUNT STALLE.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"82\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"5724\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Until 2026, works. Stop not served. Take tram 82 at FOREST CENTRE / VORST CENTRUM (stop to Drogenbos).\", \"fr\": \"Jusqu'en 2026, travaux. Arr\u00eat non desservi. Prenez le tram 82 \u00e0 FOREST CENTRE (arr\u00eat vers Drogenbos).\", \"nl\": \"Tot 2026, werken. Halte niet bediend. Neem tram 82 aan VORST CENTRUM (halte naar Drogenbos).\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"82\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"5152G\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. Until 2026, stop not served. Walk to DROGENBOS.\", \"fr\": \"Travaux. Jusqu'en 2026, arr\u00eat non desservi. Pour rejoindre DROGENBOS, continuez \u00e0 pied.\", \"nl\": \"Werken. Tot 2026, halte niet bediend. Ga te voet verder om naar DROGENBOS te gaan.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"82\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"5729\"}, {\"id\": \"5725\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Jan 22, 6AM-end of June, works. B86 diverted. Stop of B86:ch.De Gand/ Gentsestwg, in front of number 219 (Stop B13).\", \"fr\": \"Du 22/1 \u00e0 6h jusqu'\u00e0 fin juin, travaux. Bus 86 d\u00e9vi\u00e9. Arr\u00eat du B86: ch. de Gand, en face du num\u00e9ro 219 (arr\u00eat B13).\", \"nl\": \"Van 22/1 om 6u tot eind juni, werken. Bus 86 omgeleid. Halte van B86: Gentsesteenweg,tegenover nr. 219 (halte bus 13).\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"86\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"6754\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Mar 3 at 7AM, works. STOP NOT SERVED. Take bus 86 at the next stop DUCHESSE BRABANT / HERTOGIN BRABANT.\", \"fr\": \"D\u00e8s le 3/3 \u00e0 7h, travaux. ARRET NON DESSERVI. Prenez le bus 86 \u00e0 l'arr\u00eat suivant, DUCHESSE BRABANT.\", \"nl\": \"Vanaf 3/3 om 7u, werken. HALTE NIET BEDIEND. Neem bus 86 aan de volgende halte HERTOGIN BRABANT.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"86\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"6706\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Jan 22 at 6AM to end of June, works. Bus 86 diverted. Stop of bus 86: rue A. Vandenpeereboomstraat 44\", \"fr\": \"Du 22/1 \u00e0 6h jusqu'\u00e0 fin juin, travaux. Bus 86 d\u00e9vi\u00e9. Arr\u00eat du bus 86: rue  A. Vandenpeereboom 44.\", \"nl\": \"Van 22/1 om 6u tot eind juni, werken. Bus 86 omgeleid. Halte van bus 86: A. Vandenpeereboomstraat 44\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"86\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"4595\"}, {\"id\": \"1242\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Jan 22, 6AM-end of June, works. Bus 86 diverted. Bus 86 at stop MERCHTEM of bus 20 to GARE DU NORD / NOORDSTATION.\", \"fr\": \"Du 22/1 \u00e0 6h jusqu'\u00e0 fin juin, travaux. Bus 86 d\u00e9vi\u00e9. Bus 86 \u00e0 l'arr\u00eat MERCHTEM du bus 20 vers GARE DU NORD.\", \"nl\": \"Van 22/1 om 6u tot eind juni, werken. Bus 86 omgeleid. B86 aan halte MERCHTEM van bus 20 naar NOORDSTATION.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"86\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"6755\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"As of Nov 16 at 6AM, works. Stop moved to av. Port / Havenln, in front of number 100 (moved backward of +/- 120m)\", \"fr\": \"D\u00e8s le 16/11 \u00e0 6h, travaux. Arr\u00eat d\u00e9plac\u00e9 avenue du Port, en face du num\u00e9ro 100 (recul\u00e9 de +/- 120m).\", \"nl\": \"Vanaf 16/11 om 6u,werken Halte verplaatst naar de Havenlaan, tegenover nr 100 (achteruitgebracht van +/- 120m)\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"88\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"2305\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Dec 4, works. STOP NOT SERVED. Stop of bus 88: rue du Progr\u00e8s / Vooruitgangstraat 64.\", \"fr\": \"D\u00e8s le 4/12, travaux. ARRET NON DESSERVI. Arr\u00eat du bus 88: rue du Progr\u00e8s 64.\", \"nl\": \"Vanaf 4/12, werken. HALTE NIET BEDIEND. Halte van bus 88: Vooruitgangstraat 64.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"88\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"3400\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Dec 4, works. STOP NOT SERVED. Stop of bus 58 and 88 : rue du Progr\u00e8s, after crossing rue des Charbonniers.\", \"fr\": \"D\u00e8s le 4/12, travaux. ARRET NON DESSERVI. Arr\u00eat des bus 58 et 88 : rue du Progr\u00e8s, apr\u00e8s rue des Charbonniers.\", \"nl\": \"Vanaf 4/12, werken. HALTE NIET BEDIEND. Halte bus 58 en 88 : Vooruitgangstraat, na Koolbrandersstraat.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"88\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"1083\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Until end of August, works. Bus 89 diverted. For the city center, take metro 1 or 5 at STE-CATHERINE.\", \"fr\": \"Jusque fin ao\u00fbt, travaux. Bus 89 d\u00e9vi\u00e9. Pour le centre-ville, prenez le m\u00e9tro 1 ou 5 \u00e0 SAINTE-CATHERINE.\", \"nl\": \"Tot einde augustus, werken. Bus 89 omgeleid. Om naar het stadscentrum te gaan, neem M 1 5 aan SINT-KATELIJNE.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"89\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"3261\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Until end of August 2024, works. Stop not served. Take bus 29 or 71 at DE BROUCKERE to go to CENTRAL STATION.\", \"fr\": \"Jsq fin ao\u00fbt 2024, travaux. Arr\u00eat non desservi. Prenez le bus 29 ou 71 \u00e0 DE BROUCKERE pour GARE CENTRALE.\", \"nl\": \"Tot einde augustus 2024, werken. halte niet bediend. Neem bus 29 of 71 aan DE BROUCKERE om naar CENTR. ST. te gaan\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"89\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"1894\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Until end of August, works. Bus 89 diverted btw PTE DE NINOVE and BOURSE, and interrupted bt BOURSE and CENTRAL ST\", \"fr\": \"Jsq fin ao\u00fbt, travaux. Bus 89 d\u00e9vi\u00e9 entre PORTE DE NINOVE et BOURSE, et interrompu entre BOURSE et GARE CENTRALE.\", \"nl\": \"Tot einde augustus, werken. Bus 89 omgeleid tss NINOOFSEPOORT en BEURS, en onderbroken tss BEURS en CENTR ST\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"89\"}]",
+        "priority": 5,
+        "points": "[{\"id\": \"2754\"}, {\"id\": \"2776\"}, {\"id\": \"2748B\"}, {\"id\": \"4595\"}, {\"id\": \"1178\"}, {\"id\": \"2784\"}, {\"id\": \"2782\"}, {\"id\": \"6648\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. From Apr 26 at 9PM until May 12, stop not served. Stop of the T-bus: av. Arbre Ballon / Dikke Beuklaan 117\", \"fr\": \"Travaux. Du 26/4 \u00e0 21h au 12/5, arr\u00eat non desservi. Arr\u00eat du T-bus: avenue de l'Arbre Ballon 117.\", \"nl\": \"Werken. Van 26/4 om 21u tot en met 12/5, halte niet bediend. Halte van de T-bus: Dikke Beuklaan 117.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"9\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"4223F\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. From Apr 26 at 9PM until May 12, stop not served. T-bus to UZ BRUSSEL at the stop of bus 820 to UZ BRUSSEL.\", \"fr\": \"Travaux. Du 26/4 \u00e0 21h au 12/5, arr\u00eat non desservi. T-bus vers UZ BRUSSEL \u00e0 l'arr\u00eat du bus 820 vers UZ BRUSSEL.\", \"nl\": \"Werken. 26/4, 21u-12/5, halte niet bediend. T-bus naar UZ BRUSSEL aan de halte van bus 820 naar UZ BRUSSEL.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"9\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"1686F\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. From Apr 26 at 9PM until May 12, stop not served. Walk to ROI BAUDOUIN / KONING BOUDEWIJN.\", \"fr\": \"Travaux. Du 26/4 \u00e0 21h au 12/5, arr\u00eat non desservi. Pour rejoindre ROI BAUDOUIN, continuez \u00e0 pied.\", \"nl\": \"Werken. Van 26/4 om 21u tot en met 12/5, halte niet bediend. Ga te voet verder naar KONING BOUDEWIJN.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"9\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"1693F\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. From Apr 26 at 9PM until May 12, stop not served. T-bus to ROI BAUDOUIN at the stop of bus 820 to ZAVENTEM.\", \"fr\": \"Travaux. Du 26/4 \u00e0 21h au 12/5, arr\u00eat non desservi. T-bus vers ROI BAUDOUIN \u00e0 l'arr\u00eat du bus 820 vers ZAVENTEM.\", \"nl\": \"Werken. 26/4, 21u-12/5, halte niet bediend.T-bus naar KONING BOUDEWIJN aan de halte van bus 820 naar ZAVENTEM.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"9\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"1687F\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Mar 5 at 9AM, works. STOP NOT SERVED. Temporary stop: avenue Jean & Pierre Carsoellaan 4.\", \"fr\": \"D\u00e8s le 5/3 \u00e0 9h, travaux. ARRET NON DESSERVI. Arr\u00eat provisoire: avenue Jean et Pierre Carsoel 4.\", \"nl\": \"Vanaf 5/3 om 9u, werken. HALTE NIET BEDIEND. Tijdelijke halte: Jean en Pierre Carsoellaan 4.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"92\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"6931H\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Mar 18, works. STOP NOT SERVED. stop of bus 95: chauss\u00e9e de Boondael / Boondaalsesteenweg, before roundabout.\", \"fr\": \"D\u00e8s le 18/3, travaux. ARRET NON DESSERVI. Arr\u00eat du bus 95: chauss\u00e9e de Boondael, avant le rond-point.\", \"nl\": \"Vanaf 18/3, werken. HALTE NIET BEDIEND. Halte van bus 95: Boondaalsesteenweg, voor rondpunt.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"95\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"3514\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Mar 25 until Jun 30, works. STOP NOT SERVED. Stop of bus 95: bd. Gen. Jacqueslaan 235.\", \"fr\": \"Du 25/3 au 30/6, travaux. ARRET NON DESSERVI. Arr\u00eat du bus 95: boulevard G\u00e9n\u00e9ral Jacques, 235.\", \"nl\": \"Van 25/3 tot en met 30/6, werken. HALTE NIET BEDIEND. Halte van bus 95:  Generaal Jacqueslaan 235.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"95\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"4363\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Mar 18, works. STOP NOT SERVED. Temporary stop: avenue de la Couronne / Kroonlaan 439-443.\", \"fr\": \"D\u00e8s le 18/3, travaux. ARRET NON DESSERVI. Arr\u00eat provisoire: avenue de la Couronne 439-443.\", \"nl\": \"Vanaf 18/3, werken. HALTE NIET BEDIEND. Tijdelijke halte: Kroonlaan 439-443.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"95\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"3558\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Until 2026, works. As of Mar 11, tram 97 interrupted between WIELS and DIEWEG. Take tram 4 to go to GLOBE.\", \"fr\": \"Jsq 2026,travaux. D\u00e8s le 11/3, tram 97 interrompu entre WIELS et DIEWEG. Prenez le tram 4 pour rejoindre GLOBE.\", \"nl\": \"Tot 2026, werken. Vanaf 11/3, tram 97 onderbroken tussen WIELS en DIEWEG. Neem tram 4 om naar GLOBE te gaan.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"97\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"5723G\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Until 2026, works. Tram 97 interrupted. T-bus to CARREFOUR / KRUISPUNT STALLE at the stop of bus 54 to TRONE/TROON\", \"fr\": \"Jusqu'en 2026, travaux. Tram 97 interrompu. T-bus vers CARREFOUR STALLE \u00e0 l'arr\u00eat du bus 54 vers TRONE.\", \"nl\": \"Tot 2026, werken. Tram 97 onderbroken. T-bus naar KRUISPUNT STALLE aan de halte van bus 54 naar TROON.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"97\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"5121F\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Until 2026, works. As of Mar 11, T97 operated only btw LOUISE and WIELS. T82 at WIELS or T-bus at PIERRE DECOSTER\", \"fr\": \"Jsq 2026, travaux. D\u00e8s le 11/3, T97  uniquement entre LOUISE et WIELS. Tram 82 \u00e0 WIELS ou T-bus \u00e0 PIERRE DECOSTER.\", \"nl\": \"Tot 2026, werken. Vanaf 11/3 rijdt T97 enkel tss LOUIZA en WIELS.Neem T82 aan WIELS of de T-bus aan PIERRE DECOSTER.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"97\"}]",
+        "priority": 5,
+        "points": "[{\"id\": \"5116\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Until 2026, works. T97 interrupted to WIELS. Stop of the T-bus to ROCHEFORT: r. Soierie / Zijdeweverijstraat 9\", \"fr\": \"Jusqu'en 2026, travaux. Tram 97 interrompu jusqu'\u00e0 WIELS. Arr\u00eat du T-bus vers ROCHEFORT: rue de la Soierie 9.\", \"nl\": \"Tot 2026, werken. Tram 97 onderbroken tot WIELS. Halte van de T-bus naar ROCHEFORT: Zijdeweverijstraat 9.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"97\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"5156F\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Until 2026, works. As of Mar 11, tram 97 interrupted to DIEWEG. For GLOBE, tram 4 at CARR. STALLE via T-bus\", \"fr\": \"Jsq 2026,travaux. D\u00e8s le 11/3, tram 97 interrompu jsq DIEWEG. Pour GLOBE, tram 4 \u00e0 CARREFOUR STALLE via T-bus.\", \"nl\": \"Tot 2026, werken. Vanaf 11/3,T97 onderbroken tot DIEWEG. Voor GLOBE, neem T4 aan KRUISPUNT STALLE via T-bus.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"97\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"5163F\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Until 2026, works. As of Mar 11, tram 97 interrupted btw WIELS and DIEWEG. Take tram 92 to go to DIEWEG\", \"fr\": \"Jsq 2026,travaux. D\u00e8s le 11/3, tram 97 interrompu entre WIELS et DIEWEG. Prenez le tram 92 pour rejoindre DIEWEG\", \"nl\": \"Tot 2026, werken. Vanaf 11/3,tram 97 onderbroken tss WIELS en DIEWEG. Neem tram 92 om naar DIEWEG te gaan\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"97\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"2765\"}, {\"id\": \"2764G\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Until 2026, works. As of Mar 11, tram 97 operated only btw LOUISE and WIELS.T-bus to CARREFOUR STALLE at ROCHEFORT.\", \"fr\": \"Jsq 2026,travaux. D\u00e8s le 11/3, tram 97 circule uniquement entre LOUISE et WIELS.T-bus vers CARR STALLE \u00e0 ROCHEFORT.\", \"nl\": \"Tot 2026, werken. Vanaf 11/3 rijdt tram 97 enkel tussen LOUIZA en WIELS. T-bus naar KRUISPUNT STALLE aan ROCHEFORT.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"97\"}]",
+        "priority": 5,
+        "points": "[{\"id\": \"6078\"}, {\"id\": \"6428F\"}, {\"id\": \"5018F\"}, {\"id\": \"5016F\"}, {\"id\": \"2404F\"}, {\"id\": \"6314\"}, {\"id\": \"2336G\"}, {\"id\": \"6162\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Until 2026, works. As of Mar 11, tram 97 interrupted btw WIELS and DIEWEG. Take T92 at MARLOW to go to DIEWEG\", \"fr\": \"Jsq 2026,travaux. D\u00e8s le 11/3, tram 97 interrompu entre WIELS et DIEWEG. Prenez le T92 \u00e0 MARLOW pour aller \u00e0 DIEWEG\", \"nl\": \"Tot 2026, werken. Vanaf 11/3,tram 97 onderbroken tss WIELS en DIEWEG. Neem tram 92 aan MARLOW om naar DIEWEG te gaan\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"97\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"1985G\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Mar 18, works. STOP NOT SERVED. stop of bus N08: avenue de l'Universit\u00e9 / Hogeschoollaan 4-10.\", \"fr\": \"D\u00e8s le 18/3, travaux. ARRET NON DESSERVI. Arr\u00eat du bus N08: avenue de l'Universit\u00e9 4-10.\", \"nl\": \"Vanaf 18/3, werken. HALTE NIET BEDIEND. Halte van bus N08: Hogeschoollaan 4-10.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"N08\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"3558\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Jan 15, works. STOP NOT SERVED. Stop of Noctis N09: boulevard du Souverain / Vorstlaan 159.\", \"fr\": \"D\u00e8s le 15/1, travaux. ARRET NON DESSERVI. Arr\u00eat des Noctis N09: boulevard du Souverain 159.\", \"nl\": \"Vanaf 15/1, werken. HALTE NIET BEDIEND. Halte van Noctis N09: Vorstlaan 159.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"N09\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"1731\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Jan 15, works. STOP NOT SERVED. Stop of Noctis N09: chauss\u00e9e de Wavre / Waversesteenweg 1303.\", \"fr\": \"D\u00e8s le 15/1, travaux. ARRET NON DESSERVI. Arr\u00eat du Noctis N09: chauss\u00e9e de Wavre 1303.\", \"nl\": \"Vanaf 15/1, werken. HALTE NIET BEDIEND. Halte van Noctis N09: Waversesteenweg 1303.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"N09\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"1718B\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Feb 15, subsidence. N10 diverted. Take the bus at the stop FLAGEY.\", \"fr\": \"D\u00e8s le 15/2, effondrement. N10 d\u00e9vi\u00e9. Prenez le bus \u00e0 l'arr\u00eat FLAGEY.\", \"nl\": \"Vanaf 15/2, wegverzakking. N10 omgeleid. Neem de bus aan de halte FLAGEY.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"N10\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"1986\"}, {\"id\": \"1977\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Feb 15, subsidence. N10 diverted. Take the bus at the previous stop, LEPOUTRE.\", \"fr\": \"D\u00e8s le 15/2, effondrement. N10 d\u00e9vi\u00e9. Prenez le bus \u00e0 l'arr\u00eat pr\u00e9c\u00e9dent, LEPOUTRE.\", \"nl\": \"Vanaf 15/2, wegverzakking. N10 omgeleid. Neem de bus aan de vorige halte, LEPOUTRE.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"N10\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"1976\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Werken. 8/5, 21u-12/5, T-bus 19 diverted from GUILL. DE GREEF to DE WAND. HOP. BRUGMANN served by tram 51 93\", \"fr\": \"Travaux. 8/5, 21h-12/5, T-bus 19 d\u00e9vi\u00e9 depuis GUILL. DE GREEF vers DE WAND. HOP. BRUGMANN desservi par tram 51 93\", \"nl\": \"Werken. 8/5, 21u-12/5, T-bus 19 omgeleid vanaf GUILL. DE GREEF naar DE WAND. BRUGMANN-ZKH bediend door tram 51 93\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"T19\"}]",
+        "priority": 5,
+        "points": "[{\"id\": \"1767\"}, {\"id\": \"2515B\"}, {\"id\": \"6865\"}, {\"id\": \"6864\"}, {\"id\": \"1183\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. As of Apr 15, bus 12 diverted btw MEISER and LUXEMBOURG via MAELBEEK. Stop SCHUMAN moved rue Franklinstr.\", \"fr\": \"Travaux. D\u00e8s le 15/4, bus 12 d\u00e9vi\u00e9 entre MEISER et LUXEMBOURG via MAELBEEK. Arr\u00eat SCHUMAN d\u00e9plac\u00e9 rue Franklin.\", \"nl\": \"Werken. Vanaf 15/4, bus 12 omgeleid tss MEISER en LUXEMBURG via MAALBEEK. Halte SCHUMAN verplaatst Franklinstr.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"12\"}]",
+        "priority": 6,
+        "points": "[{\"id\": \"3017\"}, {\"id\": \"2695\"}, {\"id\": \"5048\"}, {\"id\": \"9600B\"}, {\"id\": \"2250\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Bus 17: From Sep 5 6AM, works. Diversion between BRILLANT/BRILJANT and BEAULIEU via Michiels\", \"fr\": \"Bus 17: D\u00e8s le 5/9 6h, travaux. D\u00e9viation entre BRILLANT et BEAULIEU via Michiels\", \"nl\": \"Bus 17: Vanaf 5/9 6u, werken. Omleiding tussen BRILJANT en BEAULIEU via Michiels\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"17\"}]",
+        "priority": 6,
+        "points": "[{\"id\": \"9059\"}, {\"id\": \"4351\"}, {\"id\": \"4341\"}, {\"id\": \"1455\"}, {\"id\": \"4287\"}, {\"id\": \"4355\"}, {\"id\": \"4357\"}, {\"id\": \"4358\"}, {\"id\": \"4348\"}, {\"id\": \"4292\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. As of Mar 27, STOP MOVED. Stop of bus 17: rue des Thuyas / Thujastraat 5.\", \"fr\": \"Travaux. D\u00e8s le 27/3, ARRET DEPLACE. Arr\u00eat du bus 17: rue des Thuyas, 5.\", \"nl\": \"Werken. Vanaf 27/3, HALTE VERPLAATST. Halte van bus 17: Thujastraat 5.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"17\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"4310\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. Until mid-2024, T19 interrupted at this stop. Stop of T-bus 19: av. Jette 232 (next to this stop)\", \"fr\": \"Travaux. Jusque mi-2024, T19 interrompu \u00e0 cet arr\u00eat. Arr\u00eat du T-bus 19: av. de Jette, 232 (\u00e0 c\u00f4t\u00e9 de cet arr\u00eat).\", \"nl\": \"Werken. Tot midden 2024, T19 onderbroken aan deze halte. Halte van T-bus 19: Jetselaan 232 (naast deze halte)\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"19\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"6865F\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. May 8, 9PM-May 12, tram 19 replaced by a T-bus to SIMONIS. T-bus at the stop of bus 53 to WESTLAND SHOPPING.\", \"fr\": \"Travaux. 8/5, 21h-12/5, tram 19 remplac\u00e9 par des T-bus jsq SIMONIS. T-bus \u00e0 l'arr\u00eat du bus 53 vers WESTLAND SHOPPING.\", \"nl\": \"Werken. 8/5, 21u-12/5, tram 19 vervangen door T-bus tot SIMONIS. T-bus aan de halte van bus 53 naar WESTLAND SHOPPING.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"19\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"5001F\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. Until mid-2024, stop not served. T-bus at LEOPOLD I (bd de Smet de Naeyer 59), or T19 at MIROIR.\", \"fr\": \"Travaux, jusque mi-2024, arr\u00eat non desservi. T-bus \u00e0 LEOPOLD I (bd de Smet de Naeyer 59), ou T19 \u00e0 MIROIR.\", \"nl\": \"Werken. Tot midden 2024, halte niet bediend. T-bus aan LEOPOLD I (de Smet de Naeyerlaan 59), of T19 aan SPIEGEL.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"19\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"6804F\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. May 8, 9PM-May 12, STOP NOT SERVED. T-bus to SIMONIS at GUILLAUME DE GREEF (stop of bus 88 to UZ-VUB).\", \"fr\": \"Travaux. 8/5, 21h-12/5, ARRET NON DESSERVI. T-bus vers SIMONIS \u00e0 GUILL. DE GREEF (arr\u00eat du bus 88 vers UZ-VUB).\", \"nl\": \"Werken. 8/5, 21u-12/5, HALTE NIET BEDIEND. T-bus naar SIMONIS aan GUILL. DE GREEF (halte van bus 88 naar UZ-VUB).\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"19\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"5003\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. Until mid-2024, stop not served. T-bus at VERBEYST (bd de Smet de Naeyer 234, stop of bus 14 to UZ-VUB).\", \"fr\": \"Travaux. Jusque mi-2024, arr\u00eat non desservi. T-bus \u00e0 VERBEYST (bd de Smet de Naeyer 234, arr\u00eat B14 vers UZ-VUB).\", \"nl\": \"Werken. Tot midden 2024, halte niet bediend. T-bus aan VERBEYST (de Smet de Naeyerlaan 234, halte B14 naar UZ-VUB).\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"19\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"6867F\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. Until mid-2024, tram 19 replaced by T-bus btw DE WAND and MIROIR / SPIEGEL. Take T-bus at CIM. DE JETTE.\", \"fr\": \"Travaux. Jusque mi-2024, tram 19 remplac\u00e9 par des T-bus entre DE WAND et MIROIR. Prenez le T-bus \u00e0 CIMETIERE DE JETTE.\", \"nl\": \"Werken. Tot midden 2024, tram 19 vervangen door T-bus tss DE WAND en SPIEGEL. Neem de T-bus aan KERKHOF VAN JETTE\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"19\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"6800F\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. May 8, 9PM-May 12, tram 19 interrupted. T-bus to SIMONIS at the stop of bus 88 to UZ-VUB.\", \"fr\": \"Travaux. 8/5, 21h-12/5, tram 19 interrompu. T-bus vers SIMONIS \u00e0 l'arr\u00eat du bus 88 vers UZ-VUB.\", \"nl\": \"Werken. 8/5, 21u-12/5, tram 19 onderbroken. T-bus naar SIMONIS aan de halte van bus 88 naar UZ-VUB.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"19\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"5093F\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. May 8, 9PM-May 12, tram 19 replaced by a T-bus to DE WAND.T-bus at PR. LEOPOLD (stop of bus 88 to UZ-VUB).\", \"fr\": \"Travaux. 8/5, 21h-12/5, tram 19 remplac\u00e9 par des T-bus jsq DE WAND. T-bus \u00e0 PRINCE LEOPOLD (arr\u00eat du bus 88 vers UZ-VUB).\", \"nl\": \"Werken. 8/5, 21u-12/5, tram 19 vervangen door T-bus tot DE WAND. T-bus aan PRINS LEOPOLD (halte van bus 88 naar UZ-VUB)\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"19\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"4958F\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Dec 4, works. STOP NOT SERVED. Take bus 20 at the previous stop, GARE DU NORD / NOORDSTATION.\", \"fr\": \"D\u00e8s le 4/12, travaux. ARRET NON DESSERVI. Prenez le bus 20 \u00e0 l'arr\u00eat pr\u00e9c\u00e9dent, GARE DU NORD.\", \"nl\": \"Vanaf 4/12, werken. HALTE NIET BEDIEND. Neem bus 20 aan de vorige halte, NOORDSTATION.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"20\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"3400\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. As of Apr 15, bus 21 diverted btw TREVES and MICHEL-ANGE via MAELBEEK. Stop SCHUMAN moved rue Archim\u00e8de.\", \"fr\": \"Travaux. D\u00e8s le 15/4,bus 21 d\u00e9vi\u00e9 entre TREVES et MICHEL-ANGE via MAELBEEK. Arr\u00eat SCHUMAN d\u00e9plac\u00e9 rue Archim\u00e8de.\", \"nl\": \"Werken. Vanaf 15/4, bus 21 omgeleid tss TRIER en MICHELANGELO via MAALBEEK. Halte SCHUMAN verplaatst Archimedesstr\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"21\"}]",
+        "priority": 6,
+        "points": "[{\"id\": \"1132\"}, {\"id\": \"1262B\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. As of Apr 15, bus 21 diverted btw MICHEL- ANGE and TOULOUSE via MAELBEEK. Stop SCHUMAN moved rue Franklin.\", \"fr\": \"Travaux. D\u00e8s le 15/4,bus 21 d\u00e9vi\u00e9 entre MICHEL- ANGE et TOULOUSE via MAELBEEK. Arr\u00eat SCHUMAN d\u00e9plac\u00e9 rue Franklin.\", \"nl\": \"Werken. Vanaf 15/4, bus 21 omgeleid tss MICHELANGELO en TOULOUSE via MAALBEEK. SCHUMAN verplaatst Franklinstr.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"21\"}]",
+        "priority": 6,
+        "points": "[{\"id\": \"6454\"}, {\"id\": \"3199\"}, {\"id\": \"3361\"}, {\"id\": \"3904\"}, {\"id\": \"3905\"}, {\"id\": \"3425\"}, {\"id\": \"3458\"}, {\"id\": \"3707\"}, {\"id\": \"3204\"}, {\"id\": \"3468\"}, {\"id\": \"3203\"}, {\"id\": \"3214\"}, {\"id\": \"3367\"}, {\"id\": \"1464\"}, {\"id\": \"3466\"}, {\"id\": \"2695\"}, {\"id\": \"1463\"}, {\"id\": \"3201\"}, {\"id\": \"4500\"}, {\"id\": \"3911\"}, {\"id\": \"4505\"}, {\"id\": \"2924\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. As of Apr 15, STOP NOT SERVED. Stop of bus 21: rue Archim\u00e8de / Archimedesstraat 16.\", \"fr\": \"Travaux. D\u00e8s le 15/4, ARRET NON DESSERVI. Arr\u00eat du bus 21: rue Archim\u00e8de 16.\", \"nl\": \"Werken. Vanaf 15/4, HALTE NIET BEDIEND. Halte van bus 21: Archimedesstraat 16.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"21\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"2083\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Jan 18, works. STOP NOT SERVED. Temporary stop: Avenue de Roodebeeklaan 45.\", \"fr\": \"D\u00e8s le 18/1, travaux. ARRET NON DESSERVI. Arr\u00eat provisoire: Avenue de Roodebeek 45.\", \"nl\": \"Vanaf 18/1, werken. HALTE NIET BEDIEND. Tijdelijke halte: Roodebeeklaan 45.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"28\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"1404\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. STOP NOT OPERATED. Temporary stop: rue de Pavie / Paviastraat 53.\", \"fr\": \"Travaux. ARRET NON DESSERVI. Arr\u00eat provisoire: rue de Pavie 53.\", \"nl\": \"Werken. HALTE NIET BEDIEND. Tijdelijke halte: Paviastraat 53.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"29\"}]",
+        "priority": 5,
+        "points": "[{\"id\": \"1568\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Bus 29: works. Stop CLOVIS not served. Temporary stop: rue de Pavie / Paviastraat 53.\", \"fr\": \"Bus 29 : travaux. Arr\u00eat CLOVIS non desservi. Arr\u00eat provisoire: rue de Pavie 53.\", \"nl\": \"Bus 29: werken. Halte CLOVIS niet bediend. Tijdelijke halte: Paviastraat 53.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"29\"}]",
+        "priority": 6,
+        "points": "[{\"id\": \"6454\"}, {\"id\": \"1561\"}, {\"id\": \"1550\"}, {\"id\": \"1385\"}, {\"id\": \"1560\"}, {\"id\": \"1558\"}, {\"id\": \"1557\"}, {\"id\": \"1567\"}, {\"id\": \"1578\"}, {\"id\": \"1566\"}, {\"id\": \"1554\"}, {\"id\": \"1565B\"}, {\"id\": \"1553\"}, {\"id\": \"3367\"}, {\"id\": \"1552\"}, {\"id\": \"3910\"}, {\"id\": \"1528\"}, {\"id\": \"1559\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. As of April 7th, stop served only by bus 66. Take bus 29, 63 or 65 at the stop of bus 71 to DELTA.\", \"fr\": \"Travaux. D\u00e8s le 7/4, arr\u00eat uniquement desservi par bus 66. Bus 29, 63 ou 65 \u00e0 l'arr\u00eat du bus 71 vers DELTA.\", \"nl\": \"Werken. Vanaf 7/4, halte enkel bediend door bus 66. Neem bus 29, 63 of 65 aan de halte van bus 71 naar DELTA.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"29\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"6445\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From FEB 2, works. Stop SAINT-JOSSE moved, go to the temporary stop: chauss\u00e9e de Louvain 73.\", \"fr\": \"D\u00e8s le 26/2, travaux. Arr\u00eat SAINT-JOSSE d\u00e9plac\u00e9, allez \u00e0 l'arr\u00eat provisoire : chauss\u00e9e de Louvain 73.\", \"nl\": \"Vanaf 26/2, werken. Halte SINT-JOOST verplaatst, ga naar de tijdelijke halte: Leuvensesteenweg 73.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"29\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"1570\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Jan 7, 9PM-Jun 28, works. Stop not served. Stop  T-bus to ESPLANADE : av. Croix du Feu, crossing r. Heembeek.\", \"fr\": \"7/1, 21h-28/6, travaux. Arr\u00eat non desservi.Arr\u00eat T-bus vers ESPLANADE:av. Croix du Feu, carrefour rue de Heembeek.\", \"nl\": \"7/1, 21u-28/6, werken. Halte niet bediend.Halte T-bus naar ESPLANADE : Vuurkruisenlaan, kruispunt Heembeeklaan.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"3\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"5771\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Jan 7, 9PM-Jun 28, works.Tram 3 diverted to the stop DOCKS BRUXSEL of tram 7 and replaced by T-bus to ESPLANADE.\", \"fr\": \"7/1, 21h-28/6, travaux. Tram 3 d\u00e9vi\u00e9 vers l'arr\u00eat DOCKS BRUXSEL du tram 7 et remplac\u00e9 par des T-bus jsq ESPLANADE.\", \"nl\": \"7/1, 21u-28/6, werken. Tram 3 omgeleid naar de halte DOCKS BRUXSEL van tram 7 en vervangen door T-bus tot ESPLANADE.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"3\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"2337F\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Jan 7, 9PM-Jun 28,works. Tram 3 and 7 replaced by T-bus to DOCKS BRUXSEL. T-bus at this stop.\", \"fr\": \"7/1, 21h-28/6, travaux. Tram 3 et 7 remplac\u00e9s par des T-bus jusqu'\u00e0 DOCKS BRUXSEL. T-bus \u00e0 cet arr\u00eat.\", \"nl\": \"7/1, 21u-28/6, werken. Tram 3 en 7 vervangen door T-bus tot DOCKS BRUXSEL. T-bus aan deze halte.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"3\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"5707\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Jan 7, 9PM-Jun 28,works. Tram 3 interrupted btw ESPLANADE and DOCKS BRUXSEL. Stop of the T-bus: av. Araucarialn.\", \"fr\": \"7/1, 21h-28/6, travaux. Tram 3 interrompu entre ESPLANADE et DOCKS BRUXSEL. Arr\u00eat du T-bus: avenue de l'Araucaria.\", \"nl\": \"7/1, 21u-28/6, werken. Tram 3 onderbroken tss ESPLANADE en DOCKS BRUXSEL. Halte van de T-bus: Araucarialaan.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"3\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"5704F\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Jan 7 at 9PM to Jun 28, works. Tram 3 replaced by T-bus. Stop T-bus: av. Croix du Feu / Vuurkruisenln, 211-213\", \"fr\": \"Du 7/1 \u00e0 21h au 28/6, travaux. Tram 3 remplac\u00e9 par des T-bus. Arr\u00eat du T-bus: avenue des Croix du Feu, 211-213\", \"nl\": \"Van 7/1 om 21u tot en met 28/6, werken. Tram 3 vervangen door T-bus. Halte T-bus: Vuurkruisenlaan, 211-213\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"3\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"5773\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From jan 15, works. STOP NOT SERVED. Take bus 34 at the stop CLESSE of bus 72 to ADEPS.\", \"fr\": \"D\u00e8s le 15/1, travaux. ARRET NON DESSERVI. Prenez le bus 34 \u00e0 l'arr\u00eat CLESSE du bus 72 vers ADEPS.\", \"nl\": \"Vanaf 15/1, werken. HALTE NIET BEDIEND. Neem bus 34 aan de halte CLESSE van bus 72 naar ADEPS.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"34\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"1719\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Apr 3 at 6AM, works. STOP NOT SERVED. Bus 38 at the stop LANGEVELD of bus 60 to UCCLE CALEVOET.\", \"fr\": \"D\u00e8s le 3/4 \u00e0 6h, travaux. ARRET NON DESSERVI. Bus 38 \u00e0 l'arr\u00eat LANGEVELD du bus 60 vers UCCLE CALEVOET.\", \"nl\": \"Vanaf 3/4 om 6u, werken. HALTE NIET BEDIEND. Bus 38 aan halte LANGEVELD van bus 60 naar UKKEL KALEVOET.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"38\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"1971\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Apr 3 at 6AM, works. STOP NOT SERVED. Bus 38 at the stop LANGEVELD of bus 60 to AMBIORIX.\", \"fr\": \"D\u00e8s le 3/4 \u00e0 6h, travaux. ARRET NON DESSERVI. Bus 38 \u00e0 l'arr\u00eat LANGEVELD du bus 60 vers AMBIORIX.\", \"nl\": \"Vanaf 3/4 om 6u, werken. HALTE NIET BEDIEND. Bus 38 aan halte LANGEVELD van bus 60 naar AMBIORIX.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"38\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"1919\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Apr 3 at 6AM, works. Bus 38 diverted between LONGCHAMP and HOUZEAU via rue Edith Cavellstraat.\", \"fr\": \"D\u00e8s le 3/4 \u00e0 6h, travaux. Bus 38 d\u00e9vi\u00e9 entre LONGCHAMP et HOUZEAU via rue Edith Cavell.\", \"nl\": \"Vanaf 3/4 om 6u, werken. Bus 38 omgeleid tussen LONGCHAMP en HOUZEAU via Edith Cavellstraat.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"38\"}]",
+        "priority": 5,
+        "points": "[{\"id\": \"1910\"}, {\"id\": \"3503\"}, {\"id\": \"1909\"}, {\"id\": \"1233\"}, {\"id\": \"6433\"}, {\"id\": \"3122\"}, {\"id\": \"1906\"}, {\"id\": \"1729\"}, {\"id\": \"1903\"}, {\"id\": \"1912\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"fr\": \"Bon voyage sur nos lignes !\", \"nl\": \"Een goede reis op onze lijnen gewenst!\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"39\"}]",
+        "priority": 9,
+        "points": "[{\"id\": \"5519\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Apr 3 at 6AM, works. STOP NOT SERVED. Take bus 38 and 41 at the next stop, HOUZEAU.\", \"fr\": \"D\u00e8s le 3/4 \u00e0 6h, travaux. ARRET NON DESSERVI. Prenez les bus 38 et 41 \u00e0 l'arr\u00eat suivant, HOUZEAU.\", \"nl\": \"Vanaf 3/4 om 6u, werken. HALTE NIET BEDIEND. Neem bus 38 en 41 aan de volgende halte, HOUZEAU.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"41\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"1920\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Apr 3 at 6AM, works. STOP NOT SERVED. Take bus 38 and 41 at the previous stop, HOUZEAU.\", \"fr\": \"D\u00e8s le 3/4 \u00e0 6h, travaux. ARRET NON DESSERVI. Prenez les bus 38 et 41 \u00e0 l'arr\u00eat pr\u00e9c\u00e9dent, HOUZEAU.\", \"nl\": \"Vanaf 3/4 om 6u, werken. HALTE NIET BEDIEND. Neem bus 38 en 41 aan de vorige halte, HOUZEAU.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"41\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"1970\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Mar 4, works. Bus 43 and N11 diverted. Take the bus at GRIOTTES / NOORDKRIEKEN.\", \"fr\": \"D\u00e8s le 4/3, travaux. Bus 43 et N11 d\u00e9vi\u00e9s. Prenez le bus \u00e0 GRIOTTES.\", \"nl\": \"Vanaf 4/3, werken. Bus 43 en N11 omgeleid. Neem de bus aan NOORDKRIEKEN.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"43\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"1957B\"}, {\"id\": \"1933B\"}, {\"id\": \"1939\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"As from 21 Sept, works. Stop moved +-60m forwards.\", \"fr\": \"D\u00e8s le 21/9, travaux. Arr\u00eat avanc\u00e9 de +-60m.\", \"nl\": \"Vanaf 21/9, werken. Halte +-60m vooruitgebracht.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"45\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"3462\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Jan 22 at 7AM, works. STOP NOT SERVED. Stop of bus 46: rue de Laeken / Lakensestraat 34.\", \"fr\": \"D\u00e8s le 22/1 \u00e0 7h, travaux. ARRET NON DESSERVI. Arr\u00eat du bus 46: rue de Laeken 34.\", \"nl\": \"Van 22/1 om 7u, werken. HALTE NIET BEDIEND. Halte van bus 46: Lakensestraat 34.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"46\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"3469\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. Until end of August, bus 46 not operated btw WTC-GLIBERT and CENTRAL STATION. Walk to the center.\", \"fr\": \"Travaux. Jsq fin ao\u00fbt, bus 46 ne circule pas entre WTC-GLIBERT et GARE CENTRALE.Pour le centre, continuez \u00e0 pied\", \"nl\": \"Werken. Tot einde augustus rijdt bus 46 niet tss WTC-GLIBERT en CENTRAAL STATION. Voor het centrum, ga te voet.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"46\"}]",
+        "priority": 5,
+        "points": "[{\"id\": \"2835\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Until Summer of 2024, works. As of Mar 3, STOP NOT SERVED. Stop of bus 47 57: ANTOON VAN OSS.\", \"fr\": \"Jusqu'\u00e0 l'\u00e9t\u00e9 2024, travaux. D\u00e8s le 4/3, ARRET NON DESSERVI. Arr\u00eat des bus 47 57 : ANTOON VAN OSS.\", \"nl\": \"Tot zomer 2024, werken. Vanaf 4/3, HALTE NIET BEDIEND. Halte van bus 47 57: ANTOON VAN OSS\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"47\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"1827\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Until Summer of 2024, works. B47 diverted btw CHEMIN VERT and ANT VAN OSS. As of Mar 3, diverted to H. MILITAIRE\", \"fr\": \"Jsq \u00e9t\u00e9 2024, travaux. B47 d\u00e9vi\u00e9 entre CHEMIN VERT et ANTOON VAN OSS. D\u00e8s le 4/3, d\u00e9vi\u00e9 jsq HOPITAL MILITAIRE.\", \"nl\": \"Tot zomer 2024, werken. Bus 47 omgeleid tss GROENWEG en ANTOON VAN OSS. Vanaf 4/3, omgeleid tot MILITAIR HOSPITAAL\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"47\"}]",
+        "priority": 5,
+        "points": "[{\"id\": \"2314\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Jan 9th at 6AM, works. STOP UNSERVED. Go to the stop HOP. MILITAIR(E) HOSP. from B53.\", \"fr\": \"D\u00e8s le 9/1 \u00e0 6h, travaux. ARRET NON DESSERVI. Aller \u00e0 l'arr\u00eat HOP. MILITAIRE du B53.\", \"nl\": \"Vanaf 9/1 om 6u, werken. HALTE NIET BEDIEND. Ga naar de halte MILITAIR HOSP. van B53.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"47\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"3067\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Oct 7, works. STOP NOT OPERATED. Temporary stop: David Terniersstraat 115\", \"fr\": \"D\u00e8s le 7/10, travaux. ARRET NON DESSERVI. Arr\u00eat provisoire : David Terniersstraat 115\", \"nl\": \"Vanaf 7/10, werken. HALTE NIET BEDIEND. Tijdelijke halte: David Terniersstraat 115\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"47\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"9627\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Feb 7, works. STOP NOT SERVED. Temporary stop: Vlierkensstraat 174.\", \"fr\": \"D\u00e8s le 7/2, travaux. ARRET NON DESSERVI. Arr\u00eat provisoire: Vlierkensstraat 174.\", \"nl\": \"Vanaf 7/2, werken. HALTE NIET BEDIEND. Tijdelijke halte: Vlierkensstraat 174.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"47\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"9605\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Until Summer of 2024, works. Stop not served. Stop of bus 47: VERGER / BOOMGAARD (av. Croix de Guerre/Oorlogskruisenln)\", \"fr\": \"Jusqu'\u00e0 l'\u00e9t\u00e9 2024, travaux. Arr\u00eat non desservi. Arr\u00eat du bus 47 : VERGER (avenue des Croix de Guerre).\", \"nl\": \"Tot zomer 2024, werken. Halte niet bediend. Halte van bus 47: BOOMGAARD (Oorlogskruisenlaan).\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"47\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"2312\"}, {\"id\": \"2363\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Until Summer of 2024, works. Stop not served. Take bus 47 or 56 at ANTOON VAN OSS. For HOP MILITAIRE , walk.\", \"fr\": \"Jsq \u00e9t\u00e9 2024, travaux. Arr\u00eat non desservi. Bus 47 ou 56 \u00e0 ANTOON VAN OSS. Pour HOPITAL MILITAIRE, \u00e0 pied.\", \"nl\": \"Tot zomer 2024, werken. Halte niet bediend. Neem bus 47 of 56 aan ANTOON VAN OSS. Voor MILITAIR HOSPITAAL, ga te voet.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"47\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"1838\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Until Summer of 2024, works. Stop not served. Stop of bus 47: CROIX DE GUERRE / OORLOGSKRUISEN.\", \"fr\": \"Jusqu'\u00e0 l'\u00e9t\u00e9 2024, travaux. Arr\u00eat non desservi. Arr\u00eat du bus 47 : CROIX DE GUERRE.\", \"nl\": \"Tot zomer 2024, werken. Halte niet bediend. Halte van bus 47: OORLOGSKRUISEN.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"47\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"1987\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Until Summer of 2024, works. Bus 47 diverted btw VTM and RAMIER. As of Mar 18, stop HOPITAL MILITAIRE in rue Bruyn.\", \"fr\": \"Jsq \u00e9t\u00e9 2024, travaux. Bus 47 d\u00e9vi\u00e9 entre VTM et RAMIER. D\u00e8s le 18/3, arr\u00eat HOPITAL MILITAIRE rue Bruyn.\", \"nl\": \"Tot zomer 2024, werken. Bus 47 omgeleid tussen VTM en BOSDUIF. Vanaf 18/3,halte MILITAIR HOSP in de Bruynstraat.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"47\"}]",
+        "priority": 5,
+        "points": "[{\"id\": \"9634\"}, {\"id\": \"9784B\"}, {\"id\": \"9786\"}, {\"id\": \"9632\"}, {\"id\": \"9606\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Apr 22 at 12PM, works. STOP NOT SERVED. Stop of bus 50: avenue Paul Gilsonlaan, just before this stop.\", \"fr\": \"D\u00e8s 22/4 \u00e0 12h, travaux. ARRET NON DESSERVI. Arr\u00eat du bus 50: avenue Paul Gilson, peu avant cet arr\u00eat.\", \"nl\": \"Vanaf 22/4 om 12u, werken. HALTE NIET BEDIEND. Halte van bus 50: Paul Gilsonlaan, net voor deze halte.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"50\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"2609\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Until 2026, works. Bus 50 diverted to FOREST CENTRE / VORST CENTRUM. Stop of bus 50: r. Abbesses / Abdissenstr.\", \"fr\": \"Jusqu'en 2026, travaux. Bus 50 d\u00e9vi\u00e9 jusqu'\u00e0 FOREST CENTRE. Arr\u00eat du bus 50: rue des Abbesses.\", \"nl\": \"Tot 2026, werken. Bus 50 omgeleid tot VORST CENTRUM. Halte van bus 50: Abdissenstraat.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"50\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"5152\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Until Summer of 2024, works. Stop not served. Stop of bus 53: KRUIPWEG (rue du Paturage / Weilandstraat).\", \"fr\": \"Jusqu'\u00e0 l'\u00e9t\u00e9 2024, travaux. Arr\u00eat non desservi. Arr\u00eat du bus 53 : KRUIPWEG (rue du Paturage)\", \"nl\": \"Tot zomer 2024, werken. Halte niet bediend. Halte van bus 53: KRUIPWEG (Weilandstraat)\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"53\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"2312\"}, {\"id\": \"2363\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Apr 2, 2024 to June 2025, works. STOP NOT SERVED. To go to BERVOETS, take bus 50 or T-bus(stop: r. Abbesses)\", \"fr\": \"Du 2/4/2024 \u00e0 juin 2025, travaux. ARRET NON DESSERVI. Pour rejoindre BERVOETS,bus 50 ou T-bus (arr\u00eat: r. des Abbesses)\", \"nl\": \"Van 2/4/2024 tot juni 2025, werken. HALTE NIET BEDIEND. Voor BERVOETS, neem bus 50 of de T-bus (halte: Abdissenstraat)\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"54\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"5161\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Apr 2, 2024 to June 2025, works. STOP NOT SERVED. To go to BERVOETS, take bus 50 or T-bus at FOREST CENTRE.\", \"fr\": \"Du 2/4/2024 \u00e0 juin 2025, travaux. ARRET NON DESSERVI. Pour rejoindre BERVOETS, bus 50 ou T-bus \u00e0 FOREST CENTRE.\", \"nl\": \"Van 2/4/2024 tot juni 2025, werken. HALTE NIET BEDIEND. Voor BERVOETS, neem bus 50 of de T-bus aan VORST CENTRUM.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"54\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"5152\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. From Apr 2 until June 2025, STOP NOT SERVED. Take bus 54 at the previous stop, FOREST CENTRE.\", \"fr\": \"Travaux. Du 2/4 \u00e0 juin 2025, ARRET NON DESSERVI. Prenez le bus 54 \u00e0 l'arr\u00eat pr\u00e9c\u00e9dent, FOREST CENTRE.\", \"nl\": \"Werken. Vanaf 2/4 tot juni 2025, HALTE NIET BEDIEND. Neem bus 54 aan de vorige halte, VORST CENTRUM.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"54\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"5719\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"As of May 6, works. Bus 54 diverted between FERNAND COCQ and BAILLI / BALJUW via FLAGEY.\", \"fr\": \"D\u00e8s le 6/5, travaux. Bus 54 d\u00e9vi\u00e9 entre FERNAND COCQ et BAILLI via FLAGEY.\", \"nl\": \"Vanaf 6/5, werken. Bus 54 omgeleid tussen FERNAND COCQ en BALJUW via FLAGEY.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"54\"}]",
+        "priority": 5,
+        "points": "[{\"id\": \"1734\"}, {\"id\": \"1780\"}, {\"id\": \"2928\"}, {\"id\": \"3518B\"}, {\"id\": \"3506\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. As of Apr 15, bus 56 diverted from AMBIORIX to MAELBEEK. Connection metro at MAELBEEK / MAALBEEK.\", \"fr\": \"Travaux. D\u00e8s le 15/4, bus 56 d\u00e9vi\u00e9 depuis AMBIORIX vers MAELBEEK. Correspondance m\u00e9tro \u00e0 MAELBEEK.\", \"nl\": \"Werken. Vanaf 15/4, bus 56 omgeleid vanaf AMBIORIX naar MAALBEEK. Aansluiting metro aan MAALBEEK.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"56\"}]",
+        "priority": 6,
+        "points": "[{\"id\": \"2092\"}, {\"id\": \"6461\"}, {\"id\": \"5740\"}, {\"id\": \"2100\"}, {\"id\": \"2067\"}, {\"id\": \"6191\"}, {\"id\": \"9291\"}, {\"id\": \"2097\"}, {\"id\": \"2096\"}, {\"id\": \"2094\"}, {\"id\": \"1007\"}, {\"id\": \"2920\"}, {\"id\": \"3414\"}, {\"id\": \"2105\"}, {\"id\": \"2102\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Until Summer 2024,works. B56 diverted btw P. BENOIT and VAN PRAET. As of Mar 18, bus 56 serves the stop MERCATOR.\", \"fr\": \"Jsq \u00e9t\u00e9 2024, travaux. Bus 56 d\u00e9vi\u00e9 entre P. BENOIT et VAN PRAET. D\u00e8s le 18/3, bus 56 dessert \u00e0 nouveau MERCATOR.\", \"nl\": \"Tot zomer 2024, werken. Bus 56 omgeleid tss P. BENOIT en VAN PRAET. Vanaf 18/3 bedient bus 56 opnieuw MERCATOR.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"56\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"2379\"}, {\"id\": \"1991\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. STOP NOT SERVED. Take bus 47 56 at the usual stop of trams 3 7 direction CHURCHILL / VANDERKINDERE.\", \"fr\": \"Travaux. ARRET NON DESSERVI. Prenez le bus 47 56 \u00e0 l'arr\u00eat habituel des trams 3 7 vers CHURCHILL/VANDERKINDERE.\", \"nl\": \"Werken. HALTE NIET BEDIEND. Neem bus 47 56 aan de gebruikelijke halte van tram 3 7 naar CHURCHILL/VANDERKINDERE.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"56\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"6368C\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Until Summer of 2024, works. Bus 56 diverted. Stop of bus 56: avenue des Croix de l'Yser / IJzerkruisenlaan 36.\", \"fr\": \"Jusqu'\u00e0 l'\u00e9t\u00e9 2024, travaux. Bus 56 d\u00e9vi\u00e9. Arr\u00eat du bus 56 : avenue des Croix de l'Yser 36.\", \"nl\": \"Tot zomer 2024, werken. Bus 56 omgeleid. Halte van bus 56: IJzerkruisenlaan 36.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"56\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"2093\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Until Summer of 2024, works. Bus 56 diverted. Take bus 56 at ANTOON VAN OSS.\", \"fr\": \"Jusqu'\u00e0 l'\u00e9t\u00e9 2024, travaux. Bus 56 d\u00e9vi\u00e9. Prenez le bus 56 \u00e0 ANTOON VAN OSS.\", \"nl\": \"Tot zomer 2024, werken. Bus 56 omgeleid. Neem bus 56 aan ANTOON VAN OSS.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"56\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"1827\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. STOP NOT SERVED. Temporary stop: avenue des Croix de Guerre 78\", \"fr\": \"Jusqu'\u00e0 l'\u00e9t\u00e9 2024, travaux. Arr\u00eat des bus 47 et 56 : avenue des Croix de Guerre 78.\", \"nl\": \"Tot zomer 2024, werken. Halte van bus 47 en 56: Oorlogskruisenlaan 78.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"56\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"2377\"}, {\"id\": \"2299\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. As of March 18, bus 56 operates normally between HOP. MILITAIRE / MILITAIR HOSP. and ANTOON VAN OSS.\", \"fr\": \"Travaux. D\u00e8s le 18/3, bus 56 circule \u00e0 nouveau normalement entre HOPITAL MILITAIRE et ANTOON VAN OSS.\", \"nl\": \"Werken. Vanaf 18/3 rijdt B56 opnieuw langs zijn gebruikelijke reisweg tss MILITAIR HOSPITAAL en ANTOON VAN OSS.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"56\"}]",
+        "priority": 5,
+        "points": "[{\"id\": \"2365\"}, {\"id\": \"2827\"}, {\"id\": \"1989\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. As of Apr 15, STOP NOT SERVED. Take bus 56 at AMBIORIX (stop of bus 64 to Bordet Station).\", \"fr\": \"Travaux. D\u00e8s le 15/4, ARRET NON DESSERVI. Prenez le bus 56 \u00e0 AMBIORIX (arr\u00eat du bus 64 vers Bordet Station).\", \"nl\": \"Werken. Vanaf 15/4, HALTE NIET BEDIEND. Neem bus 56 aan AMBIORIX (halte van bus 64 naar Bordet Station).\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"56\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"1474B\"}, {\"id\": \"2083\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. Bus 56 diverted between VERGER and VAN PRAET via avenue des Croix de Guerre\", \"fr\": \"Travaux. Bus 56 d\u00e9vi\u00e9 entre VERGER et VAN PRAET via avenue des Croix de Guerre\", \"nl\": \"Werken. Bus 56 omgeleid tussen BOOMGAARD en VAN PRAET via Oorlogskruisenlaan\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"56\"}]",
+        "priority": 5,
+        "points": "[{\"id\": \"2823B\"}, {\"id\": \"2766\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Until Summer of 2024, works. Stop not served. Take bus 47 or 57 at ANTOON VAN OSS (stop of bus 56 to BUDA).\", \"fr\": \"Jsq \u00e9t\u00e9 2024, travaux. Arr\u00eat non desservi. Prenez le bus 47 ou 57 \u00e0 ANTOON VAN OSS (arr\u00eat du bus 56 vers BUDA).\", \"nl\": \"Tot zomer 2024, werken. Halte niet bediend. Neem bus 47 of 57 aan ANTOON VAN OSS (halte van bus 56 naar BUDA).\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"56\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"1837\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Dec 4, works. STOP NOT SERVED. Take bus 14 and 57 under the CCN building, at the terminus of bus 61.\", \"fr\": \"D\u00e8s le 4/12, travaux. ARRET NON DESSERVI. Prenez le bus 14 et 57 sous le b\u00e2timent CCN, au terminus du bus 61.\", \"nl\": \"Vanaf 4/12, werken. HALTE NIET BEDIEND. Neem bus 14 en 57 onder het CCN-gebouw, aan eindhalte bus 61.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"57\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"1082\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Until Summer of 2024, works. Stop not served. Stop of bus 57: chauss\u00e9e de Vilvorde, in front of number 150.\", \"fr\": \"Jusqu'\u00e0 l'\u00e9t\u00e9 2024, travaux. Arr\u00eat non desservi. Arr\u00eat du bus 57: ch\u00e9e de Vilvorde, en face du num\u00e9ro 150.\", \"nl\": \"Tot zomer 2024, werken. Halte niet bediend. Halte van bus 57: Vilvoordsesteenweg, tegenover nummer 150.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"57\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"3063\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Until Summer of 2024, works. As of Mar 18, stop served normally by bus 57.\", \"fr\": \"Jusqu'\u00e0 l'\u00e9t\u00e9 2024, travaux. D\u00e8s le 18/3, arr\u00eat \u00e0 nouveau desservi par les bus 57.\", \"nl\": \"Tot zomer 2024, werken. Vanaf 18/3, halte opnieuw bediend door bus 57.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"57\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"2352\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Until Summer of 2024, works. Stop not served. Stop of bus 57: MARLY.\", \"fr\": \"Jsq \u00e9t\u00e9 2024, travaux. Arr\u00eat non desservi. Arr\u00eat du bus 57 : MARLY.\", \"nl\": \"Tot zomer 2024, werken. Halte niet bediend. Halte van bus 57: MARLY.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"57\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"2360\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Until Summer of 2024, works. Stop not served. Take bus 47 or 56 at ANTOON VAN OSS. For HOP MILITAIRE , walk.\", \"fr\": \"Jsq \u00e9t\u00e9 2024, travaux. Arr\u00eat non desservi. Bus 47 ou 56 \u00e0 ANTOON VAN OSS. Pour HOPITAL MILITAIRE, \u00e0 pied.\", \"nl\": \"Tot zomer 2024, werken. Halte niet bediend. Neem bus 47 of 56 aan ANTOON VAN OSS. Voor MILITAIR HOSPITAAL, ga te voet.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"57\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"1838\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Dec 4, works. STOP NOT SERVED. Take bus 58 at the stop WTC of bus 14 direction UZ-VUB.\", \"fr\": \"D\u00e8s le 4/12, travaux. ARRET NON DESSERVI. Prenez le bus 58 \u00e0 l'arr\u00eat WTC du bus 14 direction UZ-VUB.\", \"nl\": \"Vanaf 4/12, werken. HALTE NIET BEDIEND. Neem bus 58 aan de halte WTC van bus 14 richting UZ-VUB.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"58\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"3400\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Oct 22, works. The stop is moved : Rue du Pavillon, 86. (Moved 20m forwards).\", \"fr\": \"A partir du 22/10, travaux. Arr\u00eat d\u00e9plac\u00e9 : rue du Pavillon, 86. (Avanc\u00e9 de 20m).\", \"nl\": \"Vanaf 22/10, werken. De halte is verplaatst : Palvijoenstraat, 86. (20m vooruitgebracht).\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"58\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"5741\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Dec 4, works. STOP NOT SERVED. Stop of bus 58 and 88 : rue du Progr\u00e8s, after crossing rue des Charbonniers.\", \"fr\": \"D\u00e8s le 4/12, travaux. ARRET NON DESSERVI. Arr\u00eat des bus 58 et 88 : rue du Progr\u00e8s, apr\u00e8s rue des Charbonniers.\", \"nl\": \"Vanaf 4/12, werken. HALTE NIET BEDIEND. Halte bus 58 en 88 : Vooruitgangstraat, na Koolbrandersstraat.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"58\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"1083\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Mar 5 at 9AM, works. STOP NOT SERVED. Temporary stop: avenue Jean & Pierre Carsoellaan 4.\", \"fr\": \"D\u00e8s le 5/3 \u00e0 9h, travaux. ARRET NON DESSERVI. Arr\u00eat provisoire: avenue Jean et Pierre Carsoel 4.\", \"nl\": \"Vanaf 5/3 om 9u, werken. HALTE NIET BEDIEND. Tijdelijke halte: Jean en Pierre Carsoellaan 4.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"60\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"6931B\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From May 2 at 7AM, works. STOP NOT SERVED. Take bus 60 at the stop MUSEUM of bus 34 to PORTE DE NAMUR.\", \"fr\": \"D\u00e8s le 2/5 \u00e0 7h, travaux. ARRET NON DESSERVI. Prenez le bus 60 \u00e0 l'arr\u00eat MUSEUM du B34 vers PORTE DE NAMUR.\", \"nl\": \"Vanaf 2/5 om 7u, werken. HALTE NIET BEDIEND. Neem bus 60 aan de halte MUSEUM van bus 34 naar NAAMSEPOORT.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"60\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"1880\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. As of Apr 15, bus 60 diverted. Take bus 60 at the previous stop, at the St-Cyr house.\", \"fr\": \"Travaux. D\u00e8s le 15/4,bus 60 d\u00e9vi\u00e9. Prenez le bus 60 \u00e0 l'arr\u00eat pr\u00e9c\u00e9dent, devant la maison Saint-Cyr.\", \"nl\": \"Werken. Vanaf 15/4, bus 60 omgeleid. Neem bus 60 aan de vorige halte, voor het St-Cyr-huis.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"60\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"1273\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Mar 11, works. Bus 60 diverted between GROELSTVELD and DE WANSIJN via DIEWEG.\", \"fr\": \"D\u00e8s le 11/3, travaux. Bus 60 d\u00e9vi\u00e9 entre GROELSTVELD et DE WANSIJN via DIEWEG.\", \"nl\": \"Vanaf 11/3, werken. Bus 60 omgeleid tussen GROELSTVELD en DE WANSIJN via DIEWEG.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"60\"}]",
+        "priority": 5,
+        "points": "[{\"id\": \"2702\"}, {\"id\": \"2701\"}, {\"id\": \"1929\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. As of Apr 15, STOP NOT SERVED. Take bus 60 at the stop of bus 27 to LUXEMBOURG / LUXEMBURG.\", \"fr\": \"Travaux. D\u00e8s le 15/4, ARRET NON DESSERVI. Prenez le bus 60 \u00e0 l'arr\u00eat du bus 27 vers LUXEMBOURG.\", \"nl\": \"Werken. Vanaf 15/4, HALTE NIET BEDIEND. Neem bus 60 aan de halte van bus 27 naar LUXEMBURG.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"60\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"1416\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. As of April 7th, stop served only by bus 66. Take bus 29, 63 or 65 at the stop of bus 71 to DELTA.\", \"fr\": \"Travaux. D\u00e8s le 7/4, arr\u00eat uniquement desservi par bus 66. Bus 29, 63 ou 65 \u00e0 l'arr\u00eat du bus 71 vers DELTA.\", \"nl\": \"Werken. Vanaf 7/4, halte enkel bediend door bus 66. Neem bus 29, 63 of 65 aan de halte van bus 71 naar DELTA.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"65\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"6445\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Apr 14 at 7AM, works. STOP NOT SERVED. Take bus 66 at the drop off stop.\", \"fr\": \"D\u00e8s le 14/4 \u00e0 7h, travaux. ARRET NON DESSERVI. Prenez le bus 66 \u00e0 l'arr\u00eat de d\u00e9barquement.\", \"nl\": \"Vanaf 14/4 om 7u, werken. HALTE NIET BEDIEND. Neem bus 66 aan de afstaphalte.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"66\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"3284\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Jan 8-Jun 28, works. Stop not served. Stop of tram 7: av. Croix du Feu in front of av. Pagodes.\", \"fr\": \"8/1-28/6, travaux. Arr\u00eat non desservi. Arr\u00eat du tram 7: avenue des Croix du Feu, \u00e0 hauteur de l'avenue des Pagodes.\", \"nl\": \"8/1-28/6, werken. Halte niet bediend. Halte van tram 7: Vuurkruisenlaan, ter hoogte van de Pagodenlaan.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"7\"}]",
+        "priority": 5,
+        "points": "[{\"id\": \"5771\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Jan 7, 9PM-Jun 28,works. Stop not served. Stop T-bus to DOCKS BRUXSEL: av. Croix du Feu, crossing av. Pagodes.\", \"fr\": \"7/1, 21h-28/6, travaux. Arr\u00eat non desservi.Arr\u00eat du T-bus vers DOCKS BRUXSEL: av. Croix du Feu, carr. av. Pagodes.\", \"nl\": \"7/1, 21u-28/6, werken. Halte niet bediend.Halte van de T-bus naar DOCKS BRUXSEL: Vuurkruisenln, kruispt Pagodenln.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"7\"}]",
+        "priority": 5,
+        "points": "[{\"id\": \"5706\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Jan 8-Jun 28, works. Tram 7 interrupted btw HEEMBEEK and DOCKS BXL. Stop of the T-bus to DOCKS BXL: av. Araucaria\", \"fr\": \"8/1-28/6, travaux. T7 interrompu de HEEMBEEK \u00e0 DOCKS BRUXSEL. Arr\u00eat du T-bus vers DOCKS BRUXSEL: av. Araucaria\", \"nl\": \"8/1-28/6, werken. T7 onderbroken tss HEEMBEEK en DOCKS BRUXSEL. Halte T-bus naar DOCKS BRUXSEL: Araucarialaan.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"7\"}]",
+        "priority": 5,
+        "points": "[{\"id\": \"5704F\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Jan 8-Jun 28, works. Tram 7 replaced by T-bus between DOCKS BRUXSEL and HEEMBEEK. Info: stib-mivb.brussels\", \"fr\": \"8/1-28/6, travaux. Tram 7 remplac\u00e9 par des T-bus entre DOCKS BRUXSEL et HEEMBEEK. Info: stib. brussels.\", \"nl\": \"8/1-28/6, werken. Tram 7 vervangen door T-bus tussen DOCKS BRUXSEL en HEEMBEEK. info: mivb. brussels.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"7\"}]",
+        "priority": 6,
+        "points": "[{\"id\": \"5261\"}, {\"id\": \"5267\"}, {\"id\": \"5264F\"}, {\"id\": \"5256F\"}, {\"id\": \"5355F\"}, {\"id\": \"1048F\"}, {\"id\": \"5222F\"}, {\"id\": \"3480\"}, {\"id\": \"6456F\"}, {\"id\": \"5258\"}, {\"id\": \"0806\"}, {\"id\": \"5357\"}, {\"id\": \"0906\"}, {\"id\": \"5359\"}, {\"id\": \"0826\"}, {\"id\": \"5253\"}, {\"id\": \"5352\"}, {\"id\": \"5254\"}, {\"id\": \"5356\"}, {\"id\": \"5265F\"}, {\"id\": \"5221F\"}, {\"id\": \"5354H\"}, {\"id\": \"5255F\"}, {\"id\": \"5350G\"}, {\"id\": \"9963F\"}, {\"id\": \"0816\"}, {\"id\": \"2243F\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Jan 8-Jun 28, works. Stop not served. T-bus to HEEMBEEK and DE WAND at the stop of bus 56 to BUDA.\", \"fr\": \"8/1-28/6, travaux. Arr\u00eat non desservi. T-bus vers HEEMBEEK et DE WAND \u00e0 l'arr\u00eat du bus 56 vers BUDA.\", \"nl\": \"8/1-28/6, werken. Halte niet bediend. T-bus naar HEEMBEEK en DE WAND aan de halte van bus 56 naar BUDA.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"7\"}]",
+        "priority": 5,
+        "points": "[{\"id\": \"5770F\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Jan 8-Jun 28, works. Tram 7 interrupted btw HEEMBEEK and DOCKS BXL. Stop T-bus to DOCKS BXL: next to this stop.\", \"fr\": \"8/1-28/6, travaux. T7 interrompu de HEEMBEEK \u00e0 DOCKS BXL. Arr\u00eat du T-bus vers DOCKS BXL: \u00e0 c\u00f4t\u00e9 de cet arr\u00eat.\", \"nl\": \"8/1-28/6, werken. T7 onderbroken tss HEEMBEEK en DOCKS BXL. Halte T-bus naar DOCKS BXL: naast deze halte.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"7\"}]",
+        "priority": 5,
+        "points": "[{\"id\": \"5705\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Jan 8 to Jun 28, works. After CHURCHILL, tram 7 continues on line 3 direction ESPLANADE.\", \"fr\": \"Du 8/1 au 28/6, travaux. Apr\u00e8s CHURCHILL, tram 7 continue sur la ligne 3 direction ESPLANADE.\", \"nl\": \"Van 8/1 tot en met 28/6, werken. Na CHURCHILL rijdt tram 7 verder op lijn 3 richting ESPLANADE.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"7\"}]",
+        "priority": 6,
+        "points": "[{\"id\": \"5307H\"}, {\"id\": \"5317G\"}, {\"id\": \"5305G\"}, {\"id\": \"5220F\"}, {\"id\": \"5200F\"}, {\"id\": \"5266F\"}, {\"id\": \"3481\"}, {\"id\": \"0821\"}, {\"id\": \"0901\"}, {\"id\": \"2246F\"}, {\"id\": \"0801\"}, {\"id\": \"5306G\"}, {\"id\": \"5308F\"}, {\"id\": \"5210\"}, {\"id\": \"5211\"}, {\"id\": \"5758F\"}, {\"id\": \"5311\"}, {\"id\": \"5212\"}, {\"id\": \"5213\"}, {\"id\": \"5312\"}, {\"id\": \"1049F\"}, {\"id\": \"6457F\"}, {\"id\": \"5303\"}, {\"id\": \"5205\"}, {\"id\": \"5208\"}, {\"id\": \"9969F\"}, {\"id\": \"0811\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Mar 18, works. STOP NOT SERVED. Temporary stop: avenue de la Couronne / Kroonlaan 439-443.\", \"fr\": \"D\u00e8s le 18/3, travaux. ARRET NON DESSERVI. Arr\u00eat provisoire: avenue de la Couronne 439-443.\", \"nl\": \"Vanaf 18/3, werken. HALTE NIET BEDIEND. Tijdelijke halte: Kroonlaan 439-443.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"72\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"3558\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Apr 2, 2024 to June 2025, works. STOP NOT SERVED. Stop of bus 74: FOREST NATIONAL (av. du Globelaan 43)\", \"fr\": \"Du 2/4/2024 \u00e0 juin 2025, travaux. ARRET NON DESSERVI. Arr\u00eat du bus 74: FOREST NATIONAL (avenue du Globe 43).\", \"nl\": \"Van 2/4/2024 tot juni 2025, werken. HALTE NIET BEDIEND. Halte van bus 74: VORST NATIONAAL (Globelaan 43)\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"74\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"2952B\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. From Apr 2 until June 2025, STOP NOT SERVED. Take bus 74 at the previous stop, FOREST CENTRE.\", \"fr\": \"Travaux. Du 2/4 \u00e0 juin 2025, ARRET NON DESSERVI. Prenez le bus 74 \u00e0 l'arr\u00eat pr\u00e9c\u00e9dent, FOREST CENTRE.\", \"nl\": \"Werken. Vanaf 2/4 tot juni 2025, HALTE NIET BEDIEND. Neem bus 74 aan de vorige halte, VORST CENTRUM.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"74\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"5719\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Apr 2, 2024 to June 2025, works. STOP NOT SERVED. Stop of bus 74: FOREST NATIONAL (av. du Globelaan 8).\", \"fr\": \"Du 2/4/2024 \u00e0 juin 2025, travaux. ARRET NON DESSERVI. Arr\u00eat des bus 74: FOREST NATIONAL. (avenue du Globe 8).\", \"nl\": \"Van 2/4/2024 tot juni 2025, werken. HALTE NIET BEDIEND. Halte van bus 74: VORST NATIONAAL (Globelaan 8)\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"74\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"2939B\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Apr 2, 2024 to June 2025, works. STOP NOT SERVED. Stop of bus 74: av. du Globelaan 43.\", \"fr\": \"Du 2/4/2024 \u00e0 juin 2025, travaux. ARRET NON DESSERVI. Arr\u00eat du bus 74: avenue du Globe 43.\", \"nl\": \"Van 2/4/2024 tot juni 2025, werken. HALTE NIET BEDIEND. Halte van bus 74: Globelaan 43.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"74\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"2732\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Subsidence. Bus 74 limited to DECROLY. Take bus 74 at DECROLY.\", \"fr\": \"Effondrement. Bus 74 limit\u00e9 \u00e0 DECROLY. Prenez le bus 74 \u00e0 DECROLY.\", \"nl\": \"Wegverzakking. Bus 74 beperkt tot DECROLY. Neem bus 74 aan DECROLY.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"74\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"2417\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. As of Apr 15, bus 79 diverted from MICHEL-ANGE to MAELBEEK. Stop SCHUMAN moved rue Franklin.\", \"fr\": \"Travaux. D\u00e8s le 15/4, bus 79 d\u00e9vi\u00e9 depuis MICHEL-ANGE vers MAELBEEK. Arr\u00eat SCHUMAN d\u00e9plac\u00e9 rue Franklin.\", \"nl\": \"Werken. Vanaf 15/4, bus 79 omgeleid vanaf MICHELANGELO naar MAALBEEK. Halte SCHUMAN verplaatst Franklinstr.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"79\"}]",
+        "priority": 6,
+        "points": "[{\"id\": \"6450\"}, {\"id\": \"6055\"}, {\"id\": \"9853\"}, {\"id\": \"1462\"}, {\"id\": \"2043\"}, {\"id\": \"2042\"}, {\"id\": \"2041\"}, {\"id\": \"3902\"}, {\"id\": \"3903\"}, {\"id\": \"3904\"}, {\"id\": \"2028\"}, {\"id\": \"3905\"}, {\"id\": \"1533\"}, {\"id\": \"1531\"}, {\"id\": \"1464\"}, {\"id\": \"1463\"}, {\"id\": \"1320\"}, {\"id\": \"3920\"}, {\"id\": \"3911\"}, {\"id\": \"1339\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. Until 2026, tram 82 and 97 interrupted. Stop of the T-bus and of bus 50: ch. de Neerstalsestwg 236.\", \"fr\": \"Travaux. Jsq 2026, tram 82 et 97 interrompus. Arr\u00eat du T-bus et du bus 50: chauss\u00e9e de Neerstalle 236\", \"nl\": \"Werken. Tot 2026, tram 82 en 97 onderbroken. Halte van de T-bus en van bus 50: Neerstalsesteenweg 236\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"82\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"5164F\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Until 2026,works.Tram 82 replaced by T-bus btw FOREST CENTRE / VORST CENTRUM and DROGENBOS. More info: stib-mivb.be.\", \"fr\": \"Jusqu'en 2026, travaux. Tram 82 remplac\u00e9 par des T-bus entre FOREST CENTRE et DROGENBOS. Info: stib.brussels.\", \"nl\": \"Tot 2026, werken. Tram 82 wordt vervangen door T-bus tussen VORST CENTRUM en DROGENBOS. Info: mivb.brussels.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"82\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"5163F\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Until 2026, works. T-bus 82/97 diverted. Stop T-bus 82/97: bd 2e Arm\u00e9e Britannique / Britse Tweedelegerlaan.\", \"fr\": \"Jsq 2026, travaux. T-bus 82/97 d\u00e9vi\u00e9. Arr\u00eat T-bus 82/97: bd 2e Arm\u00e9e Britannique, carrefour rue de la Station.\", \"nl\": \"Tot 2026, werken. T-bus 82/97 omgeleid. Halte T-bus 82/97: Britse Tweedelegerlaan, kruispunt Stationstraat.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"82\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"5719H\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. Until 2026, stop not served. Stop of the T-bus: Grote Baan 227 (stop of De Lijn to Anderlecht).\", \"fr\": \"Travaux. Jsq 2026, arr\u00eat non desservi. Arr\u00eat du T-bus: Grand'Route 227 (arr\u00eat des bus De Lijn vers Anderlecht).\", \"nl\": \"Werken. Tot 2026, halte niet bediend. Halte van de T-bus: Grote Baan 227 (halte van De Lijn naar Anderlecht).\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"82\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"5732F\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Jan 22, 6AM-end of June, works. Bus 86 diverted between GARE DE L'OUEST/ WESTSTATION and SUZAN DANIEL via ETANGS NOIRS.\", \"fr\": \"Du 22/1 \u00e0 6h jusqu'\u00e0 fin juin, travaux. Bus 86 d\u00e9vi\u00e9 entre GARE DE L'OUEST et SUZAN DANIEL via ETANGS NOIRS.\", \"nl\": \"Van 22/1 om 6u tot eind juni, werken. Bus 86 omgeleid tussen WESTSTATION-SUZAN DANIEL via ZWARTE VIJVERS.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"86\"}]",
+        "priority": 5,
+        "points": "[{\"id\": \"3238\"}, {\"id\": \"3234\"}, {\"id\": \"3253\"}, {\"id\": \"3252\"}, {\"id\": \"3282\"}, {\"id\": \"3281\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"As of Nov 16 at 6AM, works. Stop moved to av. Port / Havenln, in front of number 100 (moved backward of +/- 120m)\", \"fr\": \"D\u00e8s le 16/11 \u00e0 6h, travaux. Arr\u00eat d\u00e9plac\u00e9 avenue du Port, en face du num\u00e9ro 100 (recul\u00e9 de +/- 120m).\", \"nl\": \"Vanaf 16/11 om 6u,werken Halte verplaatst naar de Havenlaan, tegenover nr 100 (achteruitgebracht van +/- 120m)\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"86\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"2305\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. As of Apr 22 at 9.30AM, bus 89 diverted btw TRIANGLE and QUATRE- VENTS. For DUCHESSE, T82 at TRIANGLE.\", \"fr\": \"Travaux. D\u00e8s le 22/4 \u00e0 9h30, bus 89 d\u00e9vi\u00e9 entre TRIANGLE et QUATRE- VENTS. Pour DUCHESSE, tram 82 \u00e0 TRIANGLE.\", \"nl\": \"Werken. Vanaf 22/4 om 9. 30u, bus 89 omgeleid tussen DRIEHOEK en VIER WINDEN. Voor HERTOGIN, tram 82 aan DRIEHOEK.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"89\"}]",
+        "priority": 5,
+        "points": "[{\"id\": \"1895\"}, {\"id\": \"3223B\"}, {\"id\": \"3222\"}, {\"id\": \"3221\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From May 6, works. STOP NOT SERVED. Take bus 89 to NEERPEDE at the stop of bus 53 to WESTLAND SHOPPING.\", \"fr\": \"D\u00e8s le 6/5, travaux. ARRET NON DESSERVI. Bus 89 vers NEERPEDE \u00e0 l'arr\u00eat du bus 53 vers WESTLAND SHOPPING.\", \"nl\": \"Vanaf 6/5, werken. HALTE NIET BEDIEND. Neem bus 89 naar NEERPEDE aan de halte van bus 53 naar WESTLAND SHOPPING.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"89\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"1261\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From May 6, works. Bus 89 extended to NEERPEDE. Stop WESTLAND SHOPPING relocated.\", \"fr\": \"D\u00e8s le 6/5, travaux. Bus 89 prolong\u00e9 jusqu'\u00e0 NEERPEDE. Arr\u00eat WESTLAND SHOPPING d\u00e9plac\u00e9.\", \"nl\": \"Vanaf 6/5, werken. Bus 89 verlengd tot NEERPEDE. Halte WESTLAND SHOPPING verplaatst.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"89\"}]",
+        "priority": 5,
+        "points": "[{\"id\": \"2779\"}, {\"id\": \"2768\"}, {\"id\": \"3638\"}, {\"id\": \"1117\"}, {\"id\": \"1257\"}, {\"id\": \"2750\"}, {\"id\": \"2783\"}, {\"id\": \"2781\"}, {\"id\": \"1260\"}, {\"id\": \"3636\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From May 6, works. STOP NOT SERVED. Take bus 89 at the stop of bus 53 to HOPITAL MILITAIRE / MILITAIR HOSPITAAL.\", \"fr\": \"D\u00e8s le 6/5, travaux. ARRET NON DESSERVI. Prenez le bus 89 \u00e0 l'arr\u00eat du bus 53 vers HOPITAL MILITAIRE.\", \"nl\": \"Vanaf 6/5, werken. HALTE NIET BEDIEND. Neem bus 89 aan de halte van bus 53 naar MILITAIR HOSPITAAL.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"89\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"1203\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. As of Apr 22 at 9.30AM, bus 89 diverted btw TRIANGLE and QUATRE- VENTS. For DUCHESSE, T82 at TRIANGLE.\", \"fr\": \"Travaux. D\u00e8s le 22/4 \u00e0 9h30, bus 89 d\u00e9vi\u00e9 entre TRIANGLE et QUATRE- VENTS. Pour DUCHESSE, tram 82 \u00e0 TRIANGLE.\", \"nl\": \"Werken. Vanaf 22/4 om 9. 30u, bus 89 omgeleid tussen DRIEHOEK en VIER WINDEN. Voor HERTOGIN, tram 82 aan DRIEHOEK.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"89\"}]",
+        "priority": 5,
+        "points": "[{\"id\": \"3347\"}, {\"id\": \"2301\"}, {\"id\": \"2595\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. From Apr 26 at 9PM until May 12, tram 9 replaced by T-bus btw UZ BRUSSEL and ROI BAUDOUIN / KONING BOUDEWIJN.\", \"fr\": \"Travaux. Du 26/4 \u00e0 21h au 12/5, tram 9 remplac\u00e9 par des T-bus entre UZ BRUSSEL et ROI BAUDOUIN.\", \"nl\": \"Werken. Van 26/4 om 21u tot en met 12/5, tram 9 vervangen door T-bus tussen UZ BRUSSEL en KONING BOUDEWIJN.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"9\"}]",
+        "priority": 5,
+        "points": "[{\"id\": \"1681F\"}, {\"id\": \"1679F\"}, {\"id\": \"0470F\"}, {\"id\": \"6864F\"}, {\"id\": \"6865F\"}, {\"id\": \"1675F\"}, {\"id\": \"1677F\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. From Apr 26 at 9PM until May 12, stop not served. Take tram 9 at the next stop, UZ BRUSSEL.\", \"fr\": \"Travaux. Du 26/4 \u00e0 21h au 12/5, arr\u00eat non desservi. Prenez le tram 9 \u00e0 l'arr\u00eat suivant, UZ BRUSSEL.\", \"nl\": \"Werken. Van 26/4 om 21u tot en met 12/5, halte niet bediend. Neem tram 9 aan de volgende halte, UZ BRUSSEL.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"9\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"1684F\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. From Apr 26 at 9PM until May 12, stop not served. T-bus to ROI BAUDOUIN at the stop of bus 83 to VAL MARIA.\", \"fr\": \"Travaux. Du 26/4 \u00e0 21h au 12/5, arr\u00eat non desservi. T-bus vers ROI BAUDOUIN \u00e0 l'arr\u00eat du bus 83 vers VAL MARIA.\", \"nl\": \"Werken. 26/4, 21u-12/5, halte niet bediend.T-bus naar KONING BOUDEWIJN aan de halte van bus 83 naar MARIENDAAL.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"9\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"1691F\"}, {\"id\": \"1689F\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. Apr 26, 9PM-May 12, stop not served. Stop of the T-bus: PALFIJN (stop of bus 83 to GARE DE BERCHEM).\", \"fr\": \"Travaux. 26/4, 21h-12/5, arr\u00eat non desservi. Arr\u00eat du T-bus: PALFIJN (arr\u00eat du bus 83 vers GARE DE BERCHEM).\", \"nl\": \"Werken. 26/4, 21u-12/5, halte niet bediend. Halte van de T-bus: PALFIJN (halte van bus 83 naar STATION BERCHEM)\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"9\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"1692F\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. Apr 26, 9PM-May 12, stop not served. T-bus to UZ BRUSSEL at the stop of bus 83 to GARE DE BERCHEM.\", \"fr\": \"Travaux. Du 26/4 \u00e0 21h au 12/5, arr\u00eat non desservi. T-bus vers UZ BRUSSEL \u00e0 l'arr\u00eat du bus 83 vers GARE DE BERCHEM.\", \"nl\": \"Werken. 26/4, 21u-12/5, halte niet bediend.T-bus naar UZ BRUSSEL aan de halte van bus 83 naar STATION BERCHEM.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"9\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"1690F\"}, {\"id\": \"1695F\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Until 2026, works. As of Mar 11, tram 97 interrupted between WIELS and DIEWEG. Take tram 4 to go to GLOBE.\", \"fr\": \"Jsq 2026,travaux. D\u00e8s le 11/3, tram 97 interrompu entre WIELS et DIEWEG. Prenez le tram 4 pour rejoindre GLOBE.\", \"nl\": \"Tot 2026, werken. Vanaf 11/3, tram 97 onderbroken tussen WIELS en DIEWEG. Neem tram 4 om naar GLOBE te gaan.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"97\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"5917F\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Until 2026, works. As of Mar 11, tram 97 interrupted to DIEWEG. For GLOBE, tram 4 at CARR. STALLE via T-bus.\", \"fr\": \"Jsq 2026,travaux. D\u00e8s le 11/3, tram 97 interrompu jsq DIEWEG. Pour GLOBE, tram 4 \u00e0 CARREFOUR STALLE via T-bus.\", \"nl\": \"Tot 2026, werken. Vanaf 11/3,tram 97 onderbroken tot DIEWEG. Voor GLOBE, neem tram 4 aan KRUISPT STALLE via T-bus.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"97\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"5722F\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Until 2026, works. Tram 97 interrupted to WIELS. Take tram 82 to go to WIELS.\", \"fr\": \"Jusqu'en 2026, travaux. Tram 97 interrompu jusqu'\u00e0 WIELS. Pour rejoindre WIELS, prenez le tram 82.\", \"nl\": \"Tot 2026, werken. Tram 97 onderbroken tot WIELS. Neem tram 82 om naar WIELS te gaan.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"97\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"5151\"}, {\"id\": \"2668\"}, {\"id\": \"5155\"}, {\"id\": \"2667F\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Until 2026, works. Stop not served. Stop of the T-bus: rue de la Soierie / Zijdeweverijstraat 4.\", \"fr\": \"Jusqu'en 2026, travaux. Arr\u00eat non desservi. Arr\u00eat du T-bus: rue de la Soierie 4.\", \"nl\": \"Tot 2026, werken. Halte niet bediend. Halte van de T-bus: Zijdeweverijstraat 4.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"97\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"5154F\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Until 2026, works. As of Mar 11, tram 97 interrupted between WIELS and DIEWEG. Take tram 4 to go to GLOBE.\", \"fr\": \"Jsq 2026,travaux. D\u00e8s le 11/3, tram 97 interrompu entre WIELS et DIEWEG. Prenez le tram 4 pour rejoindre GLOBE.\", \"nl\": \"Tot 2026, werken. Vanaf 11/3, tram 97 onderbroken tussen WIELS en DIEWEG. Neem tram 4 om naar GLOBE te gaan.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"97\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"5916F\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Until 2026, works. As of Mar 11, tram 97 operated only btw LOUISE and WIELS. T-bus: av. Reine Marie-Henriette 1A\", \"fr\": \"Jsq 2026,travaux. D\u00e8s le 11/3, tram 97 circule uniquement entre LOUISE et WIELS. T-bus: av. Reine Marie-Henriette 1A\", \"nl\": \"Tot 2026, werken. Vanaf 11/3 rijdt tram 97 enkel tussen LOUIZA en WIELS. T-bus: Koningin Maria-Hendrikaln 1A\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"97\"}]",
+        "priority": 5,
+        "points": "[{\"id\": \"5115F\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Mar 18, works. STOP NOT SERVED. stop of N08: chauss\u00e9e de Boondael / Boondaalsesteenweg, before roundabout.\", \"fr\": \"D\u00e8s le 18/3, travaux. ARRET NON DESSERVI. Arr\u00eat du bus N08: chauss\u00e9e de Boondael, avant le rond-point.\", \"nl\": \"Vanaf 18/3, werken. HALTE NIET BEDIEND. Halte van bus N08: Boondaalsesteenweg, voor rondpunt.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"N08\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"3514\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Jan 15, works. Noctis N09 diverted between HANKAR and HERRMANN-DEBROUX via DEMEY.\", \"fr\": \"D\u00e8s le 15/1, travaux. Noctis N09 d\u00e9vi\u00e9 entre HANKAR et HERRMANN-DEBROUX via DEMEY.\", \"nl\": \"Vanaf 15/1, werken. Noctis N09 omgeleid tussen HANKAR en HERRMANN-DEBROUX via DEMEY.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"N09\"}]",
+        "priority": 5,
+        "points": "[{\"id\": \"4362\"}, {\"id\": \"4363\"}, {\"id\": \"6443\"}, {\"id\": \"3510B\"}, {\"id\": \"2397\"}, {\"id\": \"2595\"}, {\"id\": \"1376B\"}, {\"id\": \"1063\"}, {\"id\": \"3372\"}, {\"id\": \"1128\"}, {\"id\": \"2291B\"}, {\"id\": \"2578\"}, {\"id\": \"1895\"}, {\"id\": \"2301\"}, {\"id\": \"5611\"}, {\"id\": \"4369\"}, {\"id\": \"2928\"}, {\"id\": \"1716\"}, {\"id\": \"1726\"}, {\"id\": \"5407\"}, {\"id\": \"3518B\"}, {\"id\": \"3517\"}, {\"id\": \"3506\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Mar 5 at 9AM, works. STOP NOT SERVED. Temporary stop: avenue Jean & Pierre Carsoellaan 4.\", \"fr\": \"D\u00e8s le 5/3 \u00e0 9h, travaux. ARRET NON DESSERVI. Arr\u00eat provisoire: avenue Jean et Pierre Carsoel 4.\", \"nl\": \"Vanaf 5/3 om 9u, werken. HALTE NIET BEDIEND. Tijdelijke halte: Jean en Pierre Carsoellaan 4.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"N10\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"6931B\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From May 6, works. STOP NOT SERVED. Take bus 89 at the stop of bus 53 to WESTLAND SHOPPING.\", \"fr\": \"D\u00e8s le 6/5, travaux. ARRET NON DESSERVI. Prenez le bus N13 \u00e0 l'arr\u00eat du bus 53 vers WESTLAND SHOPPING.\", \"nl\": \"Vanaf 6/5, werken. HALTE NIET BEDIEND. Neem bus N13 aan de halte van bus 53 naar WESTLAND SHOPPING.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"N13\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"1203\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From May 3 to May 12, works. Bus N16 diverted. Temporary stop: boulevard Barth\u00e9l\u00e9my- laan, in front of nr. 3.\", \"fr\": \"Du 3/5 au 12/5, travaux. Bus N16 d\u00e9vi\u00e9. Arr\u00eat provisoire: boulevard Barth\u00e9l\u00e9my, face au num\u00e9ro 3.\", \"nl\": \"Van 3/5 tot 12/5, werken. Bus N16 omgeleid. Tijdelijke halte: Barth\u00e9l\u00e9mylaan, tegenover nummer 3.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"N16\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"3222\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"As of Oct 25, stop moved +/- 50m behind, side square Lain\u00e9square.\", \"fr\": \"D\u00e8s le 25/10, arr\u00eat recul\u00e9 de +/- 50m, c\u00f4t\u00e9 square Lain\u00e9\", \"nl\": \"Vanaf 25/10, werken. Halte achteruitgebracht van +/- 50m, kant Lain\u00e9square.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"T82\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"2023\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Until 2026, works. Stop of T-bus 82/97: ch. de Neerstalsesteenweg in front of 348.\", \"fr\": \"Jusqu'en 2026, travaux. Arr\u00eat du T-bus 82/97: chauss\u00e9e de Neerstalle, en face du num\u00e9ro 348.\", \"nl\": \"Tot 2026, werken. Halte van T-bus 82/97: Neerstalsesteenweg, tegenover nummer 348.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"T82\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"3242\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. As of Apr 15, STOP NOT SERVED. Stop of bus 12: rue Franklinstraat 2a.\", \"fr\": \"Travaux. D\u00e8s le 15/4, ARRET NON DESSERVI. Arr\u00eat du bus 12: rue Franklin, 2a.\", \"nl\": \"Werken. Vanaf 15/4, HALTE NIET BEDIEND. Halte van bus 12: Franklinstraat 2a.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"12\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"1270B\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. As of Apr 15, B12 diverted btw LUXEMBOURG and MEISER via MAELBEEK. Stop SCHUMAN moved rue Archim\u00e8destr. 16.\", \"fr\": \"Travaux. D\u00e8s le 15/4,B12 d\u00e9vi\u00e9 entre LUXEMBOURG et MEISER via MAELBEEK. Arr\u00eat SCHUMAN d\u00e9plac\u00e9 rue Archim\u00e8de 16.\", \"nl\": \"Werken. Vanaf 15/4, bus 12 omgeleid ts LUXEMBURG en MEISER via MAALBEEK. Halte SCHUMAN verplaatst Archimedesstraat 16.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"12\"}]",
+        "priority": 6,
+        "points": "[{\"id\": \"6433\"}, {\"id\": \"1780\"}, {\"id\": \"1131B\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Dec 4, works. STOP NOT SERVED. Take bus 14 and 57 under the CCN building, at the terminus of bus 61.\", \"fr\": \"D\u00e8s le 4/12, travaux. ARRET NON DESSERVI. Prenez le bus 14 et 57 sous le b\u00e2timent CCN, au terminus du bus 61.\", \"nl\": \"Vanaf 4/12, werken. HALTE NIET BEDIEND. Neem bus 14 en 57 onder het CCN-gebouw, aan eindhalte bus 61.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"14\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"1082\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Sep 5 6AM, works. STOP NOT SERVED. Temporary stop: av. Charles Michiels across no. 205\", \"fr\": \"D\u00e8s le 5/9 6h, travaux. ARRET NON DESSERVI. Arr\u00eat provisoire : av. Charles Michiels face au num. 205\", \"nl\": \"Vanaf 5/9 6u, werken. HALTE NIET BEDIEND. Tijdelijke halte: Charles Michielslaan tegenover nr. 205\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"17\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"4294\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. May 8, 9PM-May 12, tram 19 replaced by a T-bus to DE WAND. T-bus at the stop of bus 88 to DE BROUCKERE.\", \"fr\": \"Travaux. 8/5, 21h-12/5, tram 19 remplac\u00e9 par des T-bus jusqu'\u00e0 DE WAND. T-bus \u00e0 l'arr\u00eat du bus 88 vers DE BROUCKERE.\", \"nl\": \"Werken. 8/5, 21u-12/5, tram 19 vervangen door T-bus tot DE WAND. T-bus aan de halte van bus 88 naar DE BROUCKERE.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"19\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"5092F\"}, {\"id\": \"5090F\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. From May 8 at 9PM until May 12, STOP NOT SERVED. T-bus to SIMONIS at DE WAND via tram 7.\", \"fr\": \"Travaux. Du 8/5 \u00e0 21h au 12/5, ARRET NON DESSERVI. T-bus vers SIMONIS \u00e0 DE WAND via tram 7.\", \"nl\": \"Werken. Van 8/5 om 21u tot 12/5, HALTE NIET BEDIEND. T-bus naar SIMONIS aan DE WAND via tram 7.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"19\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"2637F\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Wroks. Until mid-2024, stop not served. T-bus at LEOPOLD I (bd de Smet de Naeyer 54, stop of bus 14 to UZ-VUB).\", \"fr\": \"Travaux. Jusque mi-2024, arr\u00eat non desservi. T-bus \u00e0 LEOPOLD I (bd de Smet de Naeyer 54, arr\u00eat du bus 14 vers UZ-VUB).\", \"nl\": \"Werken. Tot midden 2024, halte niet bediend. T-bus aan LEOPOLD I (de Smet de Naeyerlaan 54, halte B14 naar UZ-VUB).\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"19\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"6866F\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. As of Apr 15, bus 21 diverted. Take bus 21 at MAELBEEK / MAALBEEK (stop of bus 64 to PORTE DE NAMUR / NAAMSEPOORT).\", \"fr\": \"Travaux. D\u00e8s le 15/4, bus 21 d\u00e9vi\u00e9. Prenez le bus 21 \u00e0 MAELBEEK (arr\u00eat du bus 64 vers PORTE DE NAMUR).\", \"nl\": \"Werken. Vanaf 15/4, bus 21 omgeleid. Neem bus 21 aan MAALBEEK (halte van bus 64 naar NAAMSEPOORT) .\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"21\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"1476\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. As of April 7th, STOP NOT SERVED. To go to DE BROUCKERE, take metro lines 1 or 5.\", \"fr\": \"Travaux. D\u00e8s le 7/4, ARRET NON DESSERVI. Pour rejoindre DE BROUCKERE, prenez le m\u00e9tro 1 ou 5.\", \"nl\": \"Werken. Vanaf 7/4, HALTE NIET BEDIEND. Om naar DE BROUCKERE te gaan, neem metrolijn 1 of 5.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"29\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"6447\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Jan 7, 9PM-Jun 28, works. Tram 3 replaced by T-bus. Stop T-bus: av. Croix du Feu, after rue De Wandstraat.\", \"fr\": \"7/1, 21h-28/6, travaux. Tram 3 remplac\u00e9 par des T-bus. Arr\u00eat du T-bus: avenue des Croix du Feu, apr\u00e8s la rue De Wand.\", \"nl\": \"7/1, 21u-28/6, werken. Tram 3 vervangen door T-bus. Halte T-bus: Vuurkruisenlaan, na de De Wandstraat.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"3\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"5806\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Jan 7, 9PM-Jun 28, works. Tram 3 replaced by T-bus. Stop T-bus: av. Croix du Feu, crossing av. Buissonnets\", \"fr\": \"7/1, 21h-28/6, travaux. Tram 3 remplac\u00e9 par des T-bus. Arr\u00eat du T-bus: av. Croix du Feu, carrefour av.Buissonnets\", \"nl\": \"7/1, 21u-28/6, werken. Tram 3 vervangen door T- bus. Halte T-bus: Vuurkruisenlaan, kruispunt Braambosjesln.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"3\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"5772\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Jan 7, 9PM-Jun 28,works. Stop not served. Stop T-bus to DOCKS BRUXSEL: av. Croix du Feu, crossing av. Pagodes.\", \"fr\": \"7/1, 21h-28/6, travaux. Arr\u00eat non desservi.Arr\u00eat du T-bus vers DOCKS BRUXSEL: av. Croix du Feu, carr. av. Pagodes.\", \"nl\": \"7/1, 21u-28/6, werken. Halte niet bediend.Halte van de T-bus naar DOCKS BRUXSEL: Vuurkruisenln, kruispt Pagodenln.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"3\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"5706\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Jan 8 to Jun 28, works. After CHURCHILL, tram 3 continues on line 7 direction HEYSEL / HEIZEL.\", \"fr\": \"Du 8/1 au 28/6, travaux. Apr\u00e8s CHURCHILL, tram 3 continue sur la ligne 7 direction HEYSEL.\", \"nl\": \"Van 8/1 tot en met 28/6, werken. Na CHURCHILL rijdt tram 3 verder op lijn 7 richting HEIZEL.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"3\"}]",
+        "priority": 6,
+        "points": "[{\"id\": \"6253\"}, {\"id\": \"6178\"}, {\"id\": \"2318G\"}, {\"id\": \"5221F\"}, {\"id\": \"0611\"}, {\"id\": \"0501\"}, {\"id\": \"0601\"}, {\"id\": \"0621\"}, {\"id\": \"0511\"}, {\"id\": \"0531\"}, {\"id\": \"2338F\"}, {\"id\": \"6422F\"}, {\"id\": \"0705\"}, {\"id\": \"0706\"}, {\"id\": \"0703\"}, {\"id\": \"5714\"}, {\"id\": \"2543F\"}, {\"id\": \"0704\"}, {\"id\": \"0702\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Jan 15, works. STOP NOT SERVED. Stop of bus 34: chauss\u00e9e de Wavre / Waversesteenweg 1303.\", \"fr\": \"D\u00e8s le 15/1, travaux. ARRET NON DESSERVI. Arr\u00eat du bus 34: chauss\u00e9e de Wavre 1303.\", \"nl\": \"Vanaf 15/1, werken. HALTE NIET BEDIEND. Halte van bus 34: Waversesteenweg 1303.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"34\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"1718B\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Mar 5 at 9AM, works. STOP NOT SERVED. Temporary stop: avenue Jean & Pierre Carsoellaan 4.\", \"fr\": \"D\u00e8s le 5/3 \u00e0 9h, travaux. ARRET NON DESSERVI. Arr\u00eat provisoire: avenue Jean et Pierre Carsoel 4.\", \"nl\": \"Vanaf 5/3 om 9u, werken. HALTE NIET BEDIEND. Tijdelijke halte: Jean en Pierre Carsoellaan 4.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"37\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"6931B\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Apr 3 at 6AM, works. STOP NOT SERVED. Take bus 38 and 41 at the next stop, HOUZEAU.\", \"fr\": \"D\u00e8s le 3/4 \u00e0 6h, travaux. ARRET NON DESSERVI. Prenez les bus 38 et 41 \u00e0 l'arr\u00eat suivant, HOUZEAU.\", \"nl\": \"Vanaf 3/4 om 6u, werken. HALTE NIET BEDIEND. Neem bus 38 en 41 aan de volgende halte, HOUZEAU.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"38\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"1920\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. As of April 7th, stop of bus 38 moved to the Cantersteen, at the stop of bus 52 to FOREST / VORST (BERVOETS)\", \"fr\": \"Travaux. D\u00e8s le 7/4, arr\u00eat du bus 38 d\u00e9plac\u00e9 Cantersteen, \u00e0 l'arr\u00eat du bus 52 vers FOREST (BERVOETS).\", \"nl\": \"Werken. Vanaf 7/4, halte van bus 38 verplaatst naar de Kantersteen, aan de halte van bus 52 naar VORST (BERVOETS).\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"38\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"6443\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Apr 3 at 6AM, works. STOP NOT SERVED. Temporary stop: avenue Winston Churchilllaan 202.\", \"fr\": \"D\u00e8s le 3/4 \u00e0 6h, travaux. ARRET NON DESSERVI. Arr\u00eat provisoire: avenue Winston Churchill 202.\", \"nl\": \"Vanaf 3/4 om 6u, werken. HALTE NIET BEDIEND. Tijdelijke halte: Winston Churchilllaan 202.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"38\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"1973\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. As of Apr 29, STOP NOT SERVED. Take bus 38 at the next stop, BASCULE.\", \"fr\": \"Travaux. D\u00e8s le 29/4, ARRET NON DESSERVI. Prenez le bus 38 \u00e0 l'arr\u00eat suivant, BASCULE.\", \"nl\": \"Werken. Vanaf 29/4, HALTE NIET BEDIEND. Neem bus 38 aan de volgende halte, BASCULE.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"38\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"1914\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Apr 3 at 6AM, works. Bus 38 diverted between HOUZEAU and LONGCHAMP via rue Edith Cavellstraat.\", \"fr\": \"D\u00e8s le 3/4 \u00e0 6h, travaux. Bus 38 d\u00e9vi\u00e9 entre HOUZEAU et LONGCHAMP via rue Edith Cavell.\", \"nl\": \"Vanaf 3/4 om 6u, werken. Bus 38 omgeleid tussen HOUZEAU en LONGCHAMP via Edith Cavellstraat.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"38\"}]",
+        "priority": 5,
+        "points": "[{\"id\": \"1943\"}, {\"id\": \"4076\"}, {\"id\": \"1969\"}, {\"id\": \"1968\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. As of Mar 27, STOP MOVED. Stop of bus 41: rue des C\u00e8dres / Cederlaan 5.\", \"fr\": \"Travaux. D\u00e8s le 27/3, ARRET DEPLACE. Arr\u00eat du bus 41: rue des C\u00e8dres, 5.\", \"nl\": \"Werken. Vanaf 27/3, HALTE VERPLAATST. Halte van bus 41: Cederlaan 5.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"41\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"4310\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Apr 3 at 6AM, works. Bus 41 diverted between HOUZEAU and VERT CHASSEUR / GROENE JAGER via rue Edith Cavell.\", \"fr\": \"D\u00e8s le 3/4 \u00e0 6h, travaux. Bus 41 d\u00e9vi\u00e9 entre HOUZEAU et VERT CHASSEUR via rue Edith Cavell.\", \"nl\": \"Vanaf 3/4 om 6u, werken. Bus 41 omgeleid tussen HOUZEAU en GROENE JAGER via Edith Cavellstraat.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"41\"}]",
+        "priority": 5,
+        "points": "[{\"id\": \"1943\"}, {\"id\": \"4076\"}, {\"id\": \"1969\"}, {\"id\": \"1968\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Mar 4, works. Bus 43 diverted between GRIOTTES and HOMBORCH. B43 HOMBORCH extended to BRAVES.\", \"fr\": \"D\u00e8s le 4/3, travaux. Bus 43 d\u00e9vi\u00e9 entre GRIOTTES et HOMBORCH. B43 barr\u00e9 HOMBORCH prolong\u00e9 jusqu'\u00e0 BRAVES.\", \"nl\": \"Vanaf 4/3, werken. Bus 43 omgeleid tussen NOORDKRIEKEN en HOMBORCH. B43 HOMBORCH rijdt tot DAPPEREN.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"43\"}]",
+        "priority": 5,
+        "points": "[{\"id\": \"2165\"}, {\"id\": \"1250\"}, {\"id\": \"1921\"}, {\"id\": \"1932\"}, {\"id\": \"1931\"}, {\"id\": \"1942\"}, {\"id\": \"5817\"}, {\"id\": \"1984B\"}, {\"id\": \"2355\"}, {\"id\": \"4854C\"}, {\"id\": \"1929\"}, {\"id\": \"1926B\"}, {\"id\": \"1937\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Mar 4, works. Bus 43 and N11 diverted. Take the bus at HOMBORCH (via B43 from this stop on weekdays or B37).\", \"fr\": \"D\u00e8s le 4/3, travaux. Bus 43 et N11 d\u00e9vi\u00e9s. Prenez le bus \u00e0 HOMBORCH (via B43 depuis cet arr\u00eat en semaine ou B37).\", \"nl\": \"Vanaf 4/3, werken. Bus 43 en N11 omgeleid. Neem de bus aan HOMBORCH (via B43 vanaf deze halte op weekdagen of B37).\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"43\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"1936\"}, {\"id\": \"1935\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Mar 4, works. Bus 43 and N11 diverted. Take the bus at HOMBORCH (via B43 at stop B43 VIVIER D'OIE or B37).\", \"fr\": \"D\u00e8s le 4/3, travaux. Bus 43 et N11 d\u00e9vi\u00e9s. Prenez le bus \u00e0 HOMBORCH (via B43 \u00e0 l'arr\u00eat du B43 VIVIER D'OIE ou B37).\", \"nl\": \"Vanaf 4/3, werken. Bus 43 en N11 omgeleid. Neem de bus aan HOMBORCH (via B43 aan halte B43 DIESDELLE of B37).\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"43\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"1954\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Mar 4, works. Bus 43 diverted between CABRIS / GEITJES and GRIOTTES / NOORDKRIEKEN.\", \"fr\": \"D\u00e8s le 4/3, travaux. Bus 43 d\u00e9vi\u00e9 entre CABRIS et GRIOTTES.\", \"nl\": \"Vanaf 4/3, werken. Bus 43 omgeleid tussen GEITJES en NOORDKRIEKEN.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"43\"}]",
+        "priority": 5,
+        "points": "[{\"id\": \"2144\"}, {\"id\": \"2142\"}, {\"id\": \"2140\"}, {\"id\": \"2161\"}, {\"id\": \"2109B\"}, {\"id\": \"1953\"}, {\"id\": \"2143B\"}, {\"id\": \"2168\"}, {\"id\": \"2157\"}, {\"id\": \"2146\"}, {\"id\": \"2147B\"}, {\"id\": \"2156\"}, {\"id\": \"2167\"}, {\"id\": \"2145\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Mar 4, works. Bus 43 diverted. Take the bus at HOMBORCH (via B43 from this stop on weekdays before 8PM).\", \"fr\": \"D\u00e8s le 4/3, travaux. Bus 43 d\u00e9vi\u00e9. Prenez le bus \u00e0 HOMBORCH (via B43 depuis cet arr\u00eat en semaine avant 20h).\", \"nl\": \"Vanaf 4/3, werken. Bus 43 omgeleid. Neem de bus aan HOMBORCH (via B43 vanaf deze halte op weekdagen voor 20u).\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"43\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"1944\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Mar 4, works. Bus 43 and N11 diverted. Take the bus at HOMBORCH (via B43 from this stop on weekdays or B37).\", \"fr\": \"D\u00e8s le 4/3, travaux. Bus 43 et N11 d\u00e9vi\u00e9s. Prenez le bus \u00e0 HOMBORCH (via B43 depuis cet arr\u00eat en semaine ou B37).\", \"nl\": \"Vanaf 4/3, werken. Bus 43 en N11 omgeleid. Neem de bus aan HOMBORCH (via B43 vanaf deze halte op weekdagen of B37).\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"43\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"1955\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. Until end of August, bus 46 not operated btw WTC-GLIBERT and CENTRAL STATION. Walk to WTC-GLIBERT\", \"fr\": \"Travaux. Jsq fin ao\u00fbt, bus 46 ne circule pas entre WTC-GLIBERT et GARE CENTRALE. Allez \u00e0 pied \u00e0 WTC-GLIBERT\", \"nl\": \"Werken. Tot einde augustus rijdt bus 46 niet tss WTC- GLIBERT en CENTRAAL STATION. Ga te voet naar WTC-GLIBERT.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"46\"}]",
+        "priority": 5,
+        "points": "[{\"id\": \"2269\"}, {\"id\": \"2587\"}, {\"id\": \"3075\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Until end of August, works. Stop not served. Take bus 46 at the next stop, PORTE D'ANDERLECHT\", \"fr\": \"Jusque fin ao\u00fbt, travaux. Arr\u00eat non desservi. Prenez le bus 46 \u00e0 l'arr\u00eat suivant, PORTE D'ANDERLECHT.\", \"nl\": \"Tot einde augustus, werken. Halte niet bediend. Neem bus 46 aan de volgende halte, ANDERLECHTSEPOORT.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"46\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"2213\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Until end August 2024, works. B46 diverted to ANNEESSENS. Stops between BUANDERIE and WTC-GLIBERT not served.\", \"fr\": \"Jsq fin ao\u00fbt 2024, travaux. Bus 46 d\u00e9vi\u00e9 vers ANNEESSENS. Arr\u00eats entre BUANDERIE et WTC- GLIBERT non desservis.\", \"nl\": \"Tot einde augustus 2024, werken. Bus 46 omgeleid naar ANNEESSENS. Haltes tussen WASHUIS en WTC-GLIBERT niet bediend\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"46\"}]",
+        "priority": 5,
+        "points": "[{\"id\": \"2405\"}, {\"id\": \"2259\"}, {\"id\": \"2264\"}, {\"id\": \"2262\"}, {\"id\": \"2261\"}, {\"id\": \"2260\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"As of Sep 13 at 6AM, works. Stop moved to rue de Laeken / Lakensestraat, next to numbers 57-59.\", \"fr\": \"D\u00e8s le 13/9 \u00e0 6h, travaux. Arr\u00eat d\u00e9plac\u00e9 rue de Laeken, \u00e0 hauteur des num\u00e9ros 57-59.\", \"nl\": \"Vanaf 13/9 om 6u, werken. Halte verplaatst naar de Lakensestraat, ter hoogte van huisnummer 57-59.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"46\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"3465\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Feb 6, works. STOP NOT SERVED. Temporary stop: Vlierkensstraat 94.\", \"fr\": \"D\u00e8s le 6/2, travaux. ARRET NON DESSERVI. Arr\u00eat provisoire: Vlierkensstraat 94.\", \"nl\": \"Vanaf 6/2, werken. HALTE NIET BEDIEND. Tijdelijke halte: Vlierkensstraat 94.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"47\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"2841\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Until Summer of 2024, works. Stop not served. Take bus 47 at ANTOON VAN OSS (stop of bus 56 to BUDA).\", \"fr\": \"Jsq \u00e9t\u00e9 2024, travaux. Arr\u00eat non desservi. Prenez le bus 47 \u00e0 ANTOON VAN OSS (arr\u00eat du bus 56 vers BUDA).\", \"nl\": \"Tot zomer 2024, werken. Halte niet bediend. Neem bus 47 aan ANTOON VAN OSS (halte van bus 56 naar BUDA).\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"47\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"2359\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Until Summer of 2024, works. Stop not served. Take bus 47 at ANTOON VAN OSS (stop of bus 56 to SCHUMAN).\", \"fr\": \"Jsq \u00e9t\u00e9 2024, travaux. Arr\u00eat non desservi. Prenez le bus 47 \u00e0 ANTOON VAN OSS (arr\u00eat du bus 56 vers SCHUMAN).\", \"nl\": \"Tot zomer 2024, werken. Halte niet bediend. Neem bus 47 aan ANTOON VAN OSS (halte van bus 56 naar SCHUMAN).\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"47\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"2316\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Until Summer of 2024, works. Bus 47 diverted from RAMIER / BOSDUIF to DOCKS BRUXSEL via avenue des Croix de Guerre\", \"fr\": \"Jsq \u00e9t\u00e9 2024, travaux. Bus 47 d\u00e9vi\u00e9 depuis RAMIER vers DOCKS BRUXSEL via avenue des Croix de Guerre.\", \"nl\": \"Tot zomer 2024, werken. Bus 47 omgeleid vanaf BOSDUIF naar DOCKS BRUXSEL via Oorlogskruisenlaan.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"47\"}]",
+        "priority": 5,
+        "points": "[{\"id\": \"2361\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. STOP NOT SERVED. Bus 47-56 at the stop VERGER (avenue des Croix de Guerre)\", \"fr\": \"Travaux. ARRET NON DESSERVI. Bus 47-56 \u00e0 l'arr\u00eat VERGER (avenue des Croix de Guerre)\", \"nl\": \"Werken. HALTE NIET BEDIEND. Bus 47-56 aan de halte BOOMGAARD (Oorlogskruisenlaan)\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"47\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"1974\"}, {\"id\": \"1967\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Until Summer of 2024, works. Stop not served. Stop of bus 47: av. Marlylaan, next to Verano.\", \"fr\": \"Jusqu'\u00e0 l'\u00e9t\u00e9 2024, travaux. Arr\u00eat non desservi. Arr\u00eat du bus 47: avenue du Marly, pr\u00e8s de Verano.\", \"nl\": \"Tot zomer 2024, werken. Halte niet bediend. Halte van bus 47: Marlylaan, naast Verano.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"47\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"2315\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Until Summer of 2024, works. Stop not served. Take bus 47 at the stop of bus 56 to SCHUMAN.\", \"fr\": \"Jusqu'\u00e0 l'\u00e9t\u00e9 2024, travaux. Arr\u00eat non desservi. Prenez le bus 47 \u00e0 l'arr\u00eat du bus 56 vers SCHUMAN.\", \"nl\": \"Tot zomer 2024, werken. Halte niet bediend. Neem bus 47 aan de halte van bus 56 naar SCHUMAN.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"47\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"2317\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Until Summer of 2024, works. Stop of bus 47 and 56: avenue des Croix de Guerre / Oorlogskruisenlaan 78.\", \"fr\": \"Jusqu'\u00e0 l'\u00e9t\u00e9 2024, travaux. Arr\u00eat des bus 47 et 56 : avenue des Croix de Guerre 78.\", \"nl\": \"Tot zomer 2024, werken. Halte van bus 47 en 56: Oorlogskruisenlaan 78.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"47\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"2299\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. Stop not served. As of May 6, stop of bus 49 and 74: chauss\u00e9e de Mons / Bergensesteenweg 814a\", \"fr\": \"Travaux. Arr\u00eat non desservi.  D\u00e8s le 6/5, arr\u00eat des bus 49 et 74: chauss\u00e9e de Mons, 814a.\", \"nl\": \"Werken.  Halte niet bediend. Vanaf 6/5, halte van bus 49 en 74: Bergensesteenweg 814a.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"49\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"2225\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Until 2026, works. Bus 50 diverted. Stop of bus 50: rue des Abbesses / Abdissenstraat, in front of number 1.\", \"fr\": \"Jusqu'en 2026, travaux. Bus 50 d\u00e9vi\u00e9. Arr\u00eat du bus 50: rue des Abbesses, en face du num\u00e9ro 1.\", \"nl\": \"Tot 2026, werken. Bus 50 omgeleid. Halte van bus 50: Abdissenstraat, tegenover nummer 1.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"50\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"5161\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. Until 2026, stop not served. Stop of T-bus 82 and of bus 50: rue de la Soierie / Zijdeweverijstraat 9.\", \"fr\": \"Travaux. Jusqu'en 2026, arr\u00eat non desservi. Arr\u00eat du T-bus 82 et du bus 50 : rue de la Soierie 9.\", \"nl\": \"Werken. Tot 2026, halte niet bediend. Halte van T-bus 82 en van bus 50: Zijdeweverijstraat 9.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"50\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"3603\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Until 2026, works. Stop not served. Stop of bus 50: rue de la Soierie / Zijdeweverijstraat 4.\", \"fr\": \"Jusqu'en 2026, travaux. Arr\u00eat non desservi. Arr\u00eat du bus 50: rue de la Soierie 4.\", \"nl\": \"Tot 2026, werken. Halte niet bediend. Halte van bus 50: Zijdeweverijstraat 4.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"50\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"3602\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Until 2026, works. Bus 50 diverted between BEMPT and FOREST CENTRE/VORST CENTRUM.\", \"fr\": \"Jusqu'en 2026, travaux. Bus 50 d\u00e9vi\u00e9 entre BEMPT et FOREST CENTRE.\", \"nl\": \"Tot 2026, werken. Bus 50 omgeleid tussen BEMPT en VORST CENTRUM.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"50\"}]",
+        "priority": 5,
+        "points": "[{\"id\": \"9685\"}, {\"id\": \"9683\"}, {\"id\": \"9678\"}, {\"id\": \"9679\"}, {\"id\": \"9677\"}, {\"id\": \"2661\"}, {\"id\": \"9658\"}, {\"id\": \"2662B\"}, {\"id\": \"9659\"}, {\"id\": \"9682\"}, {\"id\": \"2659\"}, {\"id\": \"9680\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From May 2 at 5AM, works. STOP NOT SERVED. Temporary stop: Karel Gilsonstraat, 2.\", \"fr\": \"D\u00e8s le 2/5 \u00e0 5h,travaux. ARRET NON DESSERVI. Arr\u00eat provisoire: Karel Gilsonstraat, 2.\", \"nl\": \"Vanaf 2/5 om 5u, werken. HALTE NIET BEDIEND. Tijdelijke halte: Karel Gilsonstraat, 2.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"50\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"9651\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. From May 8 at 9PM until May 12, T-bus 19 does not serve HOP. BRUGMANN. Connection to T-bus 19 at CIM. JETTE.\", \"fr\": \"Travaux. 8/5, 21h-12/5, T-bus 19 ne dessert pas HOPITAL BRUGMANN. Correspondance T-bus 19 \u00e0 CIMETIERE DE JETTE.\", \"nl\": \"8/5, 21u-12/5, werken. T-bus 19 bedient BRUGMANN-ZKH. niet. Aansluiting met T-bus 19 aan KERKHOF VAN JETTE.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"51\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"5402\"}, {\"id\": \"5399F\"}, {\"id\": \"1290\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. As of Apr 15 at 6AM, bus 53 diverted between PETER BENOIT and BEYSEGHEM / BEIZEGEM.\", \"fr\": \"Travaux. D\u00e8s le 15/4 \u00e0 6h, bus 53 d\u00e9vi\u00e9 entre PETER BENOIT et BEYSEGHEM.\", \"nl\": \"Werken. Vanaf 15/4 om 6u, bus 53 omgeleid tussen PETER BENOIT en BEIZEGEM.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"53\"}]",
+        "priority": 5,
+        "points": "[{\"id\": \"2823B\"}, {\"id\": \"2766\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Until Summer of 2024, works. Bus 53 diverted. Stop of bus 53: rue Bruynstraat, after the military area.\", \"fr\": \"Jsq \u00e9t\u00e9 2024, travaux. Bus 53 d\u00e9vi\u00e9. Arr\u00eat du bus 53 : rue Bruyn, apr\u00e8s le domaine militaire.\", \"nl\": \"Tot zomer 2024, werken. Bus 53 omgeleid. Halte van bus 53: Bruynstraat, na het militair domein.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"53\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"2352\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. As of Apr 15 at 6AM, bus 53 diverted between PETER BENOIT and BEYSEGHEM / BEIZEGEM.\", \"fr\": \"Travaux. D\u00e8s le 15/4 \u00e0 6h, bus 53 d\u00e9vi\u00e9 entre PETER BENOIT et BEYSEGHEM.\", \"nl\": \"Werken. Vanaf 15/4 om 6u, bus 53 omgeleid tussen PETER BENOIT en BEIZEGEM.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"53\"}]",
+        "priority": 5,
+        "points": "[{\"id\": \"3001B\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From May 6, works. STOP NOT SERVED. Take bus 54 at the next stop, BAILLI / BALJUW.\", \"fr\": \"D\u00e8s le 6/5, travaux. ARRET NON DESSERVI. Prenez le bus 54 \u00e0 l'arr\u00eat suivant, BAILLI.\", \"nl\": \"Vanaf 6/5, werken. HALTE NIET BEDIEND. Neem bus 54 aan de volgende halte, BAILLI.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"54\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"2929\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Apr 2, 2024-June 2025, works. Bus 54 diverted btw FOREST NATIONAL and FOREST CENTRE. Info: stib-mivb.brussels\", \"fr\": \"Du 2/4/2024 \u00e0 juin 2025, travaux. Bus 54 d\u00e9vi\u00e9 entre FOREST NATIONAL et FOREST CENTRE. Info: stib.brussels.\", \"nl\": \"2/4/2024-juni 2025, werken. Bus 54 omgeleid tussen VORST NATIONAAL en VORST CENTRUM. Info: mivb.brussels\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"54\"}]",
+        "priority": 5,
+        "points": "[{\"id\": \"2932\"}, {\"id\": \"2934A\"}, {\"id\": \"2931\"}, {\"id\": \"2972\"}, {\"id\": \"2950\"}, {\"id\": \"2411B\"}, {\"id\": \"2937B\"}, {\"id\": \"2936\"}, {\"id\": \"2935\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Apr 2, 2024 to June 2025, works. STOP NOT SERVED. Stop of bus 54: FOREST NATIONAL (av. du Globelaan 8).\", \"fr\": \"Du 2/4/2024 \u00e0 juin 2025, travaux. ARRET NON DESSERVI. Arr\u00eat des bus 54: FOREST NATIONAL. (avenue du Globe 8).\", \"nl\": \"Van 2/4/2024 tot juni 2025, werken. HALTE NIET BEDIEND. Halte van bus 54: VORST NATIONAAL (Globelaan 8)\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"54\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"2939B\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Until Summer of 2024, works. Stop of bus 47 and 56: av. Croix de Guerre, at the other side of Delhaize.\", \"fr\": \"Jusqu'\u00e0 l'\u00e9t\u00e9 2024, travaux. Arr\u00eat des bus 47 et 56 : avenue des Croix de Guerre, de l'autre c\u00f4t\u00e9 du Delhaize\", \"nl\": \"Tot zomer 2024, werken. Halte van bus 47 en 56: Oorlogskruisenlaan, aan de andere kant van de Delhaize.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"56\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"1974\"}, {\"id\": \"1967\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Until Summer of 2024, works. Bus 56 diverted between VAN PRAET and PETER BENOIT via avenue des Croix de Guerre.\", \"fr\": \"Jusqu'\u00e0 l'\u00e9t\u00e9 2024, travaux. Bus 56 d\u00e9vi\u00e9 entre VAN PRAET et PETER BENOIT via avenue des Croix de Guerre.\", \"nl\": \"Tot zomer 2024, werken. Bus 56 omgeleid tussen VAN PRAET en PETER BENOIT via Oorlogskruisenlaan.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"56\"}]",
+        "priority": 5,
+        "points": "[{\"id\": \"2098\"}, {\"id\": \"3451\"}, {\"id\": \"6190\"}, {\"id\": \"9296\"}, {\"id\": \"2051\"}, {\"id\": \"6082\"}, {\"id\": \"2898\"}, {\"id\": \"2106\"}, {\"id\": \"1006\"}, {\"id\": \"2367\"}, {\"id\": \"3412\"}, {\"id\": \"2101\"}, {\"id\": \"6459\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Until Summer of 2024, works. Stop not served. Stop of bus 56: place Peter Benoitplein 3\", \"fr\": \"Jusqu'\u00e0 l'\u00e9t\u00e9 2024, travaux. Arr\u00eat non desservi. Arr\u00eat du bus 56 : place Peter Benoit 3\", \"nl\": \"Tot zomer 2024, werken. Halte niet bediend. Halte van bus 56: Peter Benoitplein 3\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"56\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"1987\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Until Summer of 2024, works. As of March 18, buses 56 and 57 serve this stop normally.\", \"fr\": \"Jusqu'\u00e0 l'\u00e9t\u00e9 2024, travaux. D\u00e8s le 18/3, les bus 56 et 57 desservent \u00e0 nouveau cet arr\u00eat.\", \"nl\": \"Tot zomer 2024, werken. Vanaf 18/3 bedienen bus 56 en 57 opnieuw deze halte.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"56\"}]",
+        "priority": 5,
+        "points": "[{\"id\": \"2829B\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. As of Apr 15, bus 56 diverted. Take bus 56 at the stop of bus 64 to BORDET STATION.\", \"fr\": \"Travaux. D\u00e8s le 15/4, bus 56 d\u00e9vi\u00e9. Prenez le bus 56 \u00e0 l'arr\u00eat du bus 64 vers BORDET STATION.\", \"nl\": \"Werken. Vanaf 15/4, bus 56 omgeleid. Neem bus 56 aan de halte van bus 64 naar BORDET STATION.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"56\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"2068\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Until Summer of 2024, works. Stop not served. Stop of bus 57: chauss\u00e9e de Vilvorde, next to ropery Barrois\", \"fr\": \"Jsq \u00e9t\u00e9 2024, travaux. Arr\u00eat non desservi. Arr\u00eat du bus 57: ch\u00e9e de Vilvorde, le long de la corderie Barrois\", \"nl\": \"Tot zomer 2024, werken. Halte niet bediend. Halte B57: Vilvoordsestwg, naast de touwslagerij Barrois\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"57\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"3003\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Until Summer of 2024, works. Stop not served. Take bus 47 or 57 at ANTOON VAN OSS (stop of bus 56 to BUDA).\", \"fr\": \"Jsq \u00e9t\u00e9 2024, travaux. Arr\u00eat non desservi. Prenez le bus 47 ou 57 \u00e0 ANTOON VAN OSS (arr\u00eat du bus 56 vers BUDA).\", \"nl\": \"Tot zomer 2024, werken. Halte niet bediend. Neem bus 47 of 57 aan ANTOON VAN OSS (halte van bus 56 naar BUDA).\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"57\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"1837\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Until Summer of 2024, works. Stop not served. Stop of bus 57: MARLY (moved to ch. Vilvorde, next to number 150)\", \"fr\": \"Jsq \u00e9t\u00e9 2024, travaux. Arr\u00eat non desservi.Arr\u00eat du bus 57: MARLY (d\u00e9plac\u00e9 ch. Vilvorde, en face du num\u00e9ro 150)\", \"nl\": \"Tot zomer 2024, werken. Halte niet bediend. Halte van bus 57:MARLY (verplaatst Vilvoordsest tegenover nr. 150)\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"57\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"2315\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Until Summer 2024,works. B57 divtd btw MARLY and ANT VAN OSS. As of Oct 16, B57 divtd btw MARLY and HOP. MILITAIRE\", \"fr\": \"Jsq \u00e9t\u00e9 2024, travaux. Bus 57 d\u00e9vi\u00e9 entre MARLY et ANT VAN OSS. D\u00e8s le 16/10, B57 d\u00e9vi\u00e9 entre MARLY et HOP MILITAIRE.\", \"nl\": \"Tot zomer 2024, werken. Bus 57 omgeleid ts MARLY en ANT VAN OSS. Vanaf 16/10, B57 omgeleid tss MARLY en MILITAIR HOSP.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"57\"}]",
+        "priority": 5,
+        "points": "[{\"id\": \"1090\"}, {\"id\": \"2327\"}, {\"id\": \"2305\"}, {\"id\": \"2326\"}, {\"id\": \"1356\"}, {\"id\": \"3058\"}, {\"id\": \"1052\"}, {\"id\": \"1051\"}, {\"id\": \"2308\"}, {\"id\": \"2868\"}, {\"id\": \"3061\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Until Summer of 2024, works. Stop not served. Take bus 57 at ANTOON VAN OSS (stop of bus 56 to SCHUMAN).\", \"fr\": \"Jsq \u00e9t\u00e9 2024, travaux. Arr\u00eat non desservi. Prenez le bus 57 \u00e0 ANTOON VAN OSS (arr\u00eat du bus 56 vers SCHUMAN).\", \"nl\": \"Tot zomer 2024, werken. Halte niet bediend. Neem bus 57 aan ANTOON VAN OSS (halte van bus 56 naar SCHUMAN).\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"57\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"2316\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Until Summer of 2024, works. Stop not served. Take bus 57 at ANTOON VAN OSS (stop of bus 56 to BUDA).\", \"fr\": \"Jsq \u00e9t\u00e9 2024, travaux. Arr\u00eat non desservi. Prenez le bus 57 \u00e0 ANTOON VAN OSS (arr\u00eat du bus 56 vers BUDA).\", \"nl\": \"Tot zomer 2024, werken. Halte niet bediend. Neem bus 57 aan ANTOON VAN OSS (halte van bus 56 naar BUDA).\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"57\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"2359\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Feb 8, works. STOP NOT SERVED. Temporary stop: Place de Houffalizeplein 2-6.\", \"fr\": \"D\u00e8s le 8/2, travaux. ARRET NON DESSERVI. Arr\u00eat provisoire: Place de Houffalize 2-6.\", \"nl\": \"Vanaf 8/2, werken. HALTE NIET BEDIEND. Tijdelijke halte: Houffalizeplein 2-6.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"59\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"3110\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From May 2 at 7AM, works. STOP NOT SERVED. Take bus 60 at the stop BLYCKAERTS of bus 38 to HEROS / HELDEN.\", \"fr\": \"D\u00e8s le 2/5 \u00e0 7h, travaux. ARRET NON DESSERVI. Prenez le bus 60 \u00e0 l'arr\u00eat BLYCKAERTS du bus 38 vers HEROS.\", \"nl\": \"Vanaf 2/5 om 7u, werken. HALTE NIET BEDIEND. Neem bus 60 aan de halte BLYCKAERTS van bus 38 naar HELDEN.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"60\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"1881\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Mar 11, works. Bus 60 diverted. Temporary stop: chauss\u00e9e de Saint- Job/Sint-Jobsesteenweg, in front of nr. 390.\", \"fr\": \"D\u00e8s le 11/3, travaux. Bus 60 d\u00e9vi\u00e9. Arr\u00eat provisoire: chauss\u00e9e de Saint-Job, face au num\u00e9ro 390.\", \"nl\": \"Vanaf 11/3, werken. Bus 60 omgeleid. Tijdelijke halte: Sint-Jobsesteenweg, tegenover nr. 390.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"60\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"1738\"}, {\"id\": \"2705\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. As of Apr 15, STOP NOT SERVED. Walk to AMBIORIX.\", \"fr\": \"Travaux. D\u00e8s le 15/4, ARRET NON DESSERVI. Pour rejoindre AMBIORIX, continuez \u00e0 pied.\", \"nl\": \"Werken. Vanaf 15/4, HALTE NIET BEDIEND. Ga te voet verder om naar AMBIORIX te gaan.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"60\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"1418B\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Mar 11, works. Bus 60 diverted. Temporary stop: chauss\u00e9e de Saint- Job/Sint-Jobsesteenweg 265.\", \"fr\": \"D\u00e8s le 11/3, travaux. Bus 60 d\u00e9vi\u00e9. Arr\u00eat provisoire: chauss\u00e9e de Saint-Job 265.\", \"nl\": \"Vanaf 11/3, werken. Bus 60 omgeleid. Tijdelijke halte: Sint-Jobsesteenweg 265.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"60\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"2704\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. As of April 7th, stop served only by bus 66. Take bus 29, 63 or 65 at the stop of bus 71 to DELTA.\", \"fr\": \"Travaux. D\u00e8s le 7/4, arr\u00eat uniquement desservi par bus 66. Bus 29, 63 ou 65 \u00e0 l'arr\u00eat du bus 71 vers DELTA.\", \"nl\": \"Werken. Vanaf 7/4, halte enkel bediend door bus 66. Neem bus 29, 63 of 65 aan de halte van bus 71 naar DELTA.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"63\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"6445\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Risk of subsidence. Stop of bus 65, 66 and N04 moved to chauss\u00e9e de Haecht/Haachtsesteenweg, next to number 162\", \"fr\": \"Risque d'effondrement. Arr\u00eat des bus 65, 66 et N04 d\u00e9plac\u00e9 chauss\u00e9e de Haecht, \u00e0 hauteur du num\u00e9ro 162.\", \"nl\": \"Risico op instorting. Halte van bus 65, 66 en N04 verplaatst naar de Haachtsesteenweg, ter hoogte van nummer 162.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"65\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"6418\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Jan 7, 9PM-Jun 28,works. Tram 3 and 7 replaced by T-bus to DOCKS BRUXSEL. T-bus at this stop.\", \"fr\": \"7/1, 21h-28/6, travaux. Tram 3 et 7 remplac\u00e9s par des T-bus jusqu'\u00e0 DOCKS BRUXSEL. T-bus \u00e0 cet arr\u00eat.\", \"nl\": \"7/1, 21u-28/6, werken. Tram 3 en 7 vervangen door T-bus tot DOCKS BRUXSEL. T-bus aan deze halte.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"7\"}]",
+        "priority": 5,
+        "points": "[{\"id\": \"5707\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Jan 8-Jun 28, works. Tram 7 interrupted btw HEEMBEEK and DOCKS BXL. T-bus to DOCKS BXL at stop of B83 to VAL MARIA\", \"fr\": \"8/1-28/6, travaux. T7 interrompu de HEEMBEEK \u00e0 DOCKS BXL. T-bus vers DOCKS BXL \u00e0 l'arr\u00eat du B83 vers VAL MARIA.\", \"nl\": \"8/1-28/6, werken. T7 onderbroken tss HEEMBEEK en DOCKS BRUXSEL. T-bus naar DOCKS BRUXSEL aan halte B83 naar MARI\u00cbND.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"7\"}]",
+        "priority": 5,
+        "points": "[{\"id\": \"5700G\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Jan 7, 9PM-Jun 28, works. Stop not served. To continue to HEYSEL / HEIZEL, take tram 3 direction CHURCHILL.\", \"fr\": \"7/1, 21h-28/6, travaux. Arr\u00eat non desservi. Pour continuer vers HEYSEL, prenez le tram 3 direction CHURCHILL.\", \"nl\": \"7/1, 21u-28/6, werken. Halte niet bediend. Om naar HEIZEL te reizen, neem tram 3 richting CHURCHILL.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"7\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"6421F\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. As of April 7th, STOP NOT SERVED. To go to DE BROUCKERE, take metro lines 1 or 5.\", \"fr\": \"Travaux. D\u00e8s le 7/4, ARRET NON DESSERVI. Pour rejoindre DE BROUCKERE, prenez le m\u00e9tro 1 ou 5.\", \"nl\": \"Werken. Vanaf 7/4, HALTE NIET BEDIEND. Om naar DE BROUCKERE te gaan, neem metrolijn 1 of 5.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"71\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"6447\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Mar 18, works. STOP NOT SERVED. Temporary stop: avenue de la Couronne / Kroonlaan 439-443.\", \"fr\": \"D\u00e8s le 18/3, travaux. ARRET NON DESSERVI. Arr\u00eat provisoire: avenue de la Couronne 439-443.\", \"nl\": \"Vanaf 18/3, werken. HALTE NIET BEDIEND. Tijdelijke halte: Kroonlaan 439-443.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"71\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"3558\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Mar 18, works. STOP NOT SERVED. stop of bus 72: avenue de l'Universit\u00e9 / Hogeschoollaan 4-10.\", \"fr\": \"D\u00e8s le 18/3, travaux. ARRET NON DESSERVI. Arr\u00eat du bus 72: avenue de l'Universit\u00e9 4-10.\", \"nl\": \"Vanaf 18/3, werken. HALTE NIET BEDIEND. Halte van bus 72: Hogeschoollaan 4-10.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"72\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"3514\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works.From May 10 at 10PM to May 12, STOP NOT SERVED. Take bus 73 at VETERINAIRES.\", \"fr\": \"Travaux. Du 10/5 \u00e0 22h au 12/5, ARRET NON DESSERVI. Prenez le bus 73 \u00e0 VETERINAIRES.\", \"nl\": \"Werken. 10/5, 22u - 12/5, HALTE NIET BEDIEND. Neem bus 73 aan VEEARTSEN.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"73\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"3800\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Subsidence. Bus 74 limited to DECROLY. Take bus 74 at DECROLY.\", \"fr\": \"Effondrement. Bus 74 limit\u00e9 \u00e0 DECROLY. Prenez le bus 74 \u00e0 DECROLY.\", \"nl\": \"Wegverzakking. Bus 74 beperkt tot DECROLY. Neem bus 74 aan DECROLY.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"74\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"2452\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Subsidence. Bus 74 limited to DECROLY. Walk to UCCLE-STALLE / UKKEL-STALLE.\", \"fr\": \"Effondrement. Bus 74 limit\u00e9 \u00e0 DECROLY. Continuez \u00e0 pied jusqu'\u00e0 UCCLE STALLE.\", \"nl\": \"Wegverzakking. Bus 74 beperkt tot DECROLY. Ga te voet tot UKKEL-STALLE.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"74\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"2416\"}, {\"id\": \"2415\"}, {\"id\": \"2414\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Apr 2, 2024 to June 2025, works. STOP NOT SERVED. Stop of bus 74: chauss\u00e9e de Bruxelles / Brusselsesteenweg 84.\", \"fr\": \"Du 2/4/2024 \u00e0 juin 2025, travaux. ARRET NON DESSERVI. Arr\u00eat du bus 74: chauss\u00e9e de Bruxelles 84.\", \"nl\": \"Van 2/4/2024 tot juni 2025, werken. HALTE NIET BEDIEND. Halte van bus 74: Brusselsesteenweg 84.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"74\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"5152\"}, {\"id\": \"5161\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Subsidence. Bus 74 limited to DECROLY. Walk from DECROLY to UCCLE-STALLE / UKKEL-STALLE.\", \"fr\": \"Effondrement. Bus 74 limit\u00e9 \u00e0 DECROLY. Continuez \u00e0 pied depuis DECROLY jusqu'\u00e0 UCCLE STALLE.\", \"nl\": \"Wegverzakking. Bus 74 beperkt tot DECROLY. Ga te voet van DECROLY tot UKKEL-STALLE.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"74\"}]",
+        "priority": 5,
+        "points": "[{\"id\": \"3682\"}, {\"id\": \"3074\"}, {\"id\": \"5915\"}, {\"id\": \"2614\"}, {\"id\": \"2602\"}, {\"id\": \"2601\"}, {\"id\": \"2600\"}, {\"id\": \"2226\"}, {\"id\": \"2523\"}, {\"id\": \"2555\"}, {\"id\": \"2599\"}, {\"id\": \"1015\"}, {\"id\": \"2598\"}, {\"id\": \"2607\"}, {\"id\": \"2606\"}, {\"id\": \"2605\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Until 2026, works. Stop not served. Stop of the T-bus: rue de la Soierie / Zijdeweverijstraat 4.\", \"fr\": \"Jusqu'en 2026, travaux. Arr\u00eat non desservi. Arr\u00eat du T-bus: rue de la Soierie 4.\", \"nl\": \"Tot 2026, werken. Halte niet bediend. Halte van de T-bus: Zijdeweverijstraat 4.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"82\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"5154F\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Until 2026, works. Tram 82 replaced by T-bus to FOREST CENTRE. T-bus at this stop.\", \"fr\": \"Jusqu'en 2026, travaux. Tram 82 remplac\u00e9 par des T-bus jusqu'\u00e0 FOREST CENTRE. T-bus \u00e0 cet arr\u00eat.\", \"nl\": \"Tot 2026, werken. Tram 82 vervangen door T-bus tot VORST CENTRUM. T-bus aan deze halte.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"82\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"5756F\"}, {\"id\": \"1258G\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Until 2026, works. Tram 82 interrupted. Take tram 82 at the stop in the other direction.\", \"fr\": \"Jusqu'en 2026, travaux. Tram 82 interrompu. Prenez le tram 82 \u00e0 l'arr\u00eat dans l'autre sens.\", \"nl\": \"Tot 2026, werken. Tram 82 onderbroken. Neem tram 82 aan de halte in de andere richting.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"82\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"5161F\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. Until 2026, tram 82 replaced by T-bus btw FOREST CENTRE / VORST CENTRUM and DROGENBOS. T-bus at this stop.\", \"fr\": \"Travaux. Jusqu'en 2026, tram 82 remplac\u00e9 par des T-bus entre FOREST CENTRE et DROGENBOS. T-bus \u00e0 cet arr\u00eat.\", \"nl\": \"Werken. Tot 2026, tram 82 vervangen door T-bus tussen VORST CENTRUM en DROGENBOS. T-bus aan deze halte.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"82\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"5722F\"}, {\"id\": \"5723G\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. Until 2026, tram 82 replaced by T-bus between DROGENBOS and FOREST CENTRE / VORST CENTRUM.\", \"fr\": \"Travaux. Jusqu'en 2026, tram 82 remplac\u00e9 par des T-bus entre DROGENBOS et FOREST CENTRE. T-bus \u00e0 cet arr\u00eat.\", \"nl\": \"Werken. Tot 2026, tram 82 vervangen door T-bus tussen DROGENBOS en VORST CENTRUM. T-bus aan deze halte.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"82\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"5753F\"}, {\"id\": \"5751\"}, {\"id\": \"5754\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Until 2026, works. Tram 82 interrupted. T-bus to DROGENBOS at the stop of bus 54 to TRONE/TROON.\", \"fr\": \"Jusqu'en 2026, travaux. Tram 82 interrompu. T-bus vers DROGENBOS \u00e0 l'arr\u00eat du bus 54 vers TRONE.\", \"nl\": \"Tot 2026, werken. Tram 82 onderbroken. T-bus naar DROGENBOS aan de halte van bus 54 naar TROON.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"82\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"5121F\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. Until 2026, stop not served. Stop of T-bus 82 and of bus 50: rue de la Soierie / Zijdeweverijstraat 9.\", \"fr\": \"Travaux. Jusqu'en 2026, arr\u00eat non desservi. Arr\u00eat du T-bus 82 et du bus 50 : rue de la Soierie 9.\", \"nl\": \"Werken. Tot 2026, halte niet bediend. Halte van T-bus 82 en van bus 50: Zijdeweverijstraat 9.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"82\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"5156F\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Until 2026, works. Tram 82 replaced by T-bus between FOREST CENTRE / VORST CENTRUM and DROGENBOS.\", \"fr\": \"Jusqu'en 2026, travaux. Tram 82 remplac\u00e9 par des T-bus entre FOREST CENTRE et DROGENBOS. Info: stib.brussels.\", \"nl\": \"Tot 2026, werken. Tram 82 vervangen door T-bus tussen VORST CENTRUM en DROGENBOS. Info: mivb. brussels.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"82\"}]",
+        "priority": 5,
+        "points": "[{\"id\": \"2603\"}, {\"id\": \"5718\"}, {\"id\": \"0631\"}, {\"id\": \"5120\"}, {\"id\": \"2539F\"}, {\"id\": \"5123\"}, {\"id\": \"2548F\"}, {\"id\": \"2604F\"}, {\"id\": \"2544F\"}, {\"id\": \"5119\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Jan 22 at 6AM to end of June, works. Bus 86 diverted. B86 at the stop RIBAUCOURT of bus 20 to GARE DU NORD.\", \"fr\": \"Du 22/1 \u00e0 6h jusqu'\u00e0 fin juin, travaux. Bus 86 d\u00e9vi\u00e9. Bus 86 \u00e0 l'arr\u00eat RIBAUCOURT du bus 20 vers GARE DU NORD.\", \"nl\": \"Van 22/1 om 6u tot eind juni, werken. Bus 86 omgeleid. Bus 86 aan de halte RIBAUCOURT van bus 20 naar NOORDSTATION.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"86\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"4253\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Jan 22 at 6AM to end of June, works. Bus 86 diverted. Take the bus at the previous stop GARE DE L'OUEST.\", \"fr\": \"Du 22/1 \u00e0 6h jusqu'\u00e0 fin juin, travaux. Bus 86 d\u00e9vi\u00e9. Prenez le bus \u00e0 l'arr\u00eat pr\u00e9c\u00e9dent GARE DE  L'OUEST.\", \"nl\": \"Van 22/1 om 6u tot eind juni, werken. Bus 86 omgeleid. Neem de bus aan vorige halte WESTSTATION.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"86\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"3257\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. From Apr 23 until Jun 2, bus 13 and 88 diverted. Take bus 13 or 88 at the stop of bus 820 to UZ Brussel.\", \"fr\": \"Travaux; Du 23/4 au 2/6, bus 13 et 88 d\u00e9vi\u00e9s. Prenez le bus 13 ou 88 \u00e0 l'arr\u00eat du bus 820 vers UZ Brussel.\", \"nl\": \"Werken. Van 23/4 tot en met 2/6, bus 13 en 88 omgeleid. Neem bus 13 of 88 aan de halte van bus 820 naar UZ Brussel.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"88\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"1721\"}, {\"id\": \"1328\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Feb 2 7AM, works. STOP NOT SERVED. Temporary halte: Boulevard Emile Jacqmainlaan 82-94.\", \"fr\": \"D\u00e8s le 8/2 7h, travaux. ARRET NON DESSERVI. Arr\u00eat provisoire: Boulevard Emile Jacqmain 82-94.\", \"nl\": \"Vanaf 8/2 7u, werken. HALTE NIET BEDIEND. Tijdelijke halte: Emile Jacqmainlaan 82-94.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"88\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"2070\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Until end of August, works. Bus 89 diverted. To continue to CENTRAL STATION, take bus 29 71\", \"fr\": \"Jusque fin ao\u00fbt, travaux. Bus 89 d\u00e9vi\u00e9. Pour continuer vers GARE CENTRALE, prenez le bus 29 ou 71.\", \"nl\": \"Tot einde augustus, werken. Bus 89 omgeleid. Om verder naar CENTRAAL STATION te reizen, neem bus 29 of 71.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"89\"}]",
+        "priority": 5,
+        "points": "[{\"id\": \"1820\"}, {\"id\": \"2296\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. As of Apr 22 at 9.30AM, bus 89 diverted. Stop of bus 89: rue des Quatre-Vents / Vier Windenstraat 141\", \"fr\": \"Travaux. D\u00e8s le 22/4 \u00e0 9h30, bus 89 d\u00e9vi\u00e9. Arr\u00eat du bus 89: rue des Quatre-Vents, 141.\", \"nl\": \"Werken. Vanaf 22/4 om 9. 30u, bus 89 omgeleid. Halte van bus 89: Vier Windenstraat 141\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"89\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"4594\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Until end of August, works. Bus 89 diverted. For the city center, take metro 1 or 5 at COMTE DE FLANDRE.\", \"fr\": \"Jusque fin ao\u00fbt, travaux. Bus 89 d\u00e9vi\u00e9. Pour le centre-ville, prenez le m\u00e9tro 1 ou 5 \u00e0 COMTE DE FLANDRE.\", \"nl\": \"Tot einde augustus, werken. Bus 89 omgeleid. Om naar het stadscentrum te gaan, neem M 1 5 aan GRAAF VAN VLAANDEREN.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"89\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"3259C\"}, {\"id\": \"3260\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. As of Apr 22 at 9.30AM, bus 89 diverted. Stop of bus 89: rue Delaunoystraat 15.\", \"fr\": \"Travaux. D\u00e8s le 22/4 \u00e0 9h30, bus 89 d\u00e9vi\u00e9. Arr\u00eat du bus 89: rue Delaunoy, 15.\", \"nl\": \"Werken. Vanaf 22/4 om 9. 30u, bus 89 omgeleid. Halte van bus 89: Delaunoystraat 15.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"89\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"3228\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. From Apr 26 at 9PM until May 12, stop not served. T-bus to ROI BAUDOUIN at the stop of bus 13 to ETANGS NOIRS.\", \"fr\": \"Travaux. Du 26/4 \u00e0 21h au 12/5, arr\u00eat non desservi. T-bus vers ROI BAUDOUIN \u00e0 l'arr\u00eat du bus 13 vers ETANGS NOIRS\", \"nl\": \"Werken. 26/4, 21u-12/5, halte niet bediend.T-bus naar KONING BOUDEWIJN aan de halte van bus 13 naar ZWARTE VIJVERS.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"9\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"1683F\"}, {\"id\": \"1685F\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. From May 8 at 9PM until May 12, T-bus 19 does not serve HOP. BRUGMANN. Connection to T-bus 19 at CIM. JETTE.\", \"fr\": \"Travaux. 8/5, 21h-12/5, T-bus 19 ne dessert pas HOPITAL BRUGMANN. Correspondance T-bus 19 \u00e0 CIMETIERE DE JETTE.\", \"nl\": \"8/5, 21u-12/5, werken. T-bus 19 bedient BRUGMANN-ZKH. niet. Aansluiting met T-bus 19 aan KERKHOF VAN JETTE.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"93\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"5400\"}, {\"id\": \"5402\"}, {\"id\": \"5399F\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"As of September 21, works. Stop moved to av. de la Fauconnerie / Valkerijlaan, next to number 53a.\", \"fr\": \"D\u00e8s le 21/9, travaux. Arr\u00eat d\u00e9plac\u00e9 avenue de la Fauconnerie, \u00e0 hauteur du num\u00e9ro 53a.\", \"nl\": \"Vanaf 21/9, werken. Halte verplaatst naar de Valkerijlaan, ter hoogte van huisnummer 53a.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"95\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"4314\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Mar 25 until Jun 30, works. Bus 95 diverted btw CIMETIERE D'IXELLES and ETTERBEEK GARE\", \"fr\": \"Du 25/3 au 30/6, travaux. Bus 95 d\u00e9vi\u00e9 entre CIMETIERE D'IXELLES et  ETTERBEEK GARE.\", \"nl\": \"Van 25/3 tot en met 30/6, werken. Bus 95 omgeleid tussen BEGRAAFPLAATS VAN ELSENE en ETTERBEEK STATION.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"95\"}]",
+        "priority": 5,
+        "points": "[{\"id\": \"4360\"}, {\"id\": \"4351\"}, {\"id\": \"1455\"}, {\"id\": \"4355\"}, {\"id\": \"4357\"}, {\"id\": \"4358\"}, {\"id\": \"4359\"}, {\"id\": \"4348\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Mar 25-Jun 30, works. STOP NOT SERVED. Stop of bus 95: CIMETIERE D'IXELLES / BEGR. VAN ELSENE.\", \"fr\": \"25/3-30/6,travaux. ARRET NON DESSERVI. Arr\u00eat du bus 95: CIM. D'IXELLES (ch\u00e9e de Boondael, avant le rond-point).\", \"nl\": \"25/3-30/6, werken. HALTE NIET BEDIEND. Halte van bus 95: BEGR. VAN ELSENE (Boondaalsestwg, voor de rotonde)\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"95\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"4362\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. As of Mar 27, STOP MOVED. Stop of bus 95: rue des Thuyas / Thujastraat 5.\", \"fr\": \"Travaux. D\u00e8s le 27/3, ARRET DEPLACE. Arr\u00eat du bus 95: rue des Thuyas, 5.\", \"nl\": \"Werken. Vanaf 27/3, HALTE VERPLAATST. Halte van bus 95: Thujastraat 5.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"95\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"4310\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Mar 25 until Jun 30, works. STOP NOT SERVED. Stop of bus 95: av. Couronne / Kroonln, in front of number 384\", \"fr\": \"Du 25/3 au 30/6, travaux. ARRET NON DESSERVI. Arr\u00eat du bus 95: av. de la Couronne, en face du num\u00e9ro 384.\", \"nl\": \"Van 25/3 tot en met 30/6, werken. HALTE NIET BEDIEND. Halte van bus 95: Kroonlaan, tegenover nummer 384\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"95\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"4306\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Until 2026, works. As of Mar 11, T97 interrupted btw DIEWEG and WIELS. Take T4 to CARR. STALLE, and then the T-bus.\", \"fr\": \"Jsq 2026,travaux. D\u00e8s le 11/3, T97 interrompu entre DIEWEG et WIELS. T4 jsq CARREFOUR STALLE, et ensuite le T-bus.\", \"nl\": \"Tot 2026,werken. Vanaf 11/3, T97 onderbroken tss DIEWEG en WIELS. Neem T4 tot KRUISPUNT STALLE, en de T-bus.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"97\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"2708G\"}, {\"id\": \"5952F\"}, {\"id\": \"2709F\"}, {\"id\": \"2710G\"}, {\"id\": \"1984G\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Until 2026, works. Tram 97 interrupted to WIELS. Stop of the T-bus to ROCHEFORT: r. Abbesses / Abdissenstr.\", \"fr\": \"Jusqu'en 2026, travaux. Tram 97 interrompu jusqu'\u00e0 WIELS. Arr\u00eat du T-bus vers ROCHEFORT: rue des Abbesses.\", \"nl\": \"Tot 2026, werken. Tram 97 onderbroken tot WIELS. Halte van de T-bus naar ROCHEFORT: Abdissenstraat.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"97\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"5152G\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Until 2026, works. T-bus 82/97 diverted. Stop T-bus 82/97: bd 2e Arm\u00e9e Britannique / Britse Tweedelegerlaan.\", \"fr\": \"Jsq 2026, travaux. T-bus 82/97 d\u00e9vi\u00e9. Arr\u00eat T-bus 82/97: bd 2e Arm\u00e9e Britannique, carrefour rue de la Station.\", \"nl\": \"Tot 2026, werken. T-bus 82/97 omgeleid. Halte T-bus 82/97: Britse Tweedelegerlaan, kruispunt Stationstraat.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"97\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"5719H\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From May 18, 5AM, works. STOP NOT SERVED. Stop of tram 97: avenue du Parc / Parklaan 26, in front of number 26.\", \"fr\": \"D\u00e8s le 18/5, 5h, travaux. ARRET NON DESSERVI. Arr\u00eat du tram 97: avenue du Parc, en face du num\u00e9ro 26.\", \"nl\": \"Vanaf 18/5, 5u, werken. HALTE NIET BEDIEND. Halte van tram 97: Parklaan, tegenover nummer 26.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"97\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"2334F\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Until 2026, works. Tram 97 interrupted to WIELS. Stop of the T-bus to ROCHEFORT: ch. Neerstalsestwg 236\", \"fr\": \"Jsq 2026, travaux. Tram 97 interrompu jsq WIELS. Arr\u00eat du T-bus vers ROCHEFORT: chauss\u00e9e de Neerstalle, 236\", \"nl\": \"Tot 2026, werken. Tram 97 onderbroken tot WIELS. Halte van de T-bus naar ROCHEFORT: Neerstalsesteenweg,236\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"97\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"5164F\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Until 2026, works. Tram 97 interrupted between CARREFOUR STALLE en WIELS. T-bus to ROCHEFORT at this stop.\", \"fr\": \"Jusqu'en 2026, travaux. Tram 97 interrompu entre CARREFOUR STALLE et WIELS. T-bus vers ROCHEFORT \u00e0 cet arr\u00eat.\", \"nl\": \"Tot 2026, werken. T97 onderbroken tussen KRUISPT STALLE en WIELS. T-bus naar ROCHEFORT aan deze halte.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"97\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"5756F\"}, {\"id\": \"1258G\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Until 2026, works. T97 interrupted to WIELS. T97 at WIELS via T82, or at ROCHEFORT via T-bus (stop: r. Abbesses)\", \"fr\": \"Jsq 2026, travaux. T97 interrompu jsq WIELS. T97 \u00e0 WIELS via T82, ou \u00e0 ROCHEFORT via T-bus (arr\u00eat: r. Abbesses).\", \"nl\": \"Tot 2026, werken. T97 onderbroken tot WIELS. T97 aan WIELS via T82, of aan ROCHEFORT via T-bus, halte: Abdissenst\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"97\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"5161F\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Jan 15, works. STOP NOT SERVED. Take Noctis N09 at the stop CLESSE of bus 72 to ADEPS.\", \"fr\": \"D\u00e8s le 15/1, travaux. ARRET NON DESSERVI. Prenez le Noctis N09 \u00e0 l'arr\u00eat CLESSE du bus 72 vers ADEPS.\", \"nl\": \"Vanaf 15/1, werken. HALTE NIET BEDIEND. Neem Noctis N09 aan de halte CLESSE van bus 72 naar ADEPS.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"N09\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"1719\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Jan 15, works. STOP NOT SERVED. Noctis N09 at the stop      RO(O) DENBERG of bus 72 to ADEPS.\", \"fr\": \"D\u00e8s le 15/1, travaux. ARRET NON DESSERVI. Prenez le Noctis N09 \u00e0 l'arr\u00eat ROODENBERG du bus 72 vers ADEPS.\", \"nl\": \"Vanaf 15/1, werken. HALTE NIET BEDIEND. Neem Noctis N09 aan de halte RODENBERG van bus 72 naar ADEPS.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"N09\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"1720B\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Mar 18, works. STOP NOT SERVED. stop of N09: chauss\u00e9e de Boondael / Boondaalsesteenweg, before roundabout.\", \"fr\": \"D\u00e8s le 18/3, travaux. ARRET NON DESSERVI. Arr\u00eat du bus N09: chauss\u00e9e de Boondael, avant le rond-point.\", \"nl\": \"Vanaf 18/3, werken. HALTE NIET BEDIEND. Halte van bus N09: Boondaalsesteenweg, voor rondpunt.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"N09\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"3514\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Mar 18, works. STOP NOT SERVED. stop of bus N09: avenue de l'Universit\u00e9 / Hogeschoollaan 4-10.\", \"fr\": \"D\u00e8s le 18/3, travaux. ARRET NON DESSERVI. Arr\u00eat du bus N09: avenue de l'Universit\u00e9 4-10.\", \"nl\": \"Vanaf 18/3, werken. HALTE NIET BEDIEND. Halte van bus N09: Hogeschoollaan 4-10.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"N09\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"3558\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Feb 15, subsidence. N10 diverted between LEPOUTRE and FLAGEY.\", \"fr\": \"D\u00e8s le 15/2, effondrement. N10 d\u00e9vi\u00e9 entre LEPOUTRE et FLAGEY.\", \"nl\": \"Vanaf 15/2, wegverzakking. N10 omgeleid tussen LEPOUTRE en FLAGEY.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"N10\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"2133\"}, {\"id\": \"5053B\"}, {\"id\": \"2132\"}, {\"id\": \"2131\"}, {\"id\": \"1250\"}, {\"id\": \"4857B\"}, {\"id\": \"4804B\"}, {\"id\": \"2150\"}, {\"id\": \"6956B\"}, {\"id\": \"2002\"}, {\"id\": \"2134\"}, {\"id\": \"6406\"}, {\"id\": \"2847\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Feb 15, subsidence. N10 diverted. Temporary stop: place Albert Leemansplein 6.\", \"fr\": \"D\u00e8s le 15/2, effondrement. N10 d\u00e9vi\u00e9. Arr\u00eat provisoire: place Albert Leemans 6.\", \"nl\": \"Vanaf 15/2, wegverzakking. N10 omgeleid. Tijdelijke halte: Albert Leemansplein 6.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"N10\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"4705\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. STOP NOT SERVED. Stop of bus N18: rue de Laeken / Lakensestraat 57-59.\", \"fr\": \"Travaux. ARRET NON DESSERVI. Arr\u00eat du bus N18: rue de Laeken 57-59.\", \"nl\": \"Werken. HALTE NIET BEDIEND. Halte van bus N18: Lakensestraat 57-59.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"N18\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"3465\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works.From May 8 at 9PM until May 12, STOP NOT SERVED. T-bus to SIMONIS at CIM. / KERKH. JETTE, via tram 51 or 93.\", \"fr\": \"Travaux. Du 8/5 \u00e0 21h au 12/5, ARRET NON DESSERVI. T-bus vers SIMONIS \u00e0 CIM. DE JETTE, via tram 51 ou 93.\", \"nl\": \"Werken. Van 8/5 om 21u tot 12/5, HALTE NIET BEDIEND. T-bus naar SIMONIS aan KERKHOF VAN JETTE, via tram 51 of 93\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"T19\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"2802\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Until 2026, works. Bus 50 and T-bus diverted between FOREST CENTRE / VORST CENTRUM and BEMPT.\", \"fr\": \"Jusqu'en 2026, travaux. Bus 50 et T-bus d\u00e9vi\u00e9s entre FOREST CENTRE et BEMPT.\", \"nl\": \"Tot 2026, werken. Bus 50 en T-bus omgeleid tussen VORST CENTRUM en BEMPT.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"T82\"}]",
+        "priority": 5,
+        "points": "[{\"id\": \"3196\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Until 2026, works. T-bus 82/97 diverted between BEMPT and FOREST CENTRE/VORST CENTRUM.\", \"fr\": \"Jusqu'en 2026, travaux. T-bus 82/97 d\u00e9vi\u00e9 entre BEMPT et FOREST CENTRE.\", \"nl\": \"Tot 2026, werken. Bus T-bus 82/97 omgeleid tussen BEMPT en VORST CENTRUM.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"T82\"}]",
+        "priority": 5,
+        "points": "[{\"id\": \"3405\"}, {\"id\": \"7472\"}, {\"id\": \"7474\"}, {\"id\": \"7465\"}, {\"id\": \"3255\"}, {\"id\": \"5755\"}, {\"id\": \"5756\"}]"
+    }
+]

--- a/storage/app/samples/2024-05-16-travellers-information-rt-production.json
+++ b/storage/app/samples/2024-05-16-travellers-information-rt-production.json
@@ -1,1 +1,2452 @@
-[{"content": "[{\"text\": [{\"en\": \"Works. As of Apr 15, B12 diverted btw LUXEMBOURG and MEISER via MAELBEEK. Stop SCHUMAN moved rue Archim\u00e8destr. 16.\", \"fr\": \"Travaux. D\u00e8s le 15/4,B12 d\u00e9vi\u00e9 entre LUXEMBOURG et MEISER via MAELBEEK. Arr\u00eat SCHUMAN d\u00e9plac\u00e9 rue Archim\u00e8de 16.\", \"nl\": \"Werken. Vanaf 15/4, bus 12 omgeleid ts LUXEMBURG en MEISER via MAALBEEK. Halte SCHUMAN verplaatst Archimedesstraat 16.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"12\"}]", "priority": 6, "points": "[{\"id\": \"6433\"}, {\"id\": \"1780\"}, {\"id\": \"1131B\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. As of Apr 15, STOP NOT SERVED. Stop of bus 12: rue Franklinstraat 2a.\", \"fr\": \"Travaux. D\u00e8s le 15/4, ARRET NON DESSERVI. Arr\u00eat du bus 12: rue Franklin, 2a.\", \"nl\": \"Werken. Vanaf 15/4, HALTE NIET BEDIEND. Halte van bus 12: Franklinstraat 2a.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"12\"}]", "priority": 4, "points": "[{\"id\": \"1270B\"}]"},{"content": "[{\"text\": [{\"en\": \"From Dec 4, works. STOP NOT SERVED. Take bus 14 and 57 under the CCN building, at the terminus of bus 61.\", \"fr\": \"D\u00e8s le 4/12, travaux. ARRET NON DESSERVI. Prenez le bus 14 et 57 sous le b\u00e2timent CCN, au terminus du bus 61.\", \"nl\": \"Vanaf 4/12, werken. HALTE NIET BEDIEND. Neem bus 14 en 57 onder het CCN-gebouw, aan eindhalte bus 61.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"14\"}]", "priority": 4, "points": "[{\"id\": \"1082\"}]"},{"content": "[{\"text\": [{\"en\": \"From Sep 5 6AM, works. STOP NOT SERVED. Temporary stop: av. Charles Michiels across no. 205\", \"fr\": \"D\u00e8s le 5/9 6h, travaux. ARRET NON DESSERVI. Arr\u00eat provisoire : av. Charles Michiels face au num. 205\", \"nl\": \"Vanaf 5/9 6u, werken. HALTE NIET BEDIEND. Tijdelijke halte: Charles Michielslaan tegenover nr. 205\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"17\"}]", "priority": 4, "points": "[{\"id\": \"4294\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. May 17, 9PM-May 20, tram 19 interrupted. T-bus to SIMONIS at the stop of bus 88 to UZ-VUB.\", \"fr\": \"Travaux. 17/5, 21h-20/5, tram 19 interrompu. T-bus vers SIMONIS \u00e0 l'arr\u00eat du bus 88 vers UZ-VUB.\", \"nl\": \"Werken. 17/5, 21u-20/5, tram 19 onderbroken. T-bus naar SIMONIS aan de halte van bus 88 naar UZ-VUB.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"19\"}]", "priority": 4, "points": "[{\"id\": \"5093F\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. May 17, 9PM-May 20, STOP NOT SERVED. T-bus to SIMONIS at GUILLAUME DE GREEF (stop of bus 88 to UZ-VUB).\", \"fr\": \"Travaux. 17/5, 21h-20/5, ARRET NON DESSERVI. T-bus vers SIMONIS \u00e0 GUILL. DE GREEF (arr\u00eat du bus 88 vers UZ-VUB).\", \"nl\": \"Werken. 17/5, 21u-20/5, HALTE NIET BEDIEND. T-bus naar SIMONIS aan GUILL. DE GREEF (halte van bus 88 naar UZ-VUB).\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"19\"}]", "priority": 4, "points": "[{\"id\": \"5003\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. May 17, 9PM-May 20, tram 19 replaced by a T-bus to DE WAND.T-bus at PR. LEOPOLD (stop of bus 88 to UZ-VUB).\", \"fr\": \"Travaux. 17/5, 21h-20/5, tram 19 remplac\u00e9 par des T-bus jsq DE WAND. T-bus \u00e0 PRINCE LEOPOLD (arr\u00eat du bus 88 vers UZ-VUB).\", \"nl\": \"Werken. 17/5, 21u-20/5, tram 19 vervangen door T-bus tot DE WAND. T-bus aan PRINS LEOPOLD (halte van bus 88 naar UZ-VUB)\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"19\"}]", "priority": 4, "points": "[{\"id\": \"5082\"}]"},{"content": "[{\"text\": [{\"en\": \"Wroks. Until mid-2024, stop not served. T-bus at LEOPOLD I (bd de Smet de Naeyer 54, stop of bus 14 to UZ-VUB).\", \"fr\": \"Travaux. Jusque mi-2024, arr\u00eat non desservi. T-bus \u00e0 LEOPOLD I (bd de Smet de Naeyer 54, arr\u00eat du bus 14 vers UZ-VUB).\", \"nl\": \"Werken. Tot midden 2024, halte niet bediend. T-bus aan LEOPOLD I (de Smet de Naeyerlaan 54, halte B14 naar UZ-VUB).\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"19\"}]", "priority": 4, "points": "[{\"id\": \"6866F\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. May 17, 9PM-May 20, tram 19 replaced by a T-bus to DE WAND. T-bus at the stop of bus 88 to DE BROUCKERE.\", \"fr\": \"Travaux. 17/5, 21h-20/5, tram 19 remplac\u00e9 par des T-bus jusqu'\u00e0 DE WAND. T-bus \u00e0 l'arr\u00eat du bus 88 vers DE BROUCKERE.\", \"nl\": \"Werken. 17/5, 21u-20/5, tram 19 vervangen door T-bus tot DE WAND. T-bus aan de halte van bus 88 naar DE BROUCKERE.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"19\"}]", "priority": 4, "points": "[{\"id\": \"5092F\"}, {\"id\": \"5090F\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. As of Apr 15, bus 21 diverted. Take bus 21 at MAELBEEK / MAALBEEK (stop of bus 64 to PORTE DE NAMUR / NAAMSEPOORT).\", \"fr\": \"Travaux. D\u00e8s le 15/4, bus 21 d\u00e9vi\u00e9. Prenez le bus 21 \u00e0 MAELBEEK (arr\u00eat du bus 64 vers PORTE DE NAMUR).\", \"nl\": \"Werken. Vanaf 15/4, bus 21 omgeleid. Neem bus 21 aan MAALBEEK (halte van bus 64 naar NAAMSEPOORT) .\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"21\"}]", "priority": 4, "points": "[{\"id\": \"1476\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. As of April 7th, STOP NOT SERVED. To go to DE BROUCKERE, take metro lines 1 or 5.\", \"fr\": \"Travaux. D\u00e8s le 7/4, ARRET NON DESSERVI. Pour rejoindre DE BROUCKERE, prenez le m\u00e9tro 1 ou 5.\", \"nl\": \"Werken. Vanaf 7/4, HALTE NIET BEDIEND. Om naar DE BROUCKERE te gaan, neem metrolijn 1 of 5.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"29\"}]", "priority": 4, "points": "[{\"id\": \"6447\"}]"},{"content": "[{\"text\": [{\"en\": \"From Jan 8 to Jun 28, works. After CHURCHILL, tram 3 continues on line 7 direction HEYSEL / HEIZEL.\", \"fr\": \"Du 8/1 au 28/6, travaux. Apr\u00e8s CHURCHILL, tram 3 continue sur la ligne 7 direction HEYSEL.\", \"nl\": \"Van 8/1 tot en met 28/6, werken. Na CHURCHILL rijdt tram 3 verder op lijn 7 richting HEIZEL.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"3\"}]", "priority": 6, "points": "[{\"id\": \"6253\"}, {\"id\": \"6178\"}, {\"id\": \"2318G\"}, {\"id\": \"5221F\"}, {\"id\": \"0611\"}, {\"id\": \"0501\"}, {\"id\": \"0601\"}, {\"id\": \"0621\"}, {\"id\": \"0511\"}, {\"id\": \"0531\"}, {\"id\": \"2338F\"}, {\"id\": \"6422F\"}, {\"id\": \"0705\"}, {\"id\": \"0706\"}, {\"id\": \"0703\"}, {\"id\": \"5714\"}, {\"id\": \"2543F\"}, {\"id\": \"0704\"}, {\"id\": \"0702\"}]"},{"content": "[{\"text\": [{\"en\": \"Jan 7, 9PM-Jun 28, works. Tram 3 replaced by T-bus. Stop T-bus: av. Croix du Feu, crossing av. Buissonnets\", \"fr\": \"7/1, 21h-28/6, travaux. Tram 3 remplac\u00e9 par des T-bus. Arr\u00eat du T-bus: av. Croix du Feu, carrefour av.Buissonnets\", \"nl\": \"7/1, 21u-28/6, werken. Tram 3 vervangen door T- bus. Halte T-bus: Vuurkruisenlaan, kruispunt Braambosjesln.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"3\"}]", "priority": 4, "points": "[{\"id\": \"5772\"}]"},{"content": "[{\"text\": [{\"en\": \"Jan 7, 9PM-Jun 28,works. Stop not served. Stop T-bus to DOCKS BRUXSEL: av. Croix du Feu, crossing av. Pagodes.\", \"fr\": \"7/1, 21h-28/6, travaux. Arr\u00eat non desservi.Arr\u00eat du T-bus vers DOCKS BRUXSEL: av. Croix du Feu, carr. av. Pagodes.\", \"nl\": \"7/1, 21u-28/6, werken. Halte niet bediend.Halte van de T-bus naar DOCKS BRUXSEL: Vuurkruisenln, kruispt Pagodenln.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"3\"}]", "priority": 4, "points": "[{\"id\": \"5706\"}]"},{"content": "[{\"text\": [{\"en\": \"Jan 7, 9PM-Jun 28, works. Tram 3 replaced by T-bus. Stop T-bus: av. Croix du Feu, after rue De Wandstraat.\", \"fr\": \"7/1, 21h-28/6, travaux. Tram 3 remplac\u00e9 par des T-bus. Arr\u00eat du T-bus: avenue des Croix du Feu, apr\u00e8s la rue De Wand.\", \"nl\": \"7/1, 21u-28/6, werken. Tram 3 vervangen door T-bus. Halte T-bus: Vuurkruisenlaan, na de De Wandstraat.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"3\"}]", "priority": 4, "points": "[{\"id\": \"5806\"}]"},{"content": "[{\"text\": [{\"en\": \"From Jan 15, works. STOP NOT SERVED. Stop of bus 34: chauss\u00e9e de Wavre / Waversesteenweg 1303.\", \"fr\": \"D\u00e8s le 15/1, travaux. ARRET NON DESSERVI. Arr\u00eat du bus 34: chauss\u00e9e de Wavre 1303.\", \"nl\": \"Vanaf 15/1, werken. HALTE NIET BEDIEND. Halte van bus 34: Waversesteenweg 1303.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"34\"}]", "priority": 4, "points": "[{\"id\": \"1718B\"}]"},{"content": "[{\"text\": [{\"en\": \"From Mar 5 at 9AM, works. STOP NOT SERVED. Temporary stop: avenue Jean & Pierre Carsoellaan 4.\", \"fr\": \"D\u00e8s le 5/3 \u00e0 9h, travaux. ARRET NON DESSERVI. Arr\u00eat provisoire: avenue Jean et Pierre Carsoel 4.\", \"nl\": \"Vanaf 5/3 om 9u, werken. HALTE NIET BEDIEND. Tijdelijke halte: Jean en Pierre Carsoellaan 4.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"37\"}]", "priority": 4, "points": "[{\"id\": \"6931B\"}]"},{"content": "[{\"text\": [{\"en\": \"From Apr 3 at 6AM, works. Bus 38 diverted between LONGCHAMP and HOUZEAU via rue Edith Cavellstraat.\", \"fr\": \"D\u00e8s le 3/4 \u00e0 6h, travaux. Bus 38 d\u00e9vi\u00e9 entre LONGCHAMP et HOUZEAU via rue Edith Cavell.\", \"nl\": \"Vanaf 3/4 om 6u, werken. Bus 38 omgeleid tussen LONGCHAMP en HOUZEAU via Edith Cavellstraat.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"38\"}]", "priority": 5, "points": "[{\"id\": \"1914\"}]"},{"content": "[{\"text\": [{\"en\": \"From Apr 3 at 6AM, works. Bus 38 diverted between HOUZEAU and LONGCHAMP via rue Edith Cavellstraat.\", \"fr\": \"D\u00e8s le 3/4 \u00e0 6h, travaux. Bus 38 d\u00e9vi\u00e9 entre HOUZEAU et LONGCHAMP via rue Edith Cavell.\", \"nl\": \"Vanaf 3/4 om 6u, werken. Bus 38 omgeleid tussen HOUZEAU en LONGCHAMP via Edith Cavellstraat.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"38\"}]", "priority": 5, "points": "[{\"id\": \"1943\"}, {\"id\": \"4076\"}, {\"id\": \"1969\"}, {\"id\": \"1968\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. As of April 7th, stop of bus 38 moved to the Cantersteen, at the stop of bus 52 to FOREST / VORST (BERVOETS)\", \"fr\": \"Travaux. D\u00e8s le 7/4, arr\u00eat du bus 38 d\u00e9plac\u00e9 Cantersteen, \u00e0 l'arr\u00eat du bus 52 vers FOREST (BERVOETS).\", \"nl\": \"Werken. Vanaf 7/4, halte van bus 38 verplaatst naar de Kantersteen, aan de halte van bus 52 naar VORST (BERVOETS).\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"38\"}]", "priority": 4, "points": "[{\"id\": \"6443\"}]"},{"content": "[{\"text\": [{\"en\": \"From Apr 3 at 6AM, works. STOP NOT SERVED. Temporary stop: avenue Winston Churchilllaan 202.\", \"fr\": \"D\u00e8s le 3/4 \u00e0 6h, travaux. ARRET NON DESSERVI. Arr\u00eat provisoire: avenue Winston Churchill 202.\", \"nl\": \"Vanaf 3/4 om 6u, werken. HALTE NIET BEDIEND. Tijdelijke halte: Winston Churchilllaan 202.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"38\"}]", "priority": 4, "points": "[{\"id\": \"1973\"}]"},{"content": "[{\"text\": [{\"en\": \"From Apr 3 at 6AM, works. STOP NOT SERVED. Take bus 38 and 41 at the next stop, HOUZEAU.\", \"fr\": \"D\u00e8s le 3/4 \u00e0 6h, travaux. ARRET NON DESSERVI. Prenez les bus 38 et 41 \u00e0 l'arr\u00eat suivant, HOUZEAU.\", \"nl\": \"Vanaf 3/4 om 6u, werken. HALTE NIET BEDIEND. Neem bus 38 en 41 aan de volgende halte, HOUZEAU.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"38\"}]", "priority": 4, "points": "[{\"id\": \"1920\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. As of Mar 27, STOP MOVED. Stop of bus 41: rue des C\u00e8dres / Cederlaan 5.\", \"fr\": \"Travaux. D\u00e8s le 27/3, ARRET DEPLACE. Arr\u00eat du bus 41: rue des C\u00e8dres, 5.\", \"nl\": \"Werken. Vanaf 27/3, HALTE VERPLAATST. Halte van bus 41: Cederlaan 5.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"41\"}]", "priority": 4, "points": "[{\"id\": \"4310\"}]"},{"content": "[{\"text\": [{\"en\": \"From Apr 3 at 6AM, works. Bus 41 diverted between HOUZEAU and VERT CHASSEUR / GROENE JAGER via rue Edith Cavell.\", \"fr\": \"D\u00e8s le 3/4 \u00e0 6h, travaux. Bus 41 d\u00e9vi\u00e9 entre HOUZEAU et VERT CHASSEUR via rue Edith Cavell.\", \"nl\": \"Vanaf 3/4 om 6u, werken. Bus 41 omgeleid tussen HOUZEAU en GROENE JAGER via Edith Cavellstraat.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"41\"}]", "priority": 5, "points": "[{\"id\": \"1943\"}, {\"id\": \"4076\"}, {\"id\": \"1969\"}, {\"id\": \"1968\"}]"},{"content": "[{\"text\": [{\"en\": \"From Mar 4, works. Bus 43 diverted between CABRIS / GEITJES and GRIOTTES / NOORDKRIEKEN.\", \"fr\": \"D\u00e8s le 4/3, travaux. Bus 43 d\u00e9vi\u00e9 entre CABRIS et GRIOTTES.\", \"nl\": \"Vanaf 4/3, werken. Bus 43 omgeleid tussen GEITJES en NOORDKRIEKEN.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"43\"}]", "priority": 5, "points": "[{\"id\": \"2144\"}, {\"id\": \"2142\"}, {\"id\": \"2140\"}, {\"id\": \"2161\"}, {\"id\": \"2109B\"}, {\"id\": \"1953\"}, {\"id\": \"2143B\"}, {\"id\": \"2168\"}, {\"id\": \"2157\"}, {\"id\": \"2146\"}, {\"id\": \"2147B\"}, {\"id\": \"2156\"}, {\"id\": \"2167\"}, {\"id\": \"2145\"}]"},{"content": "[{\"text\": [{\"en\": \"From Mar 4, works. Bus 43 and N11 diverted. Take the bus at HOMBORCH (via B43 at stop B43 VIVIER D'OIE or B37).\", \"fr\": \"D\u00e8s le 4/3, travaux. Bus 43 et N11 d\u00e9vi\u00e9s. Prenez le bus \u00e0 HOMBORCH (via B43 \u00e0 l'arr\u00eat du B43 VIVIER D'OIE ou B37).\", \"nl\": \"Vanaf 4/3, werken. Bus 43 en N11 omgeleid. Neem de bus aan HOMBORCH (via B43 aan halte B43 DIESDELLE of B37).\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"43\"}]", "priority": 4, "points": "[{\"id\": \"1954\"}]"},{"content": "[{\"text\": [{\"en\": \"From Mar 4, works. Bus 43 diverted. Take the bus at HOMBORCH (via B43 from this stop on weekdays before 8PM).\", \"fr\": \"D\u00e8s le 4/3, travaux. Bus 43 d\u00e9vi\u00e9. Prenez le bus \u00e0 HOMBORCH (via B43 depuis cet arr\u00eat en semaine avant 20h).\", \"nl\": \"Vanaf 4/3, werken. Bus 43 omgeleid. Neem de bus aan HOMBORCH (via B43 vanaf deze halte op weekdagen voor 20u).\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"43\"}]", "priority": 4, "points": "[{\"id\": \"1944\"}]"},{"content": "[{\"text\": [{\"en\": \"From Mar 4, works. Bus 43 and N11 diverted. Take the bus at HOMBORCH (via B43 from this stop on weekdays or B37).\", \"fr\": \"D\u00e8s le 4/3, travaux. Bus 43 et N11 d\u00e9vi\u00e9s. Prenez le bus \u00e0 HOMBORCH (via B43 depuis cet arr\u00eat en semaine ou B37).\", \"nl\": \"Vanaf 4/3, werken. Bus 43 en N11 omgeleid. Neem de bus aan HOMBORCH (via B43 vanaf deze halte op weekdagen of B37).\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"43\"}]", "priority": 4, "points": "[{\"id\": \"1955\"}]"},{"content": "[{\"text\": [{\"en\": \"From Mar 4, works. Bus 43 and N11 diverted. Take the bus at HOMBORCH (via B43 from this stop on weekdays or B37).\", \"fr\": \"D\u00e8s le 4/3, travaux. Bus 43 et N11 d\u00e9vi\u00e9s. Prenez le bus \u00e0 HOMBORCH (via B43 depuis cet arr\u00eat en semaine ou B37).\", \"nl\": \"Vanaf 4/3, werken. Bus 43 en N11 omgeleid. Neem de bus aan HOMBORCH (via B43 vanaf deze halte op weekdagen of B37).\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"43\"}]", "priority": 4, "points": "[{\"id\": \"1936\"}, {\"id\": \"1935\"}]"},{"content": "[{\"text\": [{\"en\": \"From Mar 4, works. Bus 43 diverted between GRIOTTES and HOMBORCH. B43 HOMBORCH extended to BRAVES.\", \"fr\": \"D\u00e8s le 4/3, travaux. Bus 43 d\u00e9vi\u00e9 entre GRIOTTES et HOMBORCH. B43 barr\u00e9 HOMBORCH prolong\u00e9 jusqu'\u00e0 BRAVES.\", \"nl\": \"Vanaf 4/3, werken. Bus 43 omgeleid tussen NOORDKRIEKEN en HOMBORCH. B43 HOMBORCH rijdt tot DAPPEREN.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"43\"}]", "priority": 5, "points": "[{\"id\": \"2165\"}, {\"id\": \"1250\"}, {\"id\": \"1921\"}, {\"id\": \"1932\"}, {\"id\": \"1931\"}, {\"id\": \"1942\"}, {\"id\": \"5817\"}, {\"id\": \"1984B\"}, {\"id\": \"2355\"}, {\"id\": \"4854C\"}, {\"id\": \"1929\"}, {\"id\": \"1926B\"}, {\"id\": \"1937\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. Until end of August, bus 46 not operated btw WTC-GLIBERT and CENTRAL STATION. Walk to WTC-GLIBERT\", \"fr\": \"Travaux. Jsq fin ao\u00fbt, bus 46 ne circule pas entre WTC-GLIBERT et GARE CENTRALE. Allez \u00e0 pied \u00e0 WTC-GLIBERT\", \"nl\": \"Werken. Tot einde augustus rijdt bus 46 niet tss WTC- GLIBERT en CENTRAAL STATION. Ga te voet naar WTC-GLIBERT.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"46\"}]", "priority": 5, "points": "[{\"id\": \"2269\"}, {\"id\": \"2587\"}, {\"id\": \"3075\"}]"},{"content": "[{\"text\": [{\"en\": \"As of Sep 13 at 6AM, works. Stop moved to rue de Laeken / Lakensestraat, next to numbers 57-59.\", \"fr\": \"D\u00e8s le 13/9 \u00e0 6h, travaux. Arr\u00eat d\u00e9plac\u00e9 rue de Laeken, \u00e0 hauteur des num\u00e9ros 57-59.\", \"nl\": \"Vanaf 13/9 om 6u, werken. Halte verplaatst naar de Lakensestraat, ter hoogte van huisnummer 57-59.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"46\"}]", "priority": 4, "points": "[{\"id\": \"3465\"}]"},{"content": "[{\"text\": [{\"en\": \"Until end of August, works. Stop not served. Take bus 46 at the next stop, PORTE D'ANDERLECHT\", \"fr\": \"Jusque fin ao\u00fbt, travaux. Arr\u00eat non desservi. Prenez le bus 46 \u00e0 l'arr\u00eat suivant, PORTE D'ANDERLECHT.\", \"nl\": \"Tot einde augustus, werken. Halte niet bediend. Neem bus 46 aan de volgende halte, ANDERLECHTSEPOORT.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"46\"}]", "priority": 4, "points": "[{\"id\": \"2213\"}]"},{"content": "[{\"text\": [{\"en\": \"Until end August 2024, works. B46 diverted to ANNEESSENS. Stops between BUANDERIE and WTC-GLIBERT not served.\", \"fr\": \"Jsq fin ao\u00fbt 2024, travaux. Bus 46 d\u00e9vi\u00e9 vers ANNEESSENS. Arr\u00eats entre BUANDERIE et WTC- GLIBERT non desservis.\", \"nl\": \"Tot einde augustus 2024, werken. Bus 46 omgeleid naar ANNEESSENS. Haltes tussen WASHUIS en WTC-GLIBERT niet bediend\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"46\"}]", "priority": 5, "points": "[{\"id\": \"2405\"}, {\"id\": \"2259\"}, {\"id\": \"2264\"}, {\"id\": \"2262\"}, {\"id\": \"2261\"}, {\"id\": \"2260\"}]"},{"content": "[{\"text\": [{\"en\": \"Until Summer of 2024, works. Bus 47 diverted from RAMIER / BOSDUIF to DOCKS BRUXSEL via avenue des Croix de Guerre\", \"fr\": \"Jsq \u00e9t\u00e9 2024, travaux. Bus 47 d\u00e9vi\u00e9 depuis RAMIER vers DOCKS BRUXSEL via avenue des Croix de Guerre.\", \"nl\": \"Tot zomer 2024, werken. Bus 47 omgeleid vanaf BOSDUIF naar DOCKS BRUXSEL via Oorlogskruisenlaan.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"47\"}]", "priority": 5, "points": "[{\"id\": \"2361\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. STOP NOT SERVED. Bus 47-56 at the stop VERGER (avenue des Croix de Guerre)\", \"fr\": \"Travaux. ARRET NON DESSERVI. Bus 47-56 \u00e0 l'arr\u00eat VERGER (avenue des Croix de Guerre)\", \"nl\": \"Werken. HALTE NIET BEDIEND. Bus 47-56 aan de halte BOOMGAARD (Oorlogskruisenlaan)\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"47\"}]", "priority": 4, "points": "[{\"id\": \"1974\"}, {\"id\": \"1967\"}]"},{"content": "[{\"text\": [{\"en\": \"Until Summer of 2024, works. Stop of bus 47 and 56: avenue des Croix de Guerre / Oorlogskruisenlaan 78.\", \"fr\": \"Jusqu'\u00e0 l'\u00e9t\u00e9 2024, travaux. Arr\u00eat des bus 47 et 56 : avenue des Croix de Guerre 78.\", \"nl\": \"Tot zomer 2024, werken. Halte van bus 47 en 56: Oorlogskruisenlaan 78.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"47\"}]", "priority": 4, "points": "[{\"id\": \"2299\"}]"},{"content": "[{\"text\": [{\"en\": \"From Feb 6, works. STOP NOT SERVED. Temporary stop: Vlierkensstraat 94.\", \"fr\": \"D\u00e8s le 6/2, travaux. ARRET NON DESSERVI. Arr\u00eat provisoire: Vlierkensstraat 94.\", \"nl\": \"Vanaf 6/2, werken. HALTE NIET BEDIEND. Tijdelijke halte: Vlierkensstraat 94.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"47\"}]", "priority": 4, "points": "[{\"id\": \"2841\"}]"},{"content": "[{\"text\": [{\"en\": \"Until Summer of 2024, works. Stop not served. Take bus 47 at the stop of bus 56 to SCHUMAN.\", \"fr\": \"Jusqu'\u00e0 l'\u00e9t\u00e9 2024, travaux. Arr\u00eat non desservi. Prenez le bus 47 \u00e0 l'arr\u00eat du bus 56 vers SCHUMAN.\", \"nl\": \"Tot zomer 2024, werken. Halte niet bediend. Neem bus 47 aan de halte van bus 56 naar SCHUMAN.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"47\"}]", "priority": 4, "points": "[{\"id\": \"2317\"}]"},{"content": "[{\"text\": [{\"en\": \"Until Summer of 2024, works. Stop not served. Take bus 47 at ANTOON VAN OSS (stop of bus 56 to BUDA).\", \"fr\": \"Jsq \u00e9t\u00e9 2024, travaux. Arr\u00eat non desservi. Prenez le bus 47 \u00e0 ANTOON VAN OSS (arr\u00eat du bus 56 vers BUDA).\", \"nl\": \"Tot zomer 2024, werken. Halte niet bediend. Neem bus 47 aan ANTOON VAN OSS (halte van bus 56 naar BUDA).\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"47\"}]", "priority": 4, "points": "[{\"id\": \"2359\"}]"},{"content": "[{\"text\": [{\"en\": \"Until Summer of 2024, works. Stop not served. Take bus 47 at ANTOON VAN OSS (stop of bus 56 to SCHUMAN).\", \"fr\": \"Jsq \u00e9t\u00e9 2024, travaux. Arr\u00eat non desservi. Prenez le bus 47 \u00e0 ANTOON VAN OSS (arr\u00eat du bus 56 vers SCHUMAN).\", \"nl\": \"Tot zomer 2024, werken. Halte niet bediend. Neem bus 47 aan ANTOON VAN OSS (halte van bus 56 naar SCHUMAN).\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"47\"}]", "priority": 4, "points": "[{\"id\": \"2316\"}]"},{"content": "[{\"text\": [{\"en\": \"Until Summer of 2024, works. Stop not served. Stop of bus 47: av. Marlylaan, next to Verano.\", \"fr\": \"Jusqu'\u00e0 l'\u00e9t\u00e9 2024, travaux. Arr\u00eat non desservi. Arr\u00eat du bus 47: avenue du Marly, pr\u00e8s de Verano.\", \"nl\": \"Tot zomer 2024, werken. Halte niet bediend. Halte van bus 47: Marlylaan, naast Verano.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"47\"}]", "priority": 4, "points": "[{\"id\": \"2315\"}]"},{"content": "[{\"text\": [{\"en\": \"Until 2026, works. Stop not served. Stop of bus 50: rue de la Soierie / Zijdeweverijstraat 4.\", \"fr\": \"Jusqu'en 2026, travaux. Arr\u00eat non desservi. Arr\u00eat du bus 50: rue de la Soierie 4.\", \"nl\": \"Tot 2026, werken. Halte niet bediend. Halte van bus 50: Zijdeweverijstraat 4.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"50\"}]", "priority": 4, "points": "[{\"id\": \"3602\"}]"},{"content": "[{\"text\": [{\"en\": \"Until 2026, works. Bus 50 diverted. Stop of bus 50: rue des Abbesses / Abdissenstraat, in front of number 1.\", \"fr\": \"Jusqu'en 2026, travaux. Bus 50 d\u00e9vi\u00e9. Arr\u00eat du bus 50: rue des Abbesses, en face du num\u00e9ro 1.\", \"nl\": \"Tot 2026, werken. Bus 50 omgeleid. Halte van bus 50: Abdissenstraat, tegenover nummer 1.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"50\"}]", "priority": 4, "points": "[{\"id\": \"5161\"}]"},{"content": "[{\"text\": [{\"en\": \"Until 2026, works. Bus 50 diverted between BEMPT and FOREST CENTRE/VORST CENTRUM.\", \"fr\": \"Jusqu'en 2026, travaux. Bus 50 d\u00e9vi\u00e9 entre BEMPT et FOREST CENTRE.\", \"nl\": \"Tot 2026, werken. Bus 50 omgeleid tussen BEMPT en VORST CENTRUM.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"50\"}]", "priority": 5, "points": "[{\"id\": \"9685\"}, {\"id\": \"9683\"}, {\"id\": \"9678\"}, {\"id\": \"9679\"}, {\"id\": \"9677\"}, {\"id\": \"2661\"}, {\"id\": \"9658\"}, {\"id\": \"2662B\"}, {\"id\": \"9659\"}, {\"id\": \"9682\"}, {\"id\": \"2659\"}, {\"id\": \"9680\"}]"},{"content": "[{\"text\": [{\"en\": \"From May 2 at 5AM, works. STOP NOT SERVED. Temporary stop: Karel Gilsonstraat, 2.\", \"fr\": \"D\u00e8s le 2/5 \u00e0 5h,travaux. ARRET NON DESSERVI. Arr\u00eat provisoire: Karel Gilsonstraat, 2.\", \"nl\": \"Vanaf 2/5 om 5u, werken. HALTE NIET BEDIEND. Tijdelijke halte: Karel Gilsonstraat, 2.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"50\"}]", "priority": 4, "points": "[{\"id\": \"9651\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. Until 2026, stop not served. Stop of T-bus 82 and of bus 50: rue de la Soierie / Zijdeweverijstraat 9.\", \"fr\": \"Travaux. Jusqu'en 2026, arr\u00eat non desservi. Arr\u00eat du T-bus 82 et du bus 50 : rue de la Soierie 9.\", \"nl\": \"Werken. Tot 2026, halte niet bediend. Halte van T-bus 82 en van bus 50: Zijdeweverijstraat 9.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"50\"}]", "priority": 4, "points": "[{\"id\": \"3603\"}]"},{"content": "[{\"text\": [{\"en\": \"Until Summer of 2024, works. Bus 53 diverted. Stop of bus 53: rue Bruynstraat, after the military area.\", \"fr\": \"Jsq \u00e9t\u00e9 2024, travaux. Bus 53 d\u00e9vi\u00e9. Arr\u00eat du bus 53 : rue Bruyn, apr\u00e8s le domaine militaire.\", \"nl\": \"Tot zomer 2024, werken. Bus 53 omgeleid. Halte van bus 53: Bruynstraat, na het militair domein.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"53\"}]", "priority": 4, "points": "[{\"id\": \"2352\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. As of Apr 15 at 6AM, bus 53 diverted between PETER BENOIT and BEYSEGHEM / BEIZEGEM.\", \"fr\": \"Travaux. D\u00e8s le 15/4 \u00e0 6h, bus 53 d\u00e9vi\u00e9 entre PETER BENOIT et BEYSEGHEM.\", \"nl\": \"Werken. Vanaf 15/4 om 6u, bus 53 omgeleid tussen PETER BENOIT en BEIZEGEM.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"53\"}]", "priority": 5, "points": "[{\"id\": \"3001B\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. As of Apr 15 at 6AM, bus 53 diverted between PETER BENOIT and BEYSEGHEM / BEIZEGEM.\", \"fr\": \"Travaux. D\u00e8s le 15/4 \u00e0 6h, bus 53 d\u00e9vi\u00e9 entre PETER BENOIT et BEYSEGHEM.\", \"nl\": \"Werken. Vanaf 15/4 om 6u, bus 53 omgeleid tussen PETER BENOIT en BEIZEGEM.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"53\"}]", "priority": 5, "points": "[{\"id\": \"2823B\"}, {\"id\": \"2766\"}]"},{"content": "[{\"text\": [{\"en\": \"On May 19 until 8PM, flea market. Bus 54 diverted between MA CAMPAGNE and BAILLI / BALJUW.\", \"fr\": \"Le 19/5 jusqu'\u00e0 20h, brocante. Bus 54 d\u00e9vi\u00e9 entre MA CAMPAGNE et BAILLI.\", \"nl\": \"Op 19/5 tot 20u, rommelmarkt. Bus 54 omgeleid tussen MA CAMPAGNE en BALJUW.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"54\"}]", "priority": 5, "points": "[{\"id\": \"2955\"}, {\"id\": \"2965\"}, {\"id\": \"2953\"}, {\"id\": \"2957A\"}, {\"id\": \"2951\"}, {\"id\": \"2456\"}, {\"id\": \"2954B\"}, {\"id\": \"2959\"}]"},{"content": "[{\"text\": [{\"en\": \"On May 19 until 8PM, flea market. Bus 54 diverted between MA CAMPAGNE and BAILLI / BALJUW.\", \"fr\": \"Le 19/5 jusqu'\u00e0 20h, brocante. Bus 54 d\u00e9vi\u00e9 entre MA CAMPAGNE et BAILLI.\", \"nl\": \"Op 19/5 tot 20u, rommelmarkt. Bus 54 omgeleid tussen MA CAMPAGNE en BALJUW.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"54\"}]", "priority": 5, "points": "[{\"id\": \"5915\"}, {\"id\": \"1015\"}]"},{"content": "[{\"text\": [{\"en\": \"On May 5 until 8PM, flea market. STOP NOT SERVED. Take bus 54 at JANSON: chauss\u00e9e de Charleroisesteenweg 180.\", \"fr\": \"Le 19/5 jusqu'\u00e0 20h, brocante. ARRET NON DESSERVI. Prenez le bus 54 \u00e0 JANSON: chauss\u00e9e de Charleroi 180.\", \"nl\": \"Op 19/5 tot 20u, rommelmarkt. HALTE NIET BEDIEND. Neem bus 54 aan JANSON: Charleroisesteenweg 180.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"54\"}]", "priority": 4, "points": "[{\"id\": \"2960\"}]"},{"content": "[{\"text\": [{\"en\": \"From Apr 2, 2024 to June 2025, works. STOP NOT SERVED. Stop of bus 54: FOREST NATIONAL (av. du Globelaan 8).\", \"fr\": \"Du 2/4/2024 \u00e0 juin 2025, travaux. ARRET NON DESSERVI. Arr\u00eat des bus 54: FOREST NATIONAL. (avenue du Globe 8).\", \"nl\": \"Van 2/4/2024 tot juni 2025, werken. HALTE NIET BEDIEND. Halte van bus 54: VORST NATIONAAL (Globelaan 8)\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"54\"}]", "priority": 4, "points": "[{\"id\": \"2939B\"}]"},{"content": "[{\"text\": [{\"en\": \"Until Summer of 2024, works. Stop of bus 47 and 56: av. Croix de Guerre, at the other side of Delhaize.\", \"fr\": \"Jusqu'\u00e0 l'\u00e9t\u00e9 2024, travaux. Arr\u00eat des bus 47 et 56 : avenue des Croix de Guerre, de l'autre c\u00f4t\u00e9 du Delhaize\", \"nl\": \"Tot zomer 2024, werken. Halte van bus 47 en 56: Oorlogskruisenlaan, aan de andere kant van de Delhaize.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"56\"}]", "priority": 4, "points": "[{\"id\": \"1974\"}, {\"id\": \"1967\"}]"},{"content": "[{\"text\": [{\"en\": \"Until Summer of 2024, works. Stop not served. Stop of bus 56: place Peter Benoitplein 3\", \"fr\": \"Jusqu'\u00e0 l'\u00e9t\u00e9 2024, travaux. Arr\u00eat non desservi. Arr\u00eat du bus 56 : place Peter Benoit 3\", \"nl\": \"Tot zomer 2024, werken. Halte niet bediend. Halte van bus 56: Peter Benoitplein 3\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"56\"}]", "priority": 4, "points": "[{\"id\": \"1987\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. As of Apr 15, bus 56 diverted. Take bus 56 at the stop of bus 64 to BORDET STATION.\", \"fr\": \"Travaux. D\u00e8s le 15/4, bus 56 d\u00e9vi\u00e9. Prenez le bus 56 \u00e0 l'arr\u00eat du bus 64 vers BORDET STATION.\", \"nl\": \"Werken. Vanaf 15/4, bus 56 omgeleid. Neem bus 56 aan de halte van bus 64 naar BORDET STATION.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"56\"}]", "priority": 4, "points": "[{\"id\": \"2068\"}]"},{"content": "[{\"text\": [{\"en\": \"Until Summer of 2024, works. Bus 56 diverted between VAN PRAET and PETER BENOIT via avenue des Croix de Guerre.\", \"fr\": \"Jusqu'\u00e0 l'\u00e9t\u00e9 2024, travaux. Bus 56 d\u00e9vi\u00e9 entre VAN PRAET et PETER BENOIT via avenue des Croix de Guerre.\", \"nl\": \"Tot zomer 2024, werken. Bus 56 omgeleid tussen VAN PRAET en PETER BENOIT via Oorlogskruisenlaan.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"56\"}]", "priority": 5, "points": "[{\"id\": \"2098\"}, {\"id\": \"3451\"}, {\"id\": \"6190\"}, {\"id\": \"9296\"}, {\"id\": \"2051\"}, {\"id\": \"6082\"}, {\"id\": \"2898\"}, {\"id\": \"2106\"}, {\"id\": \"1006\"}, {\"id\": \"2367\"}, {\"id\": \"3412\"}, {\"id\": \"2101\"}, {\"id\": \"6459\"}]"},{"content": "[{\"text\": [{\"en\": \"Until Summer of 2024, works. As of March 18, buses 56 and 57 serve this stop normally.\", \"fr\": \"Jusqu'\u00e0 l'\u00e9t\u00e9 2024, travaux. D\u00e8s le 18/3, les bus 56 et 57 desservent \u00e0 nouveau cet arr\u00eat.\", \"nl\": \"Tot zomer 2024, werken. Vanaf 18/3 bedienen bus 56 en 57 opnieuw deze halte.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"56\"}]", "priority": 5, "points": "[{\"id\": \"2829B\"}]"},{"content": "[{\"text\": [{\"en\": \"Until Summer of 2024, works. Stop not served. Take bus 47 or 57 at ANTOON VAN OSS (stop of bus 56 to BUDA).\", \"fr\": \"Jsq \u00e9t\u00e9 2024, travaux. Arr\u00eat non desservi. Prenez le bus 47 ou 57 \u00e0 ANTOON VAN OSS (arr\u00eat du bus 56 vers BUDA).\", \"nl\": \"Tot zomer 2024, werken. Halte niet bediend. Neem bus 47 of 57 aan ANTOON VAN OSS (halte van bus 56 naar BUDA).\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"57\"}]", "priority": 4, "points": "[{\"id\": \"1837\"}]"},{"content": "[{\"text\": [{\"en\": \"Until Summer of 2024, works. Stop not served. Take bus 57 at ANTOON VAN OSS (stop of bus 56 to BUDA).\", \"fr\": \"Jsq \u00e9t\u00e9 2024, travaux. Arr\u00eat non desservi. Prenez le bus 57 \u00e0 ANTOON VAN OSS (arr\u00eat du bus 56 vers BUDA).\", \"nl\": \"Tot zomer 2024, werken. Halte niet bediend. Neem bus 57 aan ANTOON VAN OSS (halte van bus 56 naar BUDA).\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"57\"}]", "priority": 4, "points": "[{\"id\": \"2359\"}]"},{"content": "[{\"text\": [{\"en\": \"Until Summer 2024,works. B57 divtd btw MARLY and ANT VAN OSS. As of Oct 16, B57 divtd btw MARLY and HOP. MILITAIRE\", \"fr\": \"Jsq \u00e9t\u00e9 2024, travaux. Bus 57 d\u00e9vi\u00e9 entre MARLY et ANT VAN OSS. D\u00e8s le 16/10, B57 d\u00e9vi\u00e9 entre MARLY et HOP MILITAIRE.\", \"nl\": \"Tot zomer 2024, werken. Bus 57 omgeleid ts MARLY en ANT VAN OSS. Vanaf 16/10, B57 omgeleid tss MARLY en MILITAIR HOSP.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"57\"}]", "priority": 5, "points": "[{\"id\": \"1090\"}, {\"id\": \"2327\"}, {\"id\": \"2305\"}, {\"id\": \"2326\"}, {\"id\": \"1356\"}, {\"id\": \"3058\"}, {\"id\": \"1052\"}, {\"id\": \"1051\"}, {\"id\": \"2308\"}, {\"id\": \"2868\"}, {\"id\": \"3061\"}]"},{"content": "[{\"text\": [{\"en\": \"Until Summer of 2024, works. Stop not served. Take bus 57 at ANTOON VAN OSS (stop of bus 56 to SCHUMAN).\", \"fr\": \"Jsq \u00e9t\u00e9 2024, travaux. Arr\u00eat non desservi. Prenez le bus 57 \u00e0 ANTOON VAN OSS (arr\u00eat du bus 56 vers SCHUMAN).\", \"nl\": \"Tot zomer 2024, werken. Halte niet bediend. Neem bus 57 aan ANTOON VAN OSS (halte van bus 56 naar SCHUMAN).\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"57\"}]", "priority": 4, "points": "[{\"id\": \"2316\"}]"},{"content": "[{\"text\": [{\"en\": \"Until Summer of 2024, works. Stop not served. Stop of bus 57: chauss\u00e9e de Vilvorde, next to ropery Barrois\", \"fr\": \"Jsq \u00e9t\u00e9 2024, travaux. Arr\u00eat non desservi. Arr\u00eat du bus 57: ch\u00e9e de Vilvorde, le long de la corderie Barrois\", \"nl\": \"Tot zomer 2024, werken. Halte niet bediend. Halte B57: Vilvoordsestwg, naast de touwslagerij Barrois\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"57\"}]", "priority": 4, "points": "[{\"id\": \"3003\"}]"},{"content": "[{\"text\": [{\"en\": \"Until Summer of 2024, works. Stop not served. Stop of bus 57: MARLY (moved to ch. Vilvorde, next to number 150)\", \"fr\": \"Jsq \u00e9t\u00e9 2024, travaux. Arr\u00eat non desservi.Arr\u00eat du bus 57: MARLY (d\u00e9plac\u00e9 ch. Vilvorde, en face du num\u00e9ro 150)\", \"nl\": \"Tot zomer 2024, werken. Halte niet bediend. Halte van bus 57:MARLY (verplaatst Vilvoordsest tegenover nr. 150)\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"57\"}]", "priority": 4, "points": "[{\"id\": \"2315\"}]"},{"content": "[{\"text\": [{\"en\": \"From Feb 8, works. STOP NOT SERVED. Temporary stop: Place de Houffalizeplein 2-6.\", \"fr\": \"D\u00e8s le 8/2, travaux. ARRET NON DESSERVI. Arr\u00eat provisoire: Place de Houffalize 2-6.\", \"nl\": \"Vanaf 8/2, werken. HALTE NIET BEDIEND. Tijdelijke halte: Houffalizeplein 2-6.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"59\"}]", "priority": 4, "points": "[{\"id\": \"3110\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. As of Apr 15, bus 60 diverted between JOURDAN and AMBIORIX via MAELBEEK. Connection metro at MAELBEEK.\", \"fr\": \"Travaux. D\u00e8s le 15/4, bus 60 d\u00e9vi\u00e9 entre JOURDAN et AMBIORIX via MAELBEEK. Correspondance m\u00e9tro \u00e0 MAELBEEK.\", \"nl\": \"Werken. Vanaf 15/4, bus 60 omgeleid tussen JOURDAN en AMBIORIX via MAALBEEK. Aansluiting metro aan MAALBEEK.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"60\"}]", "priority": 6, "points": "[{\"id\": \"1980\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. As of Apr 15, bus 60 diverted between JOURDAN and AMBIORIX via MAELBEEK. Connection metro at MAELBEEK.\", \"fr\": \"Travaux. D\u00e8s le 15/4, bus 60 d\u00e9vi\u00e9 entre JOURDAN et AMBIORIX via MAELBEEK. Correspondance m\u00e9tro \u00e0 MAELBEEK.\", \"nl\": \"Werken. Vanaf 15/4, bus 60 omgeleid tussen JOURDAN en AMBIORIX via MAALBEEK. Aansluiting metro aan MAALBEEK.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"60\"}]", "priority": 6, "points": "[{\"id\": \"3158B\"}, {\"id\": \"3160\"}]"},{"content": "[{\"text\": [{\"en\": \"From Mar 11, works. Bus 60 diverted. Temporary stop: chauss\u00e9e de Saint- Job/Sint-Jobsesteenweg, in front of nr. 390.\", \"fr\": \"D\u00e8s le 11/3, travaux. Bus 60 d\u00e9vi\u00e9. Arr\u00eat provisoire: chauss\u00e9e de Saint-Job, face au num\u00e9ro 390.\", \"nl\": \"Vanaf 11/3, werken. Bus 60 omgeleid. Tijdelijke halte: Sint-Jobsesteenweg, tegenover nr. 390.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"60\"}]", "priority": 4, "points": "[{\"id\": \"1738\"}, {\"id\": \"2705\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. As of Apr 15, bus 60 diverted between JOURDAN and AMBIORIX via MAELBEEK. Connection metro at MAELBEEK.\", \"fr\": \"Travaux. D\u00e8s le 15/4, bus 60 d\u00e9vi\u00e9 entre JOURDAN et AMBIORIX via MAELBEEK. Correspondance m\u00e9tro \u00e0 MAELBEEK.\", \"nl\": \"Werken. Vanaf 15/4, bus 60 omgeleid tussen JOURDAN en AMBIORIX via MAALBEEK. Aansluiting metro aan MAALBEEK.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"60\"}]", "priority": 6, "points": "[{\"id\": \"6112\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. As of Apr 15, STOP NOT SERVED. Walk to AMBIORIX.\", \"fr\": \"Travaux. D\u00e8s le 15/4, ARRET NON DESSERVI. Pour rejoindre AMBIORIX, continuez \u00e0 pied.\", \"nl\": \"Werken. Vanaf 15/4, HALTE NIET BEDIEND. Ga te voet verder om naar AMBIORIX te gaan.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"60\"}]", "priority": 4, "points": "[{\"id\": \"1418B\"}]"},{"content": "[{\"text\": [{\"en\": \"From Mar 11, works. Bus 60 diverted. Temporary stop: chauss\u00e9e de Saint- Job/Sint-Jobsesteenweg 265.\", \"fr\": \"D\u00e8s le 11/3, travaux. Bus 60 d\u00e9vi\u00e9. Arr\u00eat provisoire: chauss\u00e9e de Saint-Job 265.\", \"nl\": \"Vanaf 11/3, werken. Bus 60 omgeleid. Tijdelijke halte: Sint-Jobsesteenweg 265.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"60\"}]", "priority": 4, "points": "[{\"id\": \"2704\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. As of April 7th, stop served only by bus 66. Take bus 29, 63 or 65 at the stop of bus 71 to DELTA.\", \"fr\": \"Travaux. D\u00e8s le 7/4, arr\u00eat uniquement desservi par bus 66. Bus 29, 63 ou 65 \u00e0 l'arr\u00eat du bus 71 vers DELTA.\", \"nl\": \"Werken. Vanaf 7/4, halte enkel bediend door bus 66. Neem bus 29, 63 of 65 aan de halte van bus 71 naar DELTA.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"63\"}]", "priority": 4, "points": "[{\"id\": \"6445\"}]"},{"content": "[{\"text\": [{\"en\": \"Risk of subsidence. Stop of bus 65, 66 and N04 moved to chauss\u00e9e de Haecht/Haachtsesteenweg, next to number 162\", \"fr\": \"Risque d'effondrement. Arr\u00eat des bus 65, 66 et N04 d\u00e9plac\u00e9 chauss\u00e9e de Haecht, \u00e0 hauteur du num\u00e9ro 162.\", \"nl\": \"Risico op instorting. Halte van bus 65, 66 en N04 verplaatst naar de Haachtsesteenweg, ter hoogte van nummer 162.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"65\"}]", "priority": 4, "points": "[{\"id\": \"6418\"}]"},{"content": "[{\"text\": [{\"en\": \"Jan 7, 9PM-Jun 28, works. Stop not served. To continue to HEYSEL / HEIZEL, take tram 3 direction CHURCHILL.\", \"fr\": \"7/1, 21h-28/6, travaux. Arr\u00eat non desservi. Pour continuer vers HEYSEL, prenez le tram 3 direction CHURCHILL.\", \"nl\": \"7/1, 21u-28/6, werken. Halte niet bediend. Om naar HEIZEL te reizen, neem tram 3 richting CHURCHILL.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"7\"}]", "priority": 4, "points": "[{\"id\": \"6421F\"}]"},{"content": "[{\"text\": [{\"en\": \"Jan 7, 9PM-Jun 28,works. Tram 3 and 7 replaced by T-bus to DOCKS BRUXSEL. T-bus at this stop.\", \"fr\": \"7/1, 21h-28/6, travaux. Tram 3 et 7 remplac\u00e9s par des T-bus jusqu'\u00e0 DOCKS BRUXSEL. T-bus \u00e0 cet arr\u00eat.\", \"nl\": \"7/1, 21u-28/6, werken. Tram 3 en 7 vervangen door T-bus tot DOCKS BRUXSEL. T-bus aan deze halte.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"7\"}]", "priority": 5, "points": "[{\"id\": \"5707\"}]"},{"content": "[{\"text\": [{\"en\": \"Jan 8-Jun 28, works. Tram 7 interrupted btw HEEMBEEK and DOCKS BXL. T-bus to DOCKS BXL at stop of B83 to VAL MARIA\", \"fr\": \"8/1-28/6, travaux. T7 interrompu de HEEMBEEK \u00e0 DOCKS BXL. T-bus vers DOCKS BXL \u00e0 l'arr\u00eat du B83 vers VAL MARIA.\", \"nl\": \"8/1-28/6, werken. T7 onderbroken tss HEEMBEEK en DOCKS BRUXSEL. T-bus naar DOCKS BRUXSEL aan halte B83 naar MARI\u00cbND.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"7\"}]", "priority": 5, "points": "[{\"id\": \"5700G\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. As of April 7th, STOP NOT SERVED. To go to DE BROUCKERE, take metro lines 1 or 5.\", \"fr\": \"Travaux. D\u00e8s le 7/4, ARRET NON DESSERVI. Pour rejoindre DE BROUCKERE, prenez le m\u00e9tro 1 ou 5.\", \"nl\": \"Werken. Vanaf 7/4, HALTE NIET BEDIEND. Om naar DE BROUCKERE te gaan, neem metrolijn 1 of 5.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"71\"}]", "priority": 4, "points": "[{\"id\": \"6447\"}]"},{"content": "[{\"text\": [{\"en\": \"From Mar 18, works. STOP NOT SERVED. Temporary stop: avenue de la Couronne / Kroonlaan 439-443.\", \"fr\": \"D\u00e8s le 18/3, travaux. ARRET NON DESSERVI. Arr\u00eat provisoire: avenue de la Couronne 439-443.\", \"nl\": \"Vanaf 18/3, werken. HALTE NIET BEDIEND. Tijdelijke halte: Kroonlaan 439-443.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"71\"}]", "priority": 4, "points": "[{\"id\": \"3558\"}]"},{"content": "[{\"text\": [{\"en\": \"From Mar 18, works. STOP NOT SERVED. stop of bus 72: avenue de l'Universit\u00e9 / Hogeschoollaan 4-10.\", \"fr\": \"D\u00e8s le 18/3, travaux. ARRET NON DESSERVI. Arr\u00eat du bus 72: avenue de l'Universit\u00e9 4-10.\", \"nl\": \"Vanaf 18/3, werken. HALTE NIET BEDIEND. Halte van bus 72: Hogeschoollaan 4-10.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"72\"}]", "priority": 4, "points": "[{\"id\": \"3514\"}]"},{"content": "[{\"text\": [{\"en\": \"Subsidence. Bus 74 limited to DECROLY. Take bus 74 at DECROLY.\", \"fr\": \"Effondrement. Bus 74 limit\u00e9 \u00e0 DECROLY. Prenez le bus 74 \u00e0 DECROLY.\", \"nl\": \"Wegverzakking. Bus 74 beperkt tot DECROLY. Neem bus 74 aan DECROLY.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"74\"}]", "priority": 4, "points": "[{\"id\": \"2452\"}]"},{"content": "[{\"text\": [{\"en\": \"From Apr 2, 2024 to June 2025, works. STOP NOT SERVED. Stop of bus 74: chauss\u00e9e de Bruxelles / Brusselsesteenweg 84.\", \"fr\": \"Du 2/4/2024 \u00e0 juin 2025, travaux. ARRET NON DESSERVI. Arr\u00eat du bus 74: chauss\u00e9e de Bruxelles 84.\", \"nl\": \"Van 2/4/2024 tot juni 2025, werken. HALTE NIET BEDIEND. Halte van bus 74: Brusselsesteenweg 84.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"74\"}]", "priority": 4, "points": "[{\"id\": \"5152\"}, {\"id\": \"5161\"}]"},{"content": "[{\"text\": [{\"en\": \"Subsidence. Bus 74 limited to DECROLY. Walk to UCCLE-STALLE / UKKEL-STALLE.\", \"fr\": \"Effondrement. Bus 74 limit\u00e9 \u00e0 DECROLY. Continuez \u00e0 pied jusqu'\u00e0 UCCLE STALLE.\", \"nl\": \"Wegverzakking. Bus 74 beperkt tot DECROLY. Ga te voet tot UKKEL-STALLE.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"74\"}]", "priority": 4, "points": "[{\"id\": \"2416\"}, {\"id\": \"2415\"}, {\"id\": \"2414\"}]"},{"content": "[{\"text\": [{\"en\": \"From Apr 20, works. Stop not served. Take B74 next to number 26 (100m before this stop).\", \"fr\": \"D\u00e8s le 20/4, travaux. Arr\u00eat non desservi. Arr\u00eat du B74 \u00e0  hauteur du num\u00e9ro 26 (100 m avant cet arr\u00eat).\", \"nl\": \"Vanaf 20/4, werken. Halte niet bediend. Neem B74 ter hoogte van nummer 26 (100m voor deze halte).\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"74\"}]", "priority": 4, "points": "[{\"id\": \"2225\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. Until 2026, stop not served. Stop of T-bus 82 and of bus 50: rue de la Soierie / Zijdeweverijstraat 9.\", \"fr\": \"Travaux. Jusqu'en 2026, arr\u00eat non desservi. Arr\u00eat du T-bus 82 et du bus 50 : rue de la Soierie 9.\", \"nl\": \"Werken. Tot 2026, halte niet bediend. Halte van T-bus 82 en van bus 50: Zijdeweverijstraat 9.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"82\"}]", "priority": 4, "points": "[{\"id\": \"5156F\"}]"},{"content": "[{\"text\": [{\"en\": \"Until 2026, works. Tram 82 replaced by T-bus to FOREST CENTRE. T-bus at this stop.\", \"fr\": \"Jusqu'en 2026, travaux. Tram 82 remplac\u00e9 par des T-bus jusqu'\u00e0 FOREST CENTRE. T-bus \u00e0 cet arr\u00eat.\", \"nl\": \"Tot 2026, werken. Tram 82 vervangen door T-bus tot VORST CENTRUM. T-bus aan deze halte.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"82\"}]", "priority": 4, "points": "[{\"id\": \"5756F\"}, {\"id\": \"1258G\"}]"},{"content": "[{\"text\": [{\"en\": \"Until 2026, works. Tram 82 interrupted. Take tram 82 at the stop in the other direction.\", \"fr\": \"Jusqu'en 2026, travaux. Tram 82 interrompu. Prenez le tram 82 \u00e0 l'arr\u00eat dans l'autre sens.\", \"nl\": \"Tot 2026, werken. Tram 82 onderbroken. Neem tram 82 aan de halte in de andere richting.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"82\"}]", "priority": 4, "points": "[{\"id\": \"5161F\"}]"},{"content": "[{\"text\": [{\"en\": \"Until 2026, works. Tram 82 interrupted. T-bus to DROGENBOS at the stop of bus 54 to TRONE/TROON.\", \"fr\": \"Jusqu'en 2026, travaux. Tram 82 interrompu. T-bus vers DROGENBOS \u00e0 l'arr\u00eat du bus 54 vers TRONE.\", \"nl\": \"Tot 2026, werken. Tram 82 onderbroken. T-bus naar DROGENBOS aan de halte van bus 54 naar TROON.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"82\"}]", "priority": 4, "points": "[{\"id\": \"5121F\"}]"},{"content": "[{\"text\": [{\"en\": \"Until 2026, works. Stop not served. Stop of the T-bus: rue de la Soierie / Zijdeweverijstraat 4.\", \"fr\": \"Jusqu'en 2026, travaux. Arr\u00eat non desservi. Arr\u00eat du T-bus: rue de la Soierie 4.\", \"nl\": \"Tot 2026, werken. Halte niet bediend. Halte van de T-bus: Zijdeweverijstraat 4.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"82\"}]", "priority": 4, "points": "[{\"id\": \"5154F\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. Until 2026, tram 82 replaced by T-bus between DROGENBOS and FOREST CENTRE / VORST CENTRUM.\", \"fr\": \"Travaux. Jusqu'en 2026, tram 82 remplac\u00e9 par des T-bus entre DROGENBOS et FOREST CENTRE. T-bus \u00e0 cet arr\u00eat.\", \"nl\": \"Werken. Tot 2026, tram 82 vervangen door T-bus tussen DROGENBOS en VORST CENTRUM. T-bus aan deze halte.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"82\"}]", "priority": 4, "points": "[{\"id\": \"5753F\"}, {\"id\": \"5751\"}, {\"id\": \"5754\"}]"},{"content": "[{\"text\": [{\"en\": \"Until 2026, works. Tram 82 replaced by T-bus between FOREST CENTRE / VORST CENTRUM and DROGENBOS.\", \"fr\": \"Jusqu'en 2026, travaux. Tram 82 remplac\u00e9 par des T-bus entre FOREST CENTRE et DROGENBOS. Info: stib.brussels.\", \"nl\": \"Tot 2026, werken. Tram 82 vervangen door T-bus tussen VORST CENTRUM en DROGENBOS. Info: mivb. brussels.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"82\"}]", "priority": 5, "points": "[{\"id\": \"2603\"}, {\"id\": \"5718\"}, {\"id\": \"0631\"}, {\"id\": \"5120\"}, {\"id\": \"2539F\"}, {\"id\": \"5123\"}, {\"id\": \"2548F\"}, {\"id\": \"2604F\"}, {\"id\": \"2544F\"}, {\"id\": \"5119\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. Until 2026, tram 82 replaced by T-bus btw FOREST CENTRE / VORST CENTRUM and DROGENBOS. T-bus at this stop.\", \"fr\": \"Travaux. Jusqu'en 2026, tram 82 remplac\u00e9 par des T-bus entre FOREST CENTRE et DROGENBOS. T-bus \u00e0 cet arr\u00eat.\", \"nl\": \"Werken. Tot 2026, tram 82 vervangen door T-bus tussen VORST CENTRUM en DROGENBOS. T-bus aan deze halte.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"82\"}]", "priority": 4, "points": "[{\"id\": \"5722F\"}, {\"id\": \"5723G\"}]"},{"content": "[{\"text\": [{\"en\": \"From Jan 22 at 6AM to end of June, works. Bus 86 diverted. Take the bus at the previous stop GARE DE L'OUEST.\", \"fr\": \"Du 22/1 \u00e0 6h jusqu'\u00e0 fin juin, travaux. Bus 86 d\u00e9vi\u00e9. Prenez le bus \u00e0 l'arr\u00eat pr\u00e9c\u00e9dent GARE DE  L'OUEST.\", \"nl\": \"Van 22/1 om 6u tot eind juni, werken. Bus 86 omgeleid. Neem de bus aan vorige halte WESTSTATION.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"86\"}]", "priority": 4, "points": "[{\"id\": \"3257\"}]"},{"content": "[{\"text\": [{\"en\": \"From Jan 22 at 6AM to end of June, works. Bus 86 diverted. B86 at the stop RIBAUCOURT of bus 20 to GARE DU NORD.\", \"fr\": \"Du 22/1 \u00e0 6h jusqu'\u00e0 fin juin, travaux. Bus 86 d\u00e9vi\u00e9. Bus 86 \u00e0 l'arr\u00eat RIBAUCOURT du bus 20 vers GARE DU NORD.\", \"nl\": \"Van 22/1 om 6u tot eind juni, werken. Bus 86 omgeleid. Bus 86 aan de halte RIBAUCOURT van bus 20 naar NOORDSTATION.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"86\"}]", "priority": 4, "points": "[{\"id\": \"4253\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. From Apr 23 until Jun 2, bus 13 and 88 diverted. Take bus 13 or 88 at the stop of bus 820 to UZ Brussel.\", \"fr\": \"Travaux; Du 23/4 au 2/6, bus 13 et 88 d\u00e9vi\u00e9s. Prenez le bus 13 ou 88 \u00e0 l'arr\u00eat du bus 820 vers UZ Brussel.\", \"nl\": \"Werken. Van 23/4 tot en met 2/6, bus 13 en 88 omgeleid. Neem bus 13 of 88 aan de halte van bus 820 naar UZ Brussel.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"88\"}]", "priority": 4, "points": "[{\"id\": \"1721\"}, {\"id\": \"1328\"}]"},{"content": "[{\"text\": [{\"en\": \"From Feb 2 7AM, works. STOP NOT SERVED. Temporary halte: Boulevard Emile Jacqmainlaan 82-94.\", \"fr\": \"D\u00e8s le 8/2 7h, travaux. ARRET NON DESSERVI. Arr\u00eat provisoire: Boulevard Emile Jacqmain 82-94.\", \"nl\": \"Vanaf 8/2 7u, werken. HALTE NIET BEDIEND. Tijdelijke halte: Emile Jacqmainlaan 82-94.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"88\"}]", "priority": 4, "points": "[{\"id\": \"2070\"}]"},{"content": "[{\"text\": [{\"en\": \"Until end of August, works. Bus 89 diverted. To continue to CENTRAL STATION, take bus 29 71\", \"fr\": \"Jusque fin ao\u00fbt, travaux. Bus 89 d\u00e9vi\u00e9. Pour continuer vers GARE CENTRALE, prenez le bus 29 ou 71.\", \"nl\": \"Tot einde augustus, werken. Bus 89 omgeleid. Om verder naar CENTRAAL STATION te reizen, neem bus 29 of 71.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"89\"}]", "priority": 5, "points": "[{\"id\": \"1820\"}, {\"id\": \"2296\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. As of Apr 22 at 9.30AM, bus 89 diverted. Stop of bus 89: rue des Quatre-Vents / Vier Windenstraat 141\", \"fr\": \"Travaux. D\u00e8s le 22/4 \u00e0 9h30, bus 89 d\u00e9vi\u00e9. Arr\u00eat du bus 89: rue des Quatre-Vents, 141.\", \"nl\": \"Werken. Vanaf 22/4 om 9. 30u, bus 89 omgeleid. Halte van bus 89: Vier Windenstraat 141\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"89\"}]", "priority": 4, "points": "[{\"id\": \"4594\"}]"},{"content": "[{\"text\": [{\"en\": \"Until end of August, works. Bus 89 diverted. For the city center, take metro 1 or 5 at COMTE DE FLANDRE.\", \"fr\": \"Jusque fin ao\u00fbt, travaux. Bus 89 d\u00e9vi\u00e9. Pour le centre-ville, prenez le m\u00e9tro 1 ou 5 \u00e0 COMTE DE FLANDRE.\", \"nl\": \"Tot einde augustus, werken. Bus 89 omgeleid. Om naar het stadscentrum te gaan, neem M 1 5 aan GRAAF VAN VLAANDEREN.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"89\"}]", "priority": 4, "points": "[{\"id\": \"3259C\"}, {\"id\": \"3260\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. As of Apr 22 at 9.30AM, bus 89 diverted. Stop of bus 89: rue Delaunoystraat 15.\", \"fr\": \"Travaux. D\u00e8s le 22/4 \u00e0 9h30, bus 89 d\u00e9vi\u00e9. Arr\u00eat du bus 89: rue Delaunoy, 15.\", \"nl\": \"Werken. Vanaf 22/4 om 9. 30u, bus 89 omgeleid. Halte van bus 89: Delaunoystraat 15.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"89\"}]", "priority": 4, "points": "[{\"id\": \"3228\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. From May 17 at 9PM until May 20, T-bus 19 does not serve HOP. BRUGMANN. Connection to T-bus 19 at CIM. JETTE.\", \"fr\": \"Travaux. 17/5, 21h-20/5, T-bus 19 ne dessert pas HOPITAL BRUGMANN. Correspondance T-bus 19 \u00e0 CIMETIERE DE JETTE.\", \"nl\": \"17/5, 21u-20/5, werken. T-bus 19 bedient BRUGMANN-ZKH. niet. Aansluiting met T-bus 19 aan KERKHOF VAN JETTE.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"93\"}]", "priority": 4, "points": "[{\"id\": \"5400\"}, {\"id\": \"5402\"}, {\"id\": \"5399F\"}]"},{"content": "[{\"text\": [{\"en\": \"Mar 25-Jun 30, works. STOP NOT SERVED. Stop of bus 95: CIMETIERE D'IXELLES / BEGR. VAN ELSENE.\", \"fr\": \"25/3-30/6,travaux. ARRET NON DESSERVI. Arr\u00eat du bus 95: CIM. D'IXELLES (ch\u00e9e de Boondael, avant le rond-point).\", \"nl\": \"25/3-30/6, werken. HALTE NIET BEDIEND. Halte van bus 95: BEGR. VAN ELSENE (Boondaalsestwg, voor de rotonde)\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"95\"}]", "priority": 4, "points": "[{\"id\": \"4362\"}]"},{"content": "[{\"text\": [{\"en\": \"As of September 21, works. Stop moved to av. de la Fauconnerie / Valkerijlaan, next to number 53a.\", \"fr\": \"D\u00e8s le 21/9, travaux. Arr\u00eat d\u00e9plac\u00e9 avenue de la Fauconnerie, \u00e0 hauteur du num\u00e9ro 53a.\", \"nl\": \"Vanaf 21/9, werken. Halte verplaatst naar de Valkerijlaan, ter hoogte van huisnummer 53a.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"95\"}]", "priority": 4, "points": "[{\"id\": \"4314\"}]"},{"content": "[{\"text\": [{\"en\": \"From Mar 25 until Jun 30, works. STOP NOT SERVED. Stop of bus 95: av. Couronne / Kroonln, in front of number 384\", \"fr\": \"Du 25/3 au 30/6, travaux. ARRET NON DESSERVI. Arr\u00eat du bus 95: av. de la Couronne, en face du num\u00e9ro 384.\", \"nl\": \"Van 25/3 tot en met 30/6, werken. HALTE NIET BEDIEND. Halte van bus 95: Kroonlaan, tegenover nummer 384\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"95\"}]", "priority": 4, "points": "[{\"id\": \"4306\"}]"},{"content": "[{\"text\": [{\"en\": \"From Mar 25 until Jun 30, works. Bus 95 diverted btw CIMETIERE D'IXELLES and ETTERBEEK GARE\", \"fr\": \"Du 25/3 au 30/6, travaux. Bus 95 d\u00e9vi\u00e9 entre CIMETIERE D'IXELLES et  ETTERBEEK GARE.\", \"nl\": \"Van 25/3 tot en met 30/6, werken. Bus 95 omgeleid tussen BEGRAAFPLAATS VAN ELSENE en ETTERBEEK STATION.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"95\"}]", "priority": 5, "points": "[{\"id\": \"4360\"}, {\"id\": \"4351\"}, {\"id\": \"1455\"}, {\"id\": \"4355\"}, {\"id\": \"4357\"}, {\"id\": \"4358\"}, {\"id\": \"4359\"}, {\"id\": \"4348\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. As of Mar 27, STOP MOVED. Stop of bus 95: rue des Thuyas / Thujastraat 5.\", \"fr\": \"Travaux. D\u00e8s le 27/3, ARRET DEPLACE. Arr\u00eat du bus 95: rue des Thuyas, 5.\", \"nl\": \"Werken. Vanaf 27/3, HALTE VERPLAATST. Halte van bus 95: Thujastraat 5.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"95\"}]", "priority": 4, "points": "[{\"id\": \"4310\"}]"},{"content": "[{\"text\": [{\"en\": \"Until 2026, works. As of Mar 11, T97 interrupted btw DIEWEG and WIELS. Take T4 to CARR. STALLE, and then the T-bus.\", \"fr\": \"Jsq 2026,travaux. D\u00e8s le 11/3, T97 interrompu entre DIEWEG et WIELS. T4 jsq CARREFOUR STALLE, et ensuite le T-bus.\", \"nl\": \"Tot 2026,werken. Vanaf 11/3, T97 onderbroken tss DIEWEG en WIELS. Neem T4 tot KRUISPUNT STALLE, en de T-bus.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"97\"}]", "priority": 4, "points": "[{\"id\": \"2708G\"}, {\"id\": \"5952F\"}, {\"id\": \"2709F\"}, {\"id\": \"2710G\"}, {\"id\": \"1984G\"}]"},{"content": "[{\"text\": [{\"en\": \"Until 2026, works. T-bus 82/97 diverted. Stop T-bus 82/97: bd 2e Arm\u00e9e Britannique / Britse Tweedelegerlaan.\", \"fr\": \"Jsq 2026, travaux. T-bus 82/97 d\u00e9vi\u00e9. Arr\u00eat T-bus 82/97: bd 2e Arm\u00e9e Britannique, carrefour rue de la Station.\", \"nl\": \"Tot 2026, werken. T-bus 82/97 omgeleid. Halte T-bus 82/97: Britse Tweedelegerlaan, kruispunt Stationstraat.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"97\"}]", "priority": 4, "points": "[{\"id\": \"5719H\"}]"},{"content": "[{\"text\": [{\"en\": \"Until 2026, works. Tram 97 interrupted to WIELS. Stop of the T-bus to ROCHEFORT: r. Abbesses / Abdissenstr.\", \"fr\": \"Jusqu'en 2026, travaux. Tram 97 interrompu jusqu'\u00e0 WIELS. Arr\u00eat du T-bus vers ROCHEFORT: rue des Abbesses.\", \"nl\": \"Tot 2026, werken. Tram 97 onderbroken tot WIELS. Halte van de T-bus naar ROCHEFORT: Abdissenstraat.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"97\"}]", "priority": 4, "points": "[{\"id\": \"5152G\"}]"},{"content": "[{\"text\": [{\"en\": \"Until 2026, works. Tram 97 interrupted to WIELS. Stop of the T-bus to ROCHEFORT: ch. Neerstalsestwg 236\", \"fr\": \"Jsq 2026, travaux. Tram 97 interrompu jsq WIELS. Arr\u00eat du T-bus vers ROCHEFORT: chauss\u00e9e de Neerstalle, 236\", \"nl\": \"Tot 2026, werken. Tram 97 onderbroken tot WIELS. Halte van de T-bus naar ROCHEFORT: Neerstalsesteenweg,236\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"97\"}]", "priority": 4, "points": "[{\"id\": \"5164F\"}]"},{"content": "[{\"text\": [{\"en\": \"Until 2026, works. Tram 97 interrupted between CARREFOUR STALLE en WIELS. T-bus to ROCHEFORT at this stop.\", \"fr\": \"Jusqu'en 2026, travaux. Tram 97 interrompu entre CARREFOUR STALLE et WIELS. T-bus vers ROCHEFORT \u00e0 cet arr\u00eat.\", \"nl\": \"Tot 2026, werken. T97 onderbroken tussen KRUISPT STALLE en WIELS. T-bus naar ROCHEFORT aan deze halte.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"97\"}]", "priority": 4, "points": "[{\"id\": \"5756F\"}, {\"id\": \"1258G\"}]"},{"content": "[{\"text\": [{\"en\": \"From May 18, 5AM, works. STOP NOT SERVED. Stop of tram 97: avenue du Parc / Parklaan 26, in front of number 26.\", \"fr\": \"D\u00e8s le 18/5, 5h, travaux. ARRET NON DESSERVI. Arr\u00eat du tram 97: avenue du Parc, en face du num\u00e9ro 26.\", \"nl\": \"Vanaf 18/5, 5u, werken. HALTE NIET BEDIEND. Halte van tram 97: Parklaan, tegenover nummer 26.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"97\"}]", "priority": 4, "points": "[{\"id\": \"2334F\"}]"},{"content": "[{\"text\": [{\"en\": \"Until 2026, works. T97 interrupted to WIELS. T97 at WIELS via T82, or at ROCHEFORT via T-bus (stop: r. Abbesses)\", \"fr\": \"Jsq 2026, travaux. T97 interrompu jsq WIELS. T97 \u00e0 WIELS via T82, ou \u00e0 ROCHEFORT via T-bus (arr\u00eat: r. Abbesses).\", \"nl\": \"Tot 2026, werken. T97 onderbroken tot WIELS. T97 aan WIELS via T82, of aan ROCHEFORT via T-bus, halte: Abdissenst\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"97\"}]", "priority": 4, "points": "[{\"id\": \"5161F\"}]"},{"content": "[{\"text\": [{\"en\": \"Until 2026, works. T-bus 82/97 diverted between BEMPT and FOREST CENTRE/VORST CENTRUM.\", \"fr\": \"Jusqu'en 2026, travaux. T-bus 82/97 d\u00e9vi\u00e9 entre BEMPT et FOREST CENTRE.\", \"nl\": \"Tot 2026, werken. Bus T-bus 82/97 omgeleid tussen BEMPT en VORST CENTRUM.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"T82\"}]", "priority": 5, "points": "[{\"id\": \"3405\"}, {\"id\": \"7472\"}, {\"id\": \"7474\"}, {\"id\": \"7465\"}, {\"id\": \"3255\"}, {\"id\": \"5755\"}, {\"id\": \"5756\"}]"},{"content": "[{\"text\": [{\"en\": \"Until 2026, works. Bus 50 and T-bus diverted between FOREST CENTRE / VORST CENTRUM and BEMPT.\", \"fr\": \"Jusqu'en 2026, travaux. Bus 50 et T-bus d\u00e9vi\u00e9s entre FOREST CENTRE et BEMPT.\", \"nl\": \"Tot 2026, werken. Bus 50 en T-bus omgeleid tussen VORST CENTRUM en BEMPT.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"T82\"}]", "priority": 5, "points": "[{\"id\": \"3196\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. As of Apr 15, bus 12 diverted btw MEISER and LUXEMBOURG via MAELBEEK. Stop SCHUMAN moved rue Franklinstr.\", \"fr\": \"Travaux. D\u00e8s le 15/4, bus 12 d\u00e9vi\u00e9 entre MEISER et LUXEMBOURG via MAELBEEK. Arr\u00eat SCHUMAN d\u00e9plac\u00e9 rue Franklin.\", \"nl\": \"Werken. Vanaf 15/4, bus 12 omgeleid tss MEISER en LUXEMBURG via MAALBEEK. Halte SCHUMAN verplaatst Franklinstr.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"12\"}]", "priority": 6, "points": "[{\"id\": \"3017\"}, {\"id\": \"2695\"}, {\"id\": \"5048\"}, {\"id\": \"9600B\"}, {\"id\": \"2250\"}]"},{"content": "[{\"text\": [{\"en\": \"Bus 17: From Sep 5 6AM, works. Diversion between BRILLANT/BRILJANT and BEAULIEU via Michiels\", \"fr\": \"Bus 17: D\u00e8s le 5/9 6h, travaux. D\u00e9viation entre BRILLANT et BEAULIEU via Michiels\", \"nl\": \"Bus 17: Vanaf 5/9 6u, werken. Omleiding tussen BRILJANT en BEAULIEU via Michiels\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"17\"}]", "priority": 6, "points": "[{\"id\": \"9059\"}, {\"id\": \"4351\"}, {\"id\": \"4341\"}, {\"id\": \"1455\"}, {\"id\": \"4287\"}, {\"id\": \"4355\"}, {\"id\": \"4357\"}, {\"id\": \"4358\"}, {\"id\": \"4348\"}, {\"id\": \"4292\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. As of Mar 27, STOP MOVED. Stop of bus 17: rue des Thuyas / Thujastraat 5.\", \"fr\": \"Travaux. D\u00e8s le 27/3, ARRET DEPLACE. Arr\u00eat du bus 17: rue des Thuyas, 5.\", \"nl\": \"Werken. Vanaf 27/3, HALTE VERPLAATST. Halte van bus 17: Thujastraat 5.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"17\"}]", "priority": 4, "points": "[{\"id\": \"4310\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. May 17, 9PM-May 20, tram 19 replaced by a T-bus to SIMONIS. T-bus at the stop of bus 53 to WESTLAND SHOPPING.\", \"fr\": \"Travaux. 17/5, 21h-20/5, tram 19 remplac\u00e9 par des T-bus jsq SIMONIS. T-bus \u00e0 l'arr\u00eat du bus 53 vers WESTLAND SHOPPING.\", \"nl\": \"Werken. 17/5, 21u-20/5, tram 19 vervangen door T-bus tot SIMONIS. T-bus aan de halte van bus 53 naar WESTLAND SHOPPING.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"19\"}]", "priority": 4, "points": "[{\"id\": \"5001F\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. From May 17 at 9PM until May 20, tram 19 does not serve this stop. To go to DE WAND, take tram 7.\", \"fr\": \"Travaux. Du 17/5 \u00e0 21h au 20/5, tram 19 ne dessert pas cet arr\u00eat. Pour DE WAND, prenez le tram 7.\", \"nl\": \"Werken. Van 17/5 om 21u tot 20/5 bedient tram 19 deze halte niet. Om naar DE WAND te gaan, neem tram 7.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"19\"}]", "priority": 4, "points": "[{\"id\": \"2636F\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. Until mid-2024, T19 interrupted at this stop. Stop of T-bus 19: av. Jette 232 (next to this stop)\", \"fr\": \"Travaux. Jusque mi-2024, T19 interrompu \u00e0 cet arr\u00eat. Arr\u00eat du T-bus 19: av. de Jette, 232 (\u00e0 c\u00f4t\u00e9 de cet arr\u00eat).\", \"nl\": \"Werken. Tot midden 2024, T19 onderbroken aan deze halte. Halte van T-bus 19: Jetselaan 232 (naast deze halte)\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"19\"}]", "priority": 4, "points": "[{\"id\": \"6865F\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. Until mid-2024, stop not served. T-bus at VERBEYST (bd de Smet de Naeyer 234, stop of bus 14 to UZ-VUB).\", \"fr\": \"Travaux. Jusque mi-2024, arr\u00eat non desservi. T-bus \u00e0 VERBEYST (bd de Smet de Naeyer 234, arr\u00eat B14 vers UZ-VUB).\", \"nl\": \"Werken. Tot midden 2024, halte niet bediend. T-bus aan VERBEYST (de Smet de Naeyerlaan 234, halte B14 naar UZ-VUB).\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"19\"}]", "priority": 4, "points": "[{\"id\": \"6867F\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. Until mid-2024, tram 19 replaced by T-bus btw DE WAND and MIROIR / SPIEGEL. Take T-bus at CIM. DE JETTE.\", \"fr\": \"Travaux. Jusque mi-2024, tram 19 remplac\u00e9 par des T-bus entre DE WAND et MIROIR. Prenez le T-bus \u00e0 CIMETIERE DE JETTE.\", \"nl\": \"Werken. Tot midden 2024, tram 19 vervangen door T-bus tss DE WAND en SPIEGEL. Neem de T-bus aan KERKHOF VAN JETTE\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"19\"}]", "priority": 4, "points": "[{\"id\": \"6800F\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. Until mid-2024, stop not served. T-bus at LEOPOLD I (bd de Smet de Naeyer 59), or T19 at MIROIR.\", \"fr\": \"Travaux, jusque mi-2024, arr\u00eat non desservi. T-bus \u00e0 LEOPOLD I (bd de Smet de Naeyer 59), ou T19 \u00e0 MIROIR.\", \"nl\": \"Werken. Tot midden 2024, halte niet bediend. T-bus aan LEOPOLD I (de Smet de Naeyerlaan 59), of T19 aan SPIEGEL.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"19\"}]", "priority": 4, "points": "[{\"id\": \"6804F\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. May 17, 9PM-May 20, STOP NOT SERVED. T-bus to SIMONIS at CIM. / KERKH. JETTE, via bus 88 from PR. LEOPOLD.\", \"fr\": \"Travaux. 17/5, 21h-20/5, ARRET NON DESSERVI. T-bus vers SIMONIS \u00e0 CIM. JETTE, via bus 88 depuis PRINCE LEOPOLD.\", \"nl\": \"Werken. 17/5, 21u-20/5, HALTE NIET BEDIEND. T-bus naar SIMONIS aan KERKH. JETTE, via bus 88 vanaf PRINS LEOPOLD.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"19\"}]", "priority": 4, "points": "[{\"id\": \"4955F\"}]"},{"content": "[{\"text\": [{\"en\": \"From Dec 4, works. STOP NOT SERVED. Take bus 20 at the previous stop, GARE DU NORD / NOORDSTATION.\", \"fr\": \"D\u00e8s le 4/12, travaux. ARRET NON DESSERVI. Prenez le bus 20 \u00e0 l'arr\u00eat pr\u00e9c\u00e9dent, GARE DU NORD.\", \"nl\": \"Vanaf 4/12, werken. HALTE NIET BEDIEND. Neem bus 20 aan de vorige halte, NOORDSTATION.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"20\"}]", "priority": 4, "points": "[{\"id\": \"3400\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. As of Apr 15, bus 21 diverted btw TREVES and MICHEL-ANGE via MAELBEEK. Stop SCHUMAN moved rue Archim\u00e8de.\", \"fr\": \"Travaux. D\u00e8s le 15/4,bus 21 d\u00e9vi\u00e9 entre TREVES et MICHEL-ANGE via MAELBEEK. Arr\u00eat SCHUMAN d\u00e9plac\u00e9 rue Archim\u00e8de.\", \"nl\": \"Werken. Vanaf 15/4, bus 21 omgeleid tss TRIER en MICHELANGELO via MAALBEEK. Halte SCHUMAN verplaatst Archimedesstr\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"21\"}]", "priority": 6, "points": "[{\"id\": \"1132\"}, {\"id\": \"1262B\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. As of Apr 15, STOP NOT SERVED. Stop of bus 21: rue Archim\u00e8de / Archimedesstraat 16.\", \"fr\": \"Travaux. D\u00e8s le 15/4, ARRET NON DESSERVI. Arr\u00eat du bus 21: rue Archim\u00e8de 16.\", \"nl\": \"Werken. Vanaf 15/4, HALTE NIET BEDIEND. Halte van bus 21: Archimedesstraat 16.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"21\"}]", "priority": 4, "points": "[{\"id\": \"2083\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. As of Apr 15, bus 21 diverted btw MICHEL- ANGE and TOULOUSE via MAELBEEK. Stop SCHUMAN moved rue Franklin.\", \"fr\": \"Travaux. D\u00e8s le 15/4,bus 21 d\u00e9vi\u00e9 entre MICHEL- ANGE et TOULOUSE via MAELBEEK. Arr\u00eat SCHUMAN d\u00e9plac\u00e9 rue Franklin.\", \"nl\": \"Werken. Vanaf 15/4, bus 21 omgeleid tss MICHELANGELO en TOULOUSE via MAALBEEK. SCHUMAN verplaatst Franklinstr.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"21\"}]", "priority": 6, "points": "[{\"id\": \"6454\"}, {\"id\": \"3199\"}, {\"id\": \"3361\"}, {\"id\": \"3904\"}, {\"id\": \"3905\"}, {\"id\": \"3425\"}, {\"id\": \"3458\"}, {\"id\": \"3707\"}, {\"id\": \"3204\"}, {\"id\": \"3468\"}, {\"id\": \"3203\"}, {\"id\": \"3214\"}, {\"id\": \"3367\"}, {\"id\": \"1464\"}, {\"id\": \"3466\"}, {\"id\": \"2695\"}, {\"id\": \"1463\"}, {\"id\": \"3201\"}, {\"id\": \"4500\"}, {\"id\": \"3911\"}, {\"id\": \"4505\"}, {\"id\": \"2924\"}]"},{"content": "[{\"text\": [{\"en\": \"From Jan 18, works. STOP NOT SERVED. Temporary stop: Avenue de Roodebeeklaan 45.\", \"fr\": \"D\u00e8s le 18/1, travaux. ARRET NON DESSERVI. Arr\u00eat provisoire: Avenue de Roodebeek 45.\", \"nl\": \"Vanaf 18/1, werken. HALTE NIET BEDIEND. Tijdelijke halte: Roodebeeklaan 45.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"28\"}]", "priority": 4, "points": "[{\"id\": \"1404\"}]"},{"content": "[{\"text\": [{\"en\": \"From FEB 2, works. Stop SAINT-JOSSE moved, go to the temporary stop: chauss\u00e9e de Louvain 73.\", \"fr\": \"D\u00e8s le 26/2, travaux. Arr\u00eat SAINT-JOSSE d\u00e9plac\u00e9, allez \u00e0 l'arr\u00eat provisoire : chauss\u00e9e de Louvain 73.\", \"nl\": \"Vanaf 26/2, werken. Halte SINT-JOOST verplaatst, ga naar de tijdelijke halte: Leuvensesteenweg 73.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"29\"}]", "priority": 4, "points": "[{\"id\": \"1570\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. STOP NOT OPERATED. Temporary stop: rue de Pavie / Paviastraat 53.\", \"fr\": \"Travaux. ARRET NON DESSERVI. Arr\u00eat provisoire: rue de Pavie 53.\", \"nl\": \"Werken. HALTE NIET BEDIEND. Tijdelijke halte: Paviastraat 53.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"29\"}]", "priority": 5, "points": "[{\"id\": \"1568\"}]"},{"content": "[{\"text\": [{\"en\": \"Bus 29: works. Stop CLOVIS not served. Temporary stop: rue de Pavie / Paviastraat 53.\", \"fr\": \"Bus 29 : travaux. Arr\u00eat CLOVIS non desservi. Arr\u00eat provisoire: rue de Pavie 53.\", \"nl\": \"Bus 29: werken. Halte CLOVIS niet bediend. Tijdelijke halte: Paviastraat 53.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"29\"}]", "priority": 6, "points": "[{\"id\": \"6454\"}, {\"id\": \"1561\"}, {\"id\": \"1550\"}, {\"id\": \"1385\"}, {\"id\": \"1560\"}, {\"id\": \"1558\"}, {\"id\": \"1557\"}, {\"id\": \"1567\"}, {\"id\": \"1578\"}, {\"id\": \"1566\"}, {\"id\": \"1554\"}, {\"id\": \"1565B\"}, {\"id\": \"1553\"}, {\"id\": \"3367\"}, {\"id\": \"1552\"}, {\"id\": \"3910\"}, {\"id\": \"1528\"}, {\"id\": \"1559\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. As of April 7th, stop served only by bus 66. Take bus 29, 63 or 65 at the stop of bus 71 to DELTA.\", \"fr\": \"Travaux. D\u00e8s le 7/4, arr\u00eat uniquement desservi par bus 66. Bus 29, 63 ou 65 \u00e0 l'arr\u00eat du bus 71 vers DELTA.\", \"nl\": \"Werken. Vanaf 7/4, halte enkel bediend door bus 66. Neem bus 29, 63 of 65 aan de halte van bus 71 naar DELTA.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"29\"}]", "priority": 4, "points": "[{\"id\": \"6445\"}]"},{"content": "[{\"text\": [{\"en\": \"Jan 7, 9PM-Jun 28,works. Tram 3 and 7 replaced by T-bus to DOCKS BRUXSEL. T-bus at this stop.\", \"fr\": \"7/1, 21h-28/6, travaux. Tram 3 et 7 remplac\u00e9s par des T-bus jusqu'\u00e0 DOCKS BRUXSEL. T-bus \u00e0 cet arr\u00eat.\", \"nl\": \"7/1, 21u-28/6, werken. Tram 3 en 7 vervangen door T-bus tot DOCKS BRUXSEL. T-bus aan deze halte.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"3\"}]", "priority": 4, "points": "[{\"id\": \"5707\"}]"},{"content": "[{\"text\": [{\"en\": \"Jan 7, 9PM-Jun 28, works. Stop not served. Stop  T-bus to ESPLANADE : av. Croix du Feu, crossing r. Heembeek.\", \"fr\": \"7/1, 21h-28/6, travaux. Arr\u00eat non desservi.Arr\u00eat T-bus vers ESPLANADE:av. Croix du Feu, carrefour rue de Heembeek.\", \"nl\": \"7/1, 21u-28/6, werken. Halte niet bediend.Halte T-bus naar ESPLANADE : Vuurkruisenlaan, kruispunt Heembeeklaan.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"3\"}]", "priority": 4, "points": "[{\"id\": \"5771\"}]"},{"content": "[{\"text\": [{\"en\": \"Jan 7, 9PM-Jun 28,works. Tram 3 interrupted btw ESPLANADE and DOCKS BRUXSEL. Stop of the T-bus: av. Araucarialn.\", \"fr\": \"7/1, 21h-28/6, travaux. Tram 3 interrompu entre ESPLANADE et DOCKS BRUXSEL. Arr\u00eat du T-bus: avenue de l'Araucaria.\", \"nl\": \"7/1, 21u-28/6, werken. Tram 3 onderbroken tss ESPLANADE en DOCKS BRUXSEL. Halte van de T-bus: Araucarialaan.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"3\"}]", "priority": 4, "points": "[{\"id\": \"5704F\"}]"},{"content": "[{\"text\": [{\"en\": \"Jan 7, 9PM-Jun 28, works.Tram 3 diverted to the stop DOCKS BRUXSEL of tram 7 and replaced by T-bus to ESPLANADE.\", \"fr\": \"7/1, 21h-28/6, travaux. Tram 3 d\u00e9vi\u00e9 vers l'arr\u00eat DOCKS BRUXSEL du tram 7 et remplac\u00e9 par des T-bus jsq ESPLANADE.\", \"nl\": \"7/1, 21u-28/6, werken. Tram 3 omgeleid naar de halte DOCKS BRUXSEL van tram 7 en vervangen door T-bus tot ESPLANADE.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"3\"}]", "priority": 4, "points": "[{\"id\": \"2337F\"}]"},{"content": "[{\"text\": [{\"en\": \"From Jan 7 at 9PM to Jun 28, works. Tram 3 replaced by T-bus. Stop T-bus: av. Croix du Feu / Vuurkruisenln, 211-213\", \"fr\": \"Du 7/1 \u00e0 21h au 28/6, travaux. Tram 3 remplac\u00e9 par des T-bus. Arr\u00eat du T-bus: avenue des Croix du Feu, 211-213\", \"nl\": \"Van 7/1 om 21u tot en met 28/6, werken. Tram 3 vervangen door T-bus. Halte T-bus: Vuurkruisenlaan, 211-213\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"3\"}]", "priority": 4, "points": "[{\"id\": \"5773\"}]"},{"content": "[{\"text\": [{\"en\": \"From jan 15, works. STOP NOT SERVED. Take bus 34 at the stop CLESSE of bus 72 to ADEPS.\", \"fr\": \"D\u00e8s le 15/1, travaux. ARRET NON DESSERVI. Prenez le bus 34 \u00e0 l'arr\u00eat CLESSE du bus 72 vers ADEPS.\", \"nl\": \"Vanaf 15/1, werken. HALTE NIET BEDIEND. Neem bus 34 aan de halte CLESSE van bus 72 naar ADEPS.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"34\"}]", "priority": 4, "points": "[{\"id\": \"1719\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. As of Apr 15, STOP NOT SERVED. Stop of bus 12: rue Archim\u00e8de / Archimedesstraat 16.\", \"fr\": \"Travaux. D\u00e8s le 15/4, ARRET NON DESSERVI. Arr\u00eat du bus 12: rue Archim\u00e8de 16.\", \"nl\": \"Werken. Vanaf 15/4, HALTE NIET BEDIEND. Halte van bus 12: Archimedesstraat 16.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"12\"}]", "priority": 4, "points": "[{\"id\": \"1418B\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. From Apr 23 until Jun 2, bus 13 and 88 diverted. Take bus 13 or 88 at the stop of bus 820 to UZ Brussel.\", \"fr\": \"Travaux; Du 23/4 au 2/6, bus 13 et 88 d\u00e9vi\u00e9s. Prenez le bus 13 ou 88 \u00e0 l'arr\u00eat du bus 820 vers UZ Brussel.\", \"nl\": \"Werken. Van 23/4 tot en met 2/6, bus 13 en 88 omgeleid. Neem bus 13 of 88 aan de halte van bus 820 naar UZ Brussel.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"13\"}]", "priority": 4, "points": "[{\"id\": \"1721\"}, {\"id\": \"1328\"}]"},{"content": "[{\"text\": [{\"en\": \"From Sep 5 6AM, works. STOP NOT SERVED. Bus 17 diverted between BRILLANT and BEAULIEU via Michiels\", \"fr\": \"D\u00e8s le 5/9 6h, travaux. ARRET NON DESSERVI. Bus 17 d\u00e9vi\u00e9 entre BRILLANT et BEAULIEU via Michiels\", \"nl\": \"Vanaf 5/9 6u, werken. HALTE NIET BEDIEND. Bus 17 omgeleid tussen BRILJANT en BEAULIEU via Michiels\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"17\"}]", "priority": 4, "points": "[{\"id\": \"4295\"}, {\"id\": \"4296\"}]"},{"content": "[{\"text\": [{\"en\": \"From Sep 5 6AM, works. STOP NOT SERVED. Temporary stop: rue du Brillant (across stop towards Heiligenborre)\", \"fr\": \"D\u00e8s le 5/9 6h, travaux. ARRET NON DESSERVI. Arr\u00eat provisoire: rue du Brillant (face \u00e0 l'arr\u00eat vers Heiligenborre)\", \"nl\": \"Vanaf 5/9 6u, werken. HALTE NIET BEDIEND. Tijdelijke halte: Briljantstraat (tgnover halte > Heiligenborre)\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"17\"}]", "priority": 4, "points": "[{\"id\": \"4293\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. Until mid-2024, T19 replaced by T-bus btw MIROIR and CIMETIERE DE JETTE. T-bus at stop of bus 13 to UZ-VUB.\", \"fr\": \"Travaux. Jsq mi-2024, T19 remplac\u00e9 par T-bus entre MIROIR et CIM. JETTE. T-bus \u00e0 l'arr\u00eat du bus 13 vers UZ-VUB.\", \"nl\": \"Werken. Tot midden 2024, T19 vervangen door T-bus tss SPIEGEL en KERKH. JETTE.  T-bus aan halte van B13 naar UZ-VUB.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"19\"}]", "priority": 4, "points": "[{\"id\": \"0471\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. Until mid-2024, T19 interrupted at MIROIR. Stop of T-bus 19: av. Jette 126 (next to this stop)\", \"fr\": \"Travaux. Jusque mi-2024, T19 interrompu \u00e0 MIROIR. Arr\u00eat du T-bus 19: av. de Jette, 126 (\u00e0 c\u00f4t\u00e9 de cet arr\u00eat).\", \"nl\": \"Werken. Tot midden 2024, T19 onderbroken aan SPIEGEL. Halte van T-bus 19: Jetselaan 126 (naast deze halte)\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"19\"}]", "priority": 4, "points": "[{\"id\": \"6864F\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. Until mid-2024, stop not served. Take tram 19 at CIMETIERE DE JETTE / KERKHOF VAN JETTE.\", \"fr\": \"Travaux. Jusque mi-2024, arr\u00eat non desservi. Prenez le tram 19 \u00e0 CIMETIERE DE JETTE.\", \"nl\": \"Werken. Tot midden 2024, halte niet bediend. Neem tram 19 aan KERKHOF VAN JETTE.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"19\"}]", "priority": 4, "points": "[{\"id\": \"6869G\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. May 17, 9PM-May 20, tram 19 replaced by a T-bus to DE WAND.T-bus at PR. LEOPOLD (stop of bus 88 to UZ-VUB).\", \"fr\": \"Travaux. 17/5, 21h-20/5, tram 19 remplac\u00e9 par des T-bus jsq DE WAND. T-bus \u00e0 PRINCE LEOPOLD (arr\u00eat du bus 88 vers UZ-VUB).\", \"nl\": \"Werken. 17/5, 21u-20/5, tram 19 vervangen door T-bus tot DE WAND. T-bus aan PRINS LEOPOLD (halte van bus 88 naar UZ-VUB)\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"19\"}]", "priority": 4, "points": "[{\"id\": \"4958F\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. Until mid-2024, stop not served. T-bus at VERBEYST (bd de Smet de Naeyer 211, stop of bus 14 to GARE DU NORD).\", \"fr\": \"Travaux, jusque mi-2024, arr\u00eat non desservi.T-bus \u00e0 VERBEYST (bd de Smet de Naeyer 211, arr\u00eat B14 vers GARE DU NORD).\", \"nl\": \"Werken. Tot midden 2024, halte niet bediend. T-bus aan VERBEYST (de Smet de Naeyerlaan 211, halte B14 naar NOORDST.)\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"19\"}]", "priority": 4, "points": "[{\"id\": \"6803F\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. From May 17 at 9PM until May 20, STOP NOT SERVED. T-bus to SIMONIS at DE WAND via tram 7.\", \"fr\": \"Travaux. Du 17/5 \u00e0 21h au 20/5, ARRET NON DESSERVI. T-bus vers SIMONIS \u00e0 DE WAND via tram 7.\", \"nl\": \"Werken. Van 17/5 om 21u tot 20/5, HALTE NIET BEDIEND. T-bus naar SIMONIS aan DE WAND via tram 7.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"19\"}]", "priority": 4, "points": "[{\"id\": \"2637F\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. Until mid-2024, T19 replaced by T-bus between MIROIR and CIMETIERE DE JETTE.\", \"fr\": \"Travaux. Jusque mi-2024, tram 19 remplac\u00e9 par des T-bus entre MIROIR et CIMETIERE DE JETTE.\", \"nl\": \"Werken. Tot midden 2024, tram 19 vervangen door T-bus tussen SPIEGEL en KERKHOF VAN JETTE.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"19\"}]", "priority": 5, "points": "[{\"id\": \"1306F\"}, {\"id\": \"5105F\"}, {\"id\": \"1094F\"}, {\"id\": \"1111\"}, {\"id\": \"5104F\"}, {\"id\": \"5103\"}, {\"id\": \"5102F\"}, {\"id\": \"1064\"}, {\"id\": \"5108\"}, {\"id\": \"5109\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. As of Apr 15, STOP NOT SERVED. Stop of bus 21: rue Franklinstraat 2a.\", \"fr\": \"Travaux. D\u00e8s le 15/4, ARRET NON DESSERVI. Arr\u00eat du bus 21: rue Franklin, 2a.\", \"nl\": \"Werken. Vanaf 15/4, HALTE NIET BEDIEND. Halte van bus 21: Franklinstraat 2a.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"21\"}]", "priority": 4, "points": "[{\"id\": \"1270B\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. As of Apr 15, bus 21 diverted. Take bus 21 at the stop of bus 64 to BORDET STATION.\", \"fr\": \"Travaux. D\u00e8s le 15/4, bus 21 d\u00e9vi\u00e9. Prenez le bus 21 \u00e0 l'arr\u00eat du bus 64 vers BORDET STATION.\", \"nl\": \"Werken. Vanaf 15/4, bus 21 omgeleid. Neem bus 21 aan de halte van bus 64 naar BORDET STATION.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"21\"}]", "priority": 4, "points": "[{\"id\": \"1133\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. As of Apr 15, STOP NOT SERVED. Take bus 21 at MAELBEEK / MAALBEEK (stop of bus 64 to BORDET STATION).\", \"fr\": \"Travaux. D\u00e8s le 15/4, ARRET NON DESSERVI. Prenez le bus 21 \u00e0 MAELBEEK (halte van bus 64 naar BORDET STATION).\", \"nl\": \"Werken. Vanaf 15/4, HALTE NIET BEDIEND. Neem bus 21 aan MAALBEEK (arr\u00eat du bus 64 vers BORDET STATION).\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"21\"}]", "priority": 4, "points": "[{\"id\": \"1416\"}]"},{"content": "[{\"text\": [{\"en\": \"Jan 7, 9PM-Jun 28, works. Tram 3 replaced by T-bus between DOCKS BRUXSEL and ESPLANADE. Info: stib-mivb.brussels\", \"fr\": \"7/1, 21h-28/6, travaux. Tram 3 remplac\u00e9 par des T-bus entre DOCKS BRUXSEL et ESPLANADE. Info: stib.brussels.\", \"nl\": \"7/1, 21u-28/6, werken. Tram 3 vervangen door T-bus tussen DOCKS BRUXSEL en ESPLANADE. info: mivb.brussels.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"3\"}]", "priority": 5, "points": "[{\"id\": \"5219F\"}, {\"id\": \"6179\"}, {\"id\": \"2537F\"}, {\"id\": \"0722\"}, {\"id\": \"9986F\"}, {\"id\": \"6424F\"}, {\"id\": \"0606\"}, {\"id\": \"6177F\"}, {\"id\": \"0626\"}, {\"id\": \"0516\"}, {\"id\": \"6209\"}, {\"id\": \"0725\"}, {\"id\": \"0726\"}, {\"id\": \"0616\"}, {\"id\": \"0506\"}, {\"id\": \"2200F\"}, {\"id\": \"0723\"}, {\"id\": \"0526\"}, {\"id\": \"0724\"}]"},{"content": "[{\"text\": [{\"en\": \"Jan 7, 9PM-Jun 28, works. Stop not served. T-bus to ESPLANADE at the stop of bus 56 to BUDA.\", \"fr\": \"7/1, 21h-28/6, travaux. Arr\u00eat non desservi. T-bus vers ESPLANADE \u00e0 l'arr\u00eat du bus 56 vers BUDA.\", \"nl\": \"7/1, 21u-28/6, werken. Halte niet bediend. T-bus naar ESPLANADE aan de halte van bus 56 naar BUDA.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"3\"}]", "priority": 4, "points": "[{\"id\": \"5770F\"}]"},{"content": "[{\"text\": [{\"en\": \"From Jan 7 at 9PM to Jun 28, works. Terminus not served. Stop of the T-bus: av. de Meysse, in front of number 125.\", \"fr\": \"Du 7/1 \u00e0 21h au 28/6, travaux. Terminus non desservi. Arr\u00eat du T-bus: avenue de Meysse, en face du num\u00e9ro 125.\", \"nl\": \"7/1, 21u-28/6, werken. Eindpunt niet bediend. Halte van de T-bus: Meiseselaan, tegenover nummer 125.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"3\"}]", "priority": 4, "points": "[{\"id\": \"5701\"}]"},{"content": "[{\"text\": [{\"en\": \"Jan 7, 9PM-Jun 28,works. Tram 3 interrupted btw ESPLANADE and DOCKS BRUXSEL. T-bus at stop of bus 83 to VAL MARIA\", \"fr\": \"7/1, 21h-28/6, travaux. Tram 3 interrompu entre ESPLANADE et DOCKS BRUXSEL. T-bus \u00e0 l'arr\u00eat du bus 83 vers VAL MARIA\", \"nl\": \"7/1, 21u-28/6, werken. Tram 3 onderbroken tss ESPLANADE en DOCKS BRUXSEL. T-bus halte van bus 83 naar MARI\u00cbNDAAL.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"3\"}]", "priority": 4, "points": "[{\"id\": \"5700G\"}]"},{"content": "[{\"text\": [{\"en\": \"Jan 7, 9PM-Jun 28,works. Tram 3 interrupted btw ESPLANADE and DOCKS BRUXSEL. Stop of the T-bus: next to this stop\", \"fr\": \"7/1, 21h-28/6, travaux. Tram 3 interrompu entre ESPLANADE et DOCKS BRUXSEL. Arr\u00eat du T-bus: \u00e0 c\u00f4t\u00e9 de cet arr\u00eat.\", \"nl\": \"7/1, 21u-28/6, werken. Tram 3 onderbroken tss ESPLANADE en DOCKS BRUXSEL. Halte van de T-bus: naast deze halte.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"3\"}]", "priority": 4, "points": "[{\"id\": \"5705\"}]"},{"content": "[{\"text\": [{\"en\": \"From Jan 15, works. STOP NOT SERVED. Stop of bus 34: boulevard du Souverain / Vorstlaan 159.\", \"fr\": \"D\u00e8s le 15/1, travaux. ARRET NON DESSERVI. Arr\u00eat du bus 34: boulevard du Souverain 159.\", \"nl\": \"Vanaf 15/1, werken. HALTE NIET BEDIEND. Halte van bus 34: Vorstlaan 159.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"34\"}]", "priority": 4, "points": "[{\"id\": \"1731\"}]"},{"content": "[{\"text\": [{\"en\": \"Afterwork. Every Thursday after 4PM, stop moved to rue de Tr\u00e8ves, in front of the stop in the other direction\", \"fr\": \"Afterwork. Tous les jeudis apr\u00e8s 16h, arr\u00eat d\u00e9plac\u00e9 rue de Tr\u00e8ves, en face de l'arr\u00eat dans l'autre sens.\", \"nl\": \"Afterwork.Elke donderdag na 16u, halte verplaatst naar de Trierstraat, tegenover de halte in de andere richting.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"34\"}]", "priority": 4, "points": "[{\"id\": \"1233\"}]"},{"content": "[{\"text\": [{\"en\": \"From Jan 15, works. Bus 34 diverted between HANKAR and BERGOJE via DEMEY.\", \"fr\": \"D\u00e8s le 15/1, travaux. Bus 34 d\u00e9vi\u00e9 entre HANKAR et BERGOJE via DEMEY.\", \"nl\": \"Vanaf 15/1, werken. Bus 34 omgeleid tussen HANKAR en BERGOJE via DEMEY.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"34\"}]", "priority": 5, "points": "[{\"id\": \"1712\"}, {\"id\": \"1733\"}, {\"id\": \"2291B\"}, {\"id\": \"6433\"}, {\"id\": \"1729\"}, {\"id\": \"1728\"}, {\"id\": \"1706\"}, {\"id\": \"1716\"}, {\"id\": \"1715\"}, {\"id\": \"1714\"}, {\"id\": \"1824\"}, {\"id\": \"1713\"}]"},{"content": "[{\"text\": [{\"en\": \"From Jan 15, works. STOP NOT SERVED. Take bus 34 at the stop RO(O)DENBERG of bus 72 to ADEPS.\", \"fr\": \"D\u00e8s le 15/1, travaux. ARRET NON DESSERVI. Prenez le bus 34 \u00e0 l'arr\u00eat ROODENBERG du bus 72 vers ADEPS.\", \"nl\": \"Vanaf 15/1, werken. HALTE NIET BEDIEND. Neem bus 34 aan de halte RODENBERG van bus 72 naar ADEPS.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"34\"}]", "priority": 4, "points": "[{\"id\": \"1720B\"}]"},{"content": "[{\"text\": [{\"en\": \"From Apr 3 at 6AM, works. Bus 38 diverted between LONGCHAMP and HOUZEAU via rue Edith Cavellstraat.\", \"fr\": \"D\u00e8s le 3/4 \u00e0 6h, travaux. Bus 38 d\u00e9vi\u00e9 entre LONGCHAMP et HOUZEAU via rue Edith Cavell.\", \"nl\": \"Vanaf 3/4 om 6u, werken. Bus 38 omgeleid tussen LONGCHAMP en HOUZEAU via Edith Cavellstraat.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"38\"}]", "priority": 5, "points": "[{\"id\": \"1910\"}, {\"id\": \"3503\"}, {\"id\": \"1909\"}, {\"id\": \"6433\"}, {\"id\": \"3122\"}, {\"id\": \"1906\"}, {\"id\": \"1729\"}, {\"id\": \"1903\"}, {\"id\": \"1912\"}]"},{"content": "[{\"text\": [{\"en\": \"From Apr 3 at 6AM, works. STOP NOT SERVED. Bus 38 at the stop LANGEVELD of bus 60 to AMBIORIX.\", \"fr\": \"D\u00e8s le 3/4 \u00e0 6h, travaux. ARRET NON DESSERVI. Bus 38 \u00e0 l'arr\u00eat LANGEVELD du bus 60 vers AMBIORIX.\", \"nl\": \"Vanaf 3/4 om 6u, werken. HALTE NIET BEDIEND. Bus 38 aan halte LANGEVELD van bus 60 naar AMBIORIX.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"38\"}]", "priority": 4, "points": "[{\"id\": \"1919\"}]"},{"content": "[{\"text\": [{\"en\": \"Afterwork. Every Thursday after 4PM, stop moved to rue de Tr\u00e8ves, in front of the stop in the other direction\", \"fr\": \"Afterwork. Tous les jeudis apr\u00e8s 16h, arr\u00eat d\u00e9plac\u00e9 rue de Tr\u00e8ves, en face de l'arr\u00eat dans l'autre sens.\", \"nl\": \"Afterwork.Elke donderdag na 16u, halte verplaatst naar de Trierstraat, tegenover de halte in de andere richting.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"38\"}]", "priority": 4, "points": "[{\"id\": \"1233\"}]"},{"content": "[{\"text\": [{\"en\": \"From Apr 3 at 6AM, works. STOP NOT SERVED. Bus 38 at the stop LANGEVELD of bus 60 to UCCLE CALEVOET.\", \"fr\": \"D\u00e8s le 3/4 \u00e0 6h, travaux. ARRET NON DESSERVI. Bus 38 \u00e0 l'arr\u00eat LANGEVELD du bus 60 vers UCCLE CALEVOET.\", \"nl\": \"Vanaf 3/4 om 6u, werken. HALTE NIET BEDIEND. Bus 38 aan halte LANGEVELD van bus 60 naar UKKEL KALEVOET.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"38\"}]", "priority": 4, "points": "[{\"id\": \"1971\"}]"},{"content": "[{\"text\": [{\"fr\": \"Bon voyage sur nos lignes !\", \"nl\": \"Een goede reis op onze lijnen gewenst!\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"39\"}]", "priority": 9, "points": "[{\"id\": \"5519\"}]"},{"content": "[{\"text\": [{\"en\": \"From Apr 3 at 6AM, works. STOP NOT SERVED. Take bus 38 and 41 at the next stop, HOUZEAU.\", \"fr\": \"D\u00e8s le 3/4 \u00e0 6h, travaux. ARRET NON DESSERVI. Prenez les bus 38 et 41 \u00e0 l'arr\u00eat suivant, HOUZEAU.\", \"nl\": \"Vanaf 3/4 om 6u, werken. HALTE NIET BEDIEND. Neem bus 38 en 41 aan de volgende halte, HOUZEAU.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"41\"}]", "priority": 4, "points": "[{\"id\": \"1920\"}]"},{"content": "[{\"text\": [{\"en\": \"From Apr 3 at 6AM, works. STOP NOT SERVED. Take bus 38 and 41 at the previous stop, HOUZEAU.\", \"fr\": \"D\u00e8s le 3/4 \u00e0 6h, travaux. ARRET NON DESSERVI. Prenez les bus 38 et 41 \u00e0 l'arr\u00eat pr\u00e9c\u00e9dent, HOUZEAU.\", \"nl\": \"Vanaf 3/4 om 6u, werken. HALTE NIET BEDIEND. Neem bus 38 en 41 aan de vorige halte, HOUZEAU.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"41\"}]", "priority": 4, "points": "[{\"id\": \"1970\"}]"},{"content": "[{\"text\": [{\"en\": \"From Mar 4, works. Bus 43 and N11 diverted. Take the bus at GRIOTTES / NOORDKRIEKEN.\", \"fr\": \"D\u00e8s le 4/3, travaux. Bus 43 et N11 d\u00e9vi\u00e9s. Prenez le bus \u00e0 GRIOTTES.\", \"nl\": \"Vanaf 4/3, werken. Bus 43 en N11 omgeleid. Neem de bus aan NOORDKRIEKEN.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"43\"}]", "priority": 4, "points": "[{\"id\": \"1957B\"}, {\"id\": \"1933B\"}, {\"id\": \"1939\"}]"},{"content": "[{\"text\": [{\"en\": \"As from 21 Sept, works. Stop moved +-60m forwards.\", \"fr\": \"D\u00e8s le 21/9, travaux. Arr\u00eat avanc\u00e9 de +-60m.\", \"nl\": \"Vanaf 21/9, werken. Halte +-60m vooruitgebracht.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"45\"}]", "priority": 4, "points": "[{\"id\": \"3462\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. Until end of August, bus 46 not operated btw WTC-GLIBERT and CENTRAL STATION. Walk to the center.\", \"fr\": \"Travaux. Jsq fin ao\u00fbt, bus 46 ne circule pas entre WTC-GLIBERT et GARE CENTRALE.Pour le centre, continuez \u00e0 pied\", \"nl\": \"Werken. Tot einde augustus rijdt bus 46 niet tss WTC-GLIBERT en CENTRAAL STATION. Voor het centrum, ga te voet.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"46\"}]", "priority": 5, "points": "[{\"id\": \"2835\"}]"},{"content": "[{\"text\": [{\"en\": \"From Jan 22 at 7AM, works. STOP NOT SERVED. Stop of bus 46: rue de Laeken / Lakensestraat 34.\", \"fr\": \"D\u00e8s le 22/1 \u00e0 7h, travaux. ARRET NON DESSERVI. Arr\u00eat du bus 46: rue de Laeken 34.\", \"nl\": \"Van 22/1 om 7u, werken. HALTE NIET BEDIEND. Halte van bus 46: Lakensestraat 34.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"46\"}]", "priority": 4, "points": "[{\"id\": \"3469\"}]"},{"content": "[{\"text\": [{\"en\": \"Until Summer of 2024, works. Stop not served. Stop of bus 47: CROIX DE GUERRE / OORLOGSKRUISEN.\", \"fr\": \"Jusqu'\u00e0 l'\u00e9t\u00e9 2024, travaux. Arr\u00eat non desservi. Arr\u00eat du bus 47 : CROIX DE GUERRE.\", \"nl\": \"Tot zomer 2024, werken. Halte niet bediend. Halte van bus 47: OORLOGSKRUISEN.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"47\"}]", "priority": 4, "points": "[{\"id\": \"1987\"}]"},{"content": "[{\"text\": [{\"en\": \"From Oct 7, works. STOP NOT OPERATED. Temporary stop: David Terniersstraat 115\", \"fr\": \"D\u00e8s le 7/10, travaux. ARRET NON DESSERVI. Arr\u00eat provisoire : David Terniersstraat 115\", \"nl\": \"Vanaf 7/10, werken. HALTE NIET BEDIEND. Tijdelijke halte: David Terniersstraat 115\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"47\"}]", "priority": 4, "points": "[{\"id\": \"9627\"}]"},{"content": "[{\"text\": [{\"en\": \"Until Summer of 2024, works. As of Mar 3, STOP NOT SERVED. Stop of bus 47 57: ANTOON VAN OSS.\", \"fr\": \"Jusqu'\u00e0 l'\u00e9t\u00e9 2024, travaux. D\u00e8s le 4/3, ARRET NON DESSERVI. Arr\u00eat des bus 47 57 : ANTOON VAN OSS.\", \"nl\": \"Tot zomer 2024, werken. Vanaf 4/3, HALTE NIET BEDIEND. Halte van bus 47 57: ANTOON VAN OSS\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"47\"}]", "priority": 4, "points": "[{\"id\": \"1827\"}]"},{"content": "[{\"text\": [{\"en\": \"From Feb 7, works. STOP NOT SERVED. Temporary stop: Vlierkensstraat 174.\", \"fr\": \"D\u00e8s le 7/2, travaux. ARRET NON DESSERVI. Arr\u00eat provisoire: Vlierkensstraat 174.\", \"nl\": \"Vanaf 7/2, werken. HALTE NIET BEDIEND. Tijdelijke halte: Vlierkensstraat 174.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"47\"}]", "priority": 4, "points": "[{\"id\": \"9605\"}]"},{"content": "[{\"text\": [{\"en\": \"Until Summer of 2024, works. Stop not served. Stop of bus 47: VERGER / BOOMGAARD (av. Croix de Guerre/Oorlogskruisenln)\", \"fr\": \"Jusqu'\u00e0 l'\u00e9t\u00e9 2024, travaux. Arr\u00eat non desservi. Arr\u00eat du bus 47 : VERGER (avenue des Croix de Guerre).\", \"nl\": \"Tot zomer 2024, werken. Halte niet bediend. Halte van bus 47: BOOMGAARD (Oorlogskruisenlaan).\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"47\"}]", "priority": 4, "points": "[{\"id\": \"2312\"}, {\"id\": \"2363\"}]"},{"content": "[{\"text\": [{\"en\": \"From Jan 9th at 6AM, works. STOP UNSERVED. Go to the stop HOP. MILITAIR(E) HOSP. from B53.\", \"fr\": \"D\u00e8s le 9/1 \u00e0 6h, travaux. ARRET NON DESSERVI. Aller \u00e0 l'arr\u00eat HOP. MILITAIRE du B53.\", \"nl\": \"Vanaf 9/1 om 6u, werken. HALTE NIET BEDIEND. Ga naar de halte MILITAIR HOSP. van B53.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"47\"}]", "priority": 4, "points": "[{\"id\": \"3067\"}]"},{"content": "[{\"text\": [{\"en\": \"Until Summer of 2024, works. Bus 47 diverted btw VTM and RAMIER. As of Mar 18, stop HOPITAL MILITAIRE in rue Bruyn.\", \"fr\": \"Jsq \u00e9t\u00e9 2024, travaux. Bus 47 d\u00e9vi\u00e9 entre VTM et RAMIER. D\u00e8s le 18/3, arr\u00eat HOPITAL MILITAIRE rue Bruyn.\", \"nl\": \"Tot zomer 2024, werken. Bus 47 omgeleid tussen VTM en BOSDUIF. Vanaf 18/3,halte MILITAIR HOSP in de Bruynstraat.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"47\"}]", "priority": 5, "points": "[{\"id\": \"9634\"}, {\"id\": \"9784B\"}, {\"id\": \"9786\"}, {\"id\": \"9632\"}, {\"id\": \"9606\"}]"},{"content": "[{\"text\": [{\"en\": \"Until Summer of 2024, works. Stop not served. Take bus 47 or 56 at ANTOON VAN OSS. For HOP MILITAIRE , walk.\", \"fr\": \"Jsq \u00e9t\u00e9 2024, travaux. Arr\u00eat non desservi. Bus 47 ou 56 \u00e0 ANTOON VAN OSS. Pour HOPITAL MILITAIRE, \u00e0 pied.\", \"nl\": \"Tot zomer 2024, werken. Halte niet bediend. Neem bus 47 of 56 aan ANTOON VAN OSS. Voor MILITAIR HOSPITAAL, ga te voet.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"47\"}]", "priority": 4, "points": "[{\"id\": \"1838\"}]"},{"content": "[{\"text\": [{\"en\": \"Until Summer of 2024, works. B47 diverted btw CHEMIN VERT and ANT VAN OSS. As of Mar 3, diverted to H. MILITAIRE\", \"fr\": \"Jsq \u00e9t\u00e9 2024, travaux. B47 d\u00e9vi\u00e9 entre CHEMIN VERT et ANTOON VAN OSS. D\u00e8s le 4/3, d\u00e9vi\u00e9 jsq HOPITAL MILITAIRE.\", \"nl\": \"Tot zomer 2024, werken. Bus 47 omgeleid tss GROENWEG en ANTOON VAN OSS. Vanaf 4/3, omgeleid tot MILITAIR HOSPITAAL\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"47\"}]", "priority": 5, "points": "[{\"id\": \"2314\"}]"},{"content": "[{\"text\": [{\"en\": \"From Apr 20, works. Stop not served. Take B49 next to number 26 (100m before this stop).\", \"fr\": \"D\u00e8s le 20/4, travaux. Arr\u00eat non desservi. Arr\u00eat du B49 \u00e0  hauteur du num\u00e9ro 26 (100 m avant cet arr\u00eat).\", \"nl\": \"Vanaf 20/4, werken. Halte niet bediend. Neem B49 ter hoogte van nummer 26 (100m voor deze halte).\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"49\"}]", "priority": 4, "points": "[{\"id\": \"2225\"}]"},{"content": "[{\"text\": [{\"en\": \"From Apr 22 at 12PM, works. STOP NOT SERVED. Stop of bus 50: avenue Paul Gilsonlaan, just before this stop.\", \"fr\": \"D\u00e8s 22/4 \u00e0 12h, travaux. ARRET NON DESSERVI. Arr\u00eat du bus 50: avenue Paul Gilson, peu avant cet arr\u00eat.\", \"nl\": \"Vanaf 22/4 om 12u, werken. HALTE NIET BEDIEND. Halte van bus 50: Paul Gilsonlaan, net voor deze halte.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"50\"}]", "priority": 4, "points": "[{\"id\": \"2609\"}]"},{"content": "[{\"text\": [{\"en\": \"Until 2026, works. Bus 50 diverted to FOREST CENTRE / VORST CENTRUM. Stop of bus 50: r. Abbesses / Abdissenstr.\", \"fr\": \"Jusqu'en 2026, travaux. Bus 50 d\u00e9vi\u00e9 jusqu'\u00e0 FOREST CENTRE. Arr\u00eat du bus 50: rue des Abbesses.\", \"nl\": \"Tot 2026, werken. Bus 50 omgeleid tot VORST CENTRUM. Halte van bus 50: Abdissenstraat.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"50\"}]", "priority": 4, "points": "[{\"id\": \"5152\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. From May 17 at 9PM until May 20, T-bus 19 does not serve HOP. BRUGMANN. Connection to T-bus 19 at CIM. JETTE.\", \"fr\": \"Travaux. 17/5, 21h-20/5, T-bus 19 ne dessert pas HOPITAL BRUGMANN. Correspondance T-bus 19 \u00e0 CIMETIERE DE JETTE.\", \"nl\": \"17/5, 21u-20/5, werken. T-bus 19 bedient BRUGMANN-ZKH. niet. Aansluiting met T-bus 19 aan KERKHOF VAN JETTE.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"51\"}]", "priority": 4, "points": "[{\"id\": \"5402\"}, {\"id\": \"5399F\"}, {\"id\": \"1290\"}]"},{"content": "[{\"text\": [{\"en\": \"Until Summer of 2024, works. Stop not served. Stop of bus 53: KRUIPWEG (rue du Paturage / Weilandstraat).\", \"fr\": \"Jusqu'\u00e0 l'\u00e9t\u00e9 2024, travaux. Arr\u00eat non desservi. Arr\u00eat du bus 53 : KRUIPWEG (rue du Paturage)\", \"nl\": \"Tot zomer 2024, werken. Halte niet bediend. Halte van bus 53: KRUIPWEG (Weilandstraat)\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"53\"}]", "priority": 4, "points": "[{\"id\": \"2312\"}, {\"id\": \"2363\"}]"},{"content": "[{\"text\": [{\"en\": \"On May 5 until 8PM, flea market. STOP NOT SERVED. Stop T-bus and bus 54: crossing Lesbroussart- Louise, on tram tracks.\", \"fr\": \"19/5 jsq 20h, brocante. ARRET NON DESSERVI. Arr\u00eat T-bus et B54: carrefour Lesbroussart- Louise, sur les voies.\", \"nl\": \"19/5 tot 20u,rommelmarkt HALTE NIET BEDIEND. Halte T-bus en B54: kruispunt Lesbroussart- Louiza, op tramsporen.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"54\"}]", "priority": 4, "points": "[{\"id\": \"2971\"}]"},{"content": "[{\"text\": [{\"en\": \"From Apr 2, 2024 to June 2025, works. STOP NOT SERVED. To go to BERVOETS, take bus 50 or T-bus at FOREST CENTRE.\", \"fr\": \"Du 2/4/2024 \u00e0 juin 2025, travaux. ARRET NON DESSERVI. Pour rejoindre BERVOETS, bus 50 ou T-bus \u00e0 FOREST CENTRE.\", \"nl\": \"Van 2/4/2024 tot juni 2025, werken. HALTE NIET BEDIEND. Voor BERVOETS, neem bus 50 of de T-bus aan VORST CENTRUM.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"54\"}]", "priority": 4, "points": "[{\"id\": \"5152\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. From Apr 2 until June 2025, STOP NOT SERVED. Take bus 54 at the previous stop, FOREST CENTRE.\", \"fr\": \"Travaux. Du 2/4 \u00e0 juin 2025, ARRET NON DESSERVI. Prenez le bus 54 \u00e0 l'arr\u00eat pr\u00e9c\u00e9dent, FOREST CENTRE.\", \"nl\": \"Werken. Vanaf 2/4 tot juni 2025, HALTE NIET BEDIEND. Neem bus 54 aan de vorige halte, VORST CENTRUM.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"54\"}]", "priority": 4, "points": "[{\"id\": \"5719\"}]"},{"content": "[{\"text\": [{\"en\": \"From Apr 2, 2024 to June 2025, works. STOP NOT SERVED. To go to BERVOETS, take bus 50 or T-bus(stop: r. Abbesses)\", \"fr\": \"Du 2/4/2024 \u00e0 juin 2025, travaux. ARRET NON DESSERVI. Pour rejoindre BERVOETS,bus 50 ou T-bus (arr\u00eat: r. des Abbesses)\", \"nl\": \"Van 2/4/2024 tot juni 2025, werken. HALTE NIET BEDIEND. Voor BERVOETS, neem bus 50 of de T-bus (halte: Abdissenstraat)\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"54\"}]", "priority": 4, "points": "[{\"id\": \"5161\"}]"},{"content": "[{\"text\": [{\"en\": \"Apr 2, 2024-June 2025, works. Bus 54 diverted btw FOREST NATIONAL and FOREST CENTRE. Info: stib-mivb.brussels\", \"fr\": \"Du 2/4/2024 \u00e0 juin 2025, travaux. Bus 54 d\u00e9vi\u00e9 entre FOREST NATIONAL et FOREST CENTRE. Info: stib.brussels.\", \"nl\": \"2/4/2024-juni 2025, werken. Bus 54 omgeleid tussen VORST NATIONAAL en VORST CENTRUM. Info: mivb.brussels\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"54\"}]", "priority": 5, "points": "[{\"id\": \"2934A\"}, {\"id\": \"2950\"}, {\"id\": \"2411B\"}, {\"id\": \"2937B\"}, {\"id\": \"2936\"}, {\"id\": \"2935\"}]"},{"content": "[{\"text\": [{\"en\": \"On May 5 until 8PM, flea market. STOP NOT SERVED. Stop of bus 54: rue Defacqzstraat 133.\", \"fr\": \"Le 19/5 jusqu'\u00e0 20h, brocante. ARRET NON DESSERVI. Arr\u00eat du bus 54: rue Defacqz 133.\", \"nl\": \"Op 19/5 tot 20u, rommelmarkt. HALTE NIET BEDIEND. Halte van bus 54: Defacqzstraat 133.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"54\"}]", "priority": 4, "points": "[{\"id\": \"2931\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. Bus 56 diverted between VERGER and VAN PRAET via avenue des Croix de Guerre\", \"fr\": \"Travaux. Bus 56 d\u00e9vi\u00e9 entre VERGER et VAN PRAET via avenue des Croix de Guerre\", \"nl\": \"Werken. Bus 56 omgeleid tussen BOOMGAARD en VAN PRAET via Oorlogskruisenlaan\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"56\"}]", "priority": 5, "points": "[{\"id\": \"2823B\"}, {\"id\": \"2766\"}]"},{"content": "[{\"text\": [{\"en\": \"Until Summer of 2024, works. Bus 56 diverted. Take bus 56 at ANTOON VAN OSS.\", \"fr\": \"Jusqu'\u00e0 l'\u00e9t\u00e9 2024, travaux. Bus 56 d\u00e9vi\u00e9. Prenez le bus 56 \u00e0 ANTOON VAN OSS.\", \"nl\": \"Tot zomer 2024, werken. Bus 56 omgeleid. Neem bus 56 aan ANTOON VAN OSS.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"56\"}]", "priority": 4, "points": "[{\"id\": \"1827\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. STOP NOT SERVED. Take bus 47 56 at the usual stop of trams 3 7 direction CHURCHILL / VANDERKINDERE.\", \"fr\": \"Travaux. ARRET NON DESSERVI. Prenez le bus 47 56 \u00e0 l'arr\u00eat habituel des trams 3 7 vers CHURCHILL/VANDERKINDERE.\", \"nl\": \"Werken. HALTE NIET BEDIEND. Neem bus 47 56 aan de gebruikelijke halte van tram 3 7 naar CHURCHILL/VANDERKINDERE.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"56\"}]", "priority": 4, "points": "[{\"id\": \"6368C\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. As of Apr 15, bus 56 diverted from AMBIORIX to MAELBEEK. Connection metro at MAELBEEK / MAALBEEK.\", \"fr\": \"Travaux. D\u00e8s le 15/4, bus 56 d\u00e9vi\u00e9 depuis AMBIORIX vers MAELBEEK. Correspondance m\u00e9tro \u00e0 MAELBEEK.\", \"nl\": \"Werken. Vanaf 15/4, bus 56 omgeleid vanaf AMBIORIX naar MAALBEEK. Aansluiting metro aan MAALBEEK.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"56\"}]", "priority": 6, "points": "[{\"id\": \"2092\"}, {\"id\": \"6461\"}, {\"id\": \"5740\"}, {\"id\": \"2100\"}, {\"id\": \"2067\"}, {\"id\": \"6191\"}, {\"id\": \"9291\"}, {\"id\": \"2097\"}, {\"id\": \"2096\"}, {\"id\": \"2094\"}, {\"id\": \"1007\"}, {\"id\": \"2920\"}, {\"id\": \"3414\"}, {\"id\": \"2105\"}, {\"id\": \"2102\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. As of March 18, bus 56 operates normally between HOP. MILITAIRE / MILITAIR HOSP. and ANTOON VAN OSS.\", \"fr\": \"Travaux. D\u00e8s le 18/3, bus 56 circule \u00e0 nouveau normalement entre HOPITAL MILITAIRE et ANTOON VAN OSS.\", \"nl\": \"Werken. Vanaf 18/3 rijdt B56 opnieuw langs zijn gebruikelijke reisweg tss MILITAIR HOSPITAAL en ANTOON VAN OSS.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"56\"}]", "priority": 5, "points": "[{\"id\": \"2365\"}, {\"id\": \"2827\"}, {\"id\": \"1989\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. STOP NOT SERVED. Temporary stop: avenue des Croix de Guerre 78\", \"fr\": \"Jusqu'\u00e0 l'\u00e9t\u00e9 2024, travaux. Arr\u00eat des bus 47 et 56 : avenue des Croix de Guerre 78.\", \"nl\": \"Tot zomer 2024, werken. Halte van bus 47 en 56: Oorlogskruisenlaan 78.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"56\"}]", "priority": 4, "points": "[{\"id\": \"2377\"}, {\"id\": \"2299\"}]"},{"content": "[{\"text\": [{\"en\": \"Until Summer of 2024, works. Stop not served. Take bus 47 or 57 at ANTOON VAN OSS (stop of bus 56 to BUDA).\", \"fr\": \"Jsq \u00e9t\u00e9 2024, travaux. Arr\u00eat non desservi. Prenez le bus 47 ou 57 \u00e0 ANTOON VAN OSS (arr\u00eat du bus 56 vers BUDA).\", \"nl\": \"Tot zomer 2024, werken. Halte niet bediend. Neem bus 47 of 57 aan ANTOON VAN OSS (halte van bus 56 naar BUDA).\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"56\"}]", "priority": 4, "points": "[{\"id\": \"1837\"}]"},{"content": "[{\"text\": [{\"en\": \"Until Summer of 2024, works. Bus 56 diverted. Stop of bus 56: avenue des Croix de l'Yser / IJzerkruisenlaan 36.\", \"fr\": \"Jusqu'\u00e0 l'\u00e9t\u00e9 2024, travaux. Bus 56 d\u00e9vi\u00e9. Arr\u00eat du bus 56 : avenue des Croix de l'Yser 36.\", \"nl\": \"Tot zomer 2024, werken. Bus 56 omgeleid. Halte van bus 56: IJzerkruisenlaan 36.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"56\"}]", "priority": 4, "points": "[{\"id\": \"2093\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. As of Apr 15, STOP NOT SERVED. Take bus 56 at AMBIORIX (stop of bus 64 to Bordet Station).\", \"fr\": \"Travaux. D\u00e8s le 15/4, ARRET NON DESSERVI. Prenez le bus 56 \u00e0 AMBIORIX (arr\u00eat du bus 64 vers Bordet Station).\", \"nl\": \"Werken. Vanaf 15/4, HALTE NIET BEDIEND. Neem bus 56 aan AMBIORIX (halte van bus 64 naar Bordet Station).\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"56\"}]", "priority": 4, "points": "[{\"id\": \"1474B\"}, {\"id\": \"2083\"}]"},{"content": "[{\"text\": [{\"en\": \"Until Summer 2024,works. B56 diverted btw P. BENOIT and VAN PRAET. As of Mar 18, bus 56 serves the stop MERCATOR.\", \"fr\": \"Jsq \u00e9t\u00e9 2024, travaux. Bus 56 d\u00e9vi\u00e9 entre P. BENOIT et VAN PRAET. D\u00e8s le 18/3, bus 56 dessert \u00e0 nouveau MERCATOR.\", \"nl\": \"Tot zomer 2024, werken. Bus 56 omgeleid tss P. BENOIT en VAN PRAET. Vanaf 18/3 bedient bus 56 opnieuw MERCATOR.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"56\"}]", "priority": 4, "points": "[{\"id\": \"2379\"}, {\"id\": \"1991\"}]"},{"content": "[{\"text\": [{\"en\": \"Until Summer of 2024, works. As of Mar 18, stop served normally by bus 57.\", \"fr\": \"Jusqu'\u00e0 l'\u00e9t\u00e9 2024, travaux. D\u00e8s le 18/3, arr\u00eat \u00e0 nouveau desservi par les bus 57.\", \"nl\": \"Tot zomer 2024, werken. Vanaf 18/3, halte opnieuw bediend door bus 57.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"57\"}]", "priority": 4, "points": "[{\"id\": \"2352\"}]"},{"content": "[{\"text\": [{\"en\": \"Until Summer of 2024, works. Stop not served. Take bus 47 or 56 at ANTOON VAN OSS. For HOP MILITAIRE , walk.\", \"fr\": \"Jsq \u00e9t\u00e9 2024, travaux. Arr\u00eat non desservi. Bus 47 ou 56 \u00e0 ANTOON VAN OSS. Pour HOPITAL MILITAIRE, \u00e0 pied.\", \"nl\": \"Tot zomer 2024, werken. Halte niet bediend. Neem bus 47 of 56 aan ANTOON VAN OSS. Voor MILITAIR HOSPITAAL, ga te voet.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"57\"}]", "priority": 4, "points": "[{\"id\": \"1838\"}]"},{"content": "[{\"text\": [{\"en\": \"From Dec 4, works. STOP NOT SERVED. Take bus 14 and 57 under the CCN building, at the terminus of bus 61.\", \"fr\": \"D\u00e8s le 4/12, travaux. ARRET NON DESSERVI. Prenez le bus 14 et 57 sous le b\u00e2timent CCN, au terminus du bus 61.\", \"nl\": \"Vanaf 4/12, werken. HALTE NIET BEDIEND. Neem bus 14 en 57 onder het CCN-gebouw, aan eindhalte bus 61.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"57\"}]", "priority": 4, "points": "[{\"id\": \"1082\"}]"},{"content": "[{\"text\": [{\"en\": \"Until Summer of 2024, works. Stop not served. Stop of bus 57: chauss\u00e9e de Vilvorde, in front of number 150.\", \"fr\": \"Jusqu'\u00e0 l'\u00e9t\u00e9 2024, travaux. Arr\u00eat non desservi. Arr\u00eat du bus 57: ch\u00e9e de Vilvorde, en face du num\u00e9ro 150.\", \"nl\": \"Tot zomer 2024, werken. Halte niet bediend. Halte van bus 57: Vilvoordsesteenweg, tegenover nummer 150.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"57\"}]", "priority": 4, "points": "[{\"id\": \"3063\"}]"},{"content": "[{\"text\": [{\"en\": \"Until Summer of 2024, works. Stop not served. Stop of bus 57: MARLY.\", \"fr\": \"Jsq \u00e9t\u00e9 2024, travaux. Arr\u00eat non desservi. Arr\u00eat du bus 57 : MARLY.\", \"nl\": \"Tot zomer 2024, werken. Halte niet bediend. Halte van bus 57: MARLY.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"57\"}]", "priority": 4, "points": "[{\"id\": \"2360\"}]"},{"content": "[{\"text\": [{\"en\": \"From Dec 4, works. STOP NOT SERVED. Take bus 58 at the stop WTC of bus 14 direction UZ-VUB.\", \"fr\": \"D\u00e8s le 4/12, travaux. ARRET NON DESSERVI. Prenez le bus 58 \u00e0 l'arr\u00eat WTC du bus 14 direction UZ-VUB.\", \"nl\": \"Vanaf 4/12, werken. HALTE NIET BEDIEND. Neem bus 58 aan de halte WTC van bus 14 richting UZ-VUB.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"58\"}]", "priority": 4, "points": "[{\"id\": \"3400\"}]"},{"content": "[{\"text\": [{\"en\": \"From Oct 22, works. The stop is moved : Rue du Pavillon, 86. (Moved 20m forwards).\", \"fr\": \"A partir du 22/10, travaux. Arr\u00eat d\u00e9plac\u00e9 : rue du Pavillon, 86. (Avanc\u00e9 de 20m).\", \"nl\": \"Vanaf 22/10, werken. De halte is verplaatst : Palvijoenstraat, 86. (20m vooruitgebracht).\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"58\"}]", "priority": 4, "points": "[{\"id\": \"5741\"}]"},{"content": "[{\"text\": [{\"en\": \"From Dec 4, works. STOP NOT SERVED. Stop of bus 58 and 88 : rue du Progr\u00e8s, after crossing rue des Charbonniers.\", \"fr\": \"D\u00e8s le 4/12, travaux. ARRET NON DESSERVI. Arr\u00eat des bus 58 et 88 : rue du Progr\u00e8s, apr\u00e8s rue des Charbonniers.\", \"nl\": \"Vanaf 4/12, werken. HALTE NIET BEDIEND. Halte bus 58 en 88 : Vooruitgangstraat, na Koolbrandersstraat.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"58\"}]", "priority": 4, "points": "[{\"id\": \"1083\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. As of Apr 15, STOP NOT SERVED. Take bus 60 at the stop of bus 27 to LUXEMBOURG / LUXEMBURG.\", \"fr\": \"Travaux. D\u00e8s le 15/4, ARRET NON DESSERVI. Prenez le bus 60 \u00e0 l'arr\u00eat du bus 27 vers LUXEMBOURG.\", \"nl\": \"Werken. Vanaf 15/4, HALTE NIET BEDIEND. Neem bus 60 aan de halte van bus 27 naar LUXEMBURG.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"60\"}]", "priority": 4, "points": "[{\"id\": \"1416\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. As of Apr 15, bus 60 diverted. Take bus 60 at the previous stop, at the St-Cyr house.\", \"fr\": \"Travaux. D\u00e8s le 15/4,bus 60 d\u00e9vi\u00e9. Prenez le bus 60 \u00e0 l'arr\u00eat pr\u00e9c\u00e9dent, devant la maison Saint-Cyr.\", \"nl\": \"Werken. Vanaf 15/4, bus 60 omgeleid. Neem bus 60 aan de vorige halte, voor het St-Cyr-huis.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"60\"}]", "priority": 4, "points": "[{\"id\": \"1273\"}]"},{"content": "[{\"text\": [{\"en\": \"From Mar 11, works. Bus 60 diverted between GROELSTVELD and DE WANSIJN via DIEWEG.\", \"fr\": \"D\u00e8s le 11/3, travaux. Bus 60 d\u00e9vi\u00e9 entre GROELSTVELD et DE WANSIJN via DIEWEG.\", \"nl\": \"Vanaf 11/3, werken. Bus 60 omgeleid tussen GROELSTVELD en DE WANSIJN via DIEWEG.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"60\"}]", "priority": 5, "points": "[{\"id\": \"2702\"}, {\"id\": \"2701\"}, {\"id\": \"1929\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. As of Apr 15, bus 60 diverted between JOURDAN and AMBIORIX via MAELBEEK. Connection metro at MAELBEEK.\", \"fr\": \"Travaux. D\u00e8s le 15/4, bus 60 d\u00e9vi\u00e9 entre JOURDAN et AMBIORIX via MAELBEEK. Correspondance m\u00e9tro \u00e0 MAELBEEK.\", \"nl\": \"Werken. Vanaf 15/4, bus 60 omgeleid tussen JOURDAN en AMBIORIX via MAALBEEK. Aansluiting metro aan MAALBEEK.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"60\"}]", "priority": 6, "points": "[{\"id\": \"1884\"}, {\"id\": \"1883\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. As of Apr 15, bus 60 diverted between JOURDAN and AMBIORIX via MAELBEEK. Connection metro at MAELBEEK.\", \"fr\": \"Travaux. D\u00e8s le 15/4, bus 60 d\u00e9vi\u00e9 entre JOURDAN et AMBIORIX via MAELBEEK. Correspondance m\u00e9tro \u00e0 MAELBEEK.\", \"nl\": \"Werken. Vanaf 15/4, bus 60 omgeleid tussen JOURDAN en AMBIORIX via MAALBEEK. Aansluiting metro aan MAALBEEK.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"60\"}]", "priority": 6, "points": "[{\"id\": \"6453\"}, {\"id\": \"2133\"}, {\"id\": \"2132\"}, {\"id\": \"2131\"}, {\"id\": \"1250\"}, {\"id\": \"4857B\"}, {\"id\": \"4804B\"}, {\"id\": \"6956B\"}, {\"id\": \"1976\"}, {\"id\": \"1653\"}, {\"id\": \"2134\"}, {\"id\": \"1739\"}, {\"id\": \"6406\"}, {\"id\": \"2847\"}, {\"id\": \"1977\"}]"},{"content": "[{\"text\": [{\"en\": \"From Mar 5 at 9AM, works. STOP NOT SERVED. Temporary stop: avenue Jean & Pierre Carsoellaan 4.\", \"fr\": \"D\u00e8s le 5/3 \u00e0 9h, travaux. ARRET NON DESSERVI. Arr\u00eat provisoire: avenue Jean et Pierre Carsoel 4.\", \"nl\": \"Vanaf 5/3 om 9u, werken. HALTE NIET BEDIEND. Tijdelijke halte: Jean en Pierre Carsoellaan 4.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"60\"}]", "priority": 4, "points": "[{\"id\": \"6931B\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. As of April 7th, stop served only by bus 66. Take bus 29, 63 or 65 at the stop of bus 71 to DELTA.\", \"fr\": \"Travaux. D\u00e8s le 7/4, arr\u00eat uniquement desservi par bus 66. Bus 29, 63 ou 65 \u00e0 l'arr\u00eat du bus 71 vers DELTA.\", \"nl\": \"Werken. Vanaf 7/4, halte enkel bediend door bus 66. Neem bus 29, 63 of 65 aan de halte van bus 71 naar DELTA.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"65\"}]", "priority": 4, "points": "[{\"id\": \"6445\"}]"},{"content": "[{\"text\": [{\"en\": \"From Apr 14 at 7AM, works. STOP NOT SERVED. Take bus 66 at the drop off stop.\", \"fr\": \"D\u00e8s le 14/4 \u00e0 7h, travaux. ARRET NON DESSERVI. Prenez le bus 66 \u00e0 l'arr\u00eat de d\u00e9barquement.\", \"nl\": \"Vanaf 14/4 om 7u, werken. HALTE NIET BEDIEND. Neem bus 66 aan de afstaphalte.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"66\"}]", "priority": 4, "points": "[{\"id\": \"3284\"}]"},{"content": "[{\"text\": [{\"en\": \"Jan 8-Jun 28, works. Stop not served. Stop of tram 7: av. Croix du Feu in front of av. Pagodes.\", \"fr\": \"8/1-28/6, travaux. Arr\u00eat non desservi. Arr\u00eat du tram 7: avenue des Croix du Feu, \u00e0 hauteur de l'avenue des Pagodes.\", \"nl\": \"8/1-28/6, werken. Halte niet bediend. Halte van tram 7: Vuurkruisenlaan, ter hoogte van de Pagodenlaan.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"7\"}]", "priority": 5, "points": "[{\"id\": \"5771\"}]"},{"content": "[{\"text\": [{\"en\": \"Jan 8-Jun 28, works. Stop not served. T-bus to HEEMBEEK and DE WAND at the stop of bus 56 to BUDA.\", \"fr\": \"8/1-28/6, travaux. Arr\u00eat non desservi. T-bus vers HEEMBEEK et DE WAND \u00e0 l'arr\u00eat du bus 56 vers BUDA.\", \"nl\": \"8/1-28/6, werken. Halte niet bediend. T-bus naar HEEMBEEK en DE WAND aan de halte van bus 56 naar BUDA.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"7\"}]", "priority": 5, "points": "[{\"id\": \"5770F\"}]"},{"content": "[{\"text\": [{\"en\": \"Jan 7, 9PM-Jun 28,works. Stop not served. Stop T-bus to DOCKS BRUXSEL: av. Croix du Feu, crossing av. Pagodes.\", \"fr\": \"7/1, 21h-28/6, travaux. Arr\u00eat non desservi.Arr\u00eat du T-bus vers DOCKS BRUXSEL: av. Croix du Feu, carr. av. Pagodes.\", \"nl\": \"7/1, 21u-28/6, werken. Halte niet bediend.Halte van de T-bus naar DOCKS BRUXSEL: Vuurkruisenln, kruispt Pagodenln.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"7\"}]", "priority": 5, "points": "[{\"id\": \"5706\"}]"},{"content": "[{\"text\": [{\"en\": \"From Jan 8 to Jun 28, works. After CHURCHILL, tram 7 continues on line 3 direction ESPLANADE.\", \"fr\": \"Du 8/1 au 28/6, travaux. Apr\u00e8s CHURCHILL, tram 7 continue sur la ligne 3 direction ESPLANADE.\", \"nl\": \"Van 8/1 tot en met 28/6, werken. Na CHURCHILL rijdt tram 7 verder op lijn 3 richting ESPLANADE.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"7\"}]", "priority": 6, "points": "[{\"id\": \"5307H\"}, {\"id\": \"5317G\"}, {\"id\": \"5305G\"}, {\"id\": \"5220F\"}, {\"id\": \"5200F\"}, {\"id\": \"5266F\"}, {\"id\": \"3481\"}, {\"id\": \"0821\"}, {\"id\": \"0901\"}, {\"id\": \"2246F\"}, {\"id\": \"0801\"}, {\"id\": \"5306G\"}, {\"id\": \"5308F\"}, {\"id\": \"5210\"}, {\"id\": \"5211\"}, {\"id\": \"5758F\"}, {\"id\": \"5311\"}, {\"id\": \"5212\"}, {\"id\": \"5213\"}, {\"id\": \"5312\"}, {\"id\": \"1049F\"}, {\"id\": \"6457F\"}, {\"id\": \"5303\"}, {\"id\": \"5205\"}, {\"id\": \"5208\"}, {\"id\": \"9969F\"}, {\"id\": \"0811\"}]"},{"content": "[{\"text\": [{\"en\": \"Jan 8-Jun 28, works. Tram 7 replaced by T-bus between DOCKS BRUXSEL and HEEMBEEK. Info: stib-mivb.brussels\", \"fr\": \"8/1-28/6, travaux. Tram 7 remplac\u00e9 par des T-bus entre DOCKS BRUXSEL et HEEMBEEK. Info: stib. brussels.\", \"nl\": \"8/1-28/6, werken. Tram 7 vervangen door T-bus tussen DOCKS BRUXSEL en HEEMBEEK. info: mivb. brussels.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"7\"}]", "priority": 6, "points": "[{\"id\": \"5261\"}, {\"id\": \"5267\"}, {\"id\": \"5264F\"}, {\"id\": \"5256F\"}, {\"id\": \"1048F\"}, {\"id\": \"5355F\"}, {\"id\": \"5222F\"}, {\"id\": \"3480\"}, {\"id\": \"6456F\"}, {\"id\": \"5258\"}, {\"id\": \"0806\"}, {\"id\": \"5357\"}, {\"id\": \"0906\"}, {\"id\": \"5359\"}, {\"id\": \"0826\"}, {\"id\": \"5253\"}, {\"id\": \"5352\"}, {\"id\": \"5254\"}, {\"id\": \"5356\"}, {\"id\": \"5265F\"}, {\"id\": \"5221F\"}, {\"id\": \"5354H\"}, {\"id\": \"5255F\"}, {\"id\": \"5350G\"}, {\"id\": \"9963F\"}, {\"id\": \"0816\"}, {\"id\": \"2243F\"}]"},{"content": "[{\"text\": [{\"en\": \"Jan 8-Jun 28, works. Tram 7 interrupted btw HEEMBEEK and DOCKS BXL. Stop T-bus to DOCKS BXL: next to this stop.\", \"fr\": \"8/1-28/6, travaux. T7 interrompu de HEEMBEEK \u00e0 DOCKS BXL. Arr\u00eat du T-bus vers DOCKS BXL: \u00e0 c\u00f4t\u00e9 de cet arr\u00eat.\", \"nl\": \"8/1-28/6, werken. T7 onderbroken tss HEEMBEEK en DOCKS BXL. Halte T-bus naar DOCKS BXL: naast deze halte.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"7\"}]", "priority": 5, "points": "[{\"id\": \"5705\"}]"},{"content": "[{\"text\": [{\"en\": \"Jan 8-Jun 28, works. Tram 7 interrupted btw HEEMBEEK and DOCKS BXL. Stop of the T-bus to DOCKS BXL: av. Araucaria\", \"fr\": \"8/1-28/6, travaux. T7 interrompu de HEEMBEEK \u00e0 DOCKS BRUXSEL. Arr\u00eat du T-bus vers DOCKS BRUXSEL: av. Araucaria\", \"nl\": \"8/1-28/6, werken. T7 onderbroken tss HEEMBEEK en DOCKS BRUXSEL. Halte T-bus naar DOCKS BRUXSEL: Araucarialaan.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"7\"}]", "priority": 5, "points": "[{\"id\": \"5704F\"}]"},{"content": "[{\"text\": [{\"en\": \"From Mar 18, works. STOP NOT SERVED. Temporary stop: avenue de la Couronne / Kroonlaan 439-443.\", \"fr\": \"D\u00e8s le 18/3, travaux. ARRET NON DESSERVI. Arr\u00eat provisoire: avenue de la Couronne 439-443.\", \"nl\": \"Vanaf 18/3, werken. HALTE NIET BEDIEND. Tijdelijke halte: Kroonlaan 439-443.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"72\"}]", "priority": 4, "points": "[{\"id\": \"3558\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. From Apr 2 until June 2025, STOP NOT SERVED. Take bus 74 at the previous stop, FOREST CENTRE.\", \"fr\": \"Travaux. Du 2/4 \u00e0 juin 2025, ARRET NON DESSERVI. Prenez le bus 74 \u00e0 l'arr\u00eat pr\u00e9c\u00e9dent, FOREST CENTRE.\", \"nl\": \"Werken. Vanaf 2/4 tot juni 2025, HALTE NIET BEDIEND. Neem bus 74 aan de vorige halte, VORST CENTRUM.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"74\"}]", "priority": 4, "points": "[{\"id\": \"5719\"}]"},{"content": "[{\"text\": [{\"en\": \"From Apr 2, 2024 to June 2025, works. STOP NOT SERVED. Stop of bus 74: FOREST NATIONAL (av. du Globelaan 8).\", \"fr\": \"Du 2/4/2024 \u00e0 juin 2025, travaux. ARRET NON DESSERVI. Arr\u00eat des bus 74: FOREST NATIONAL. (avenue du Globe 8).\", \"nl\": \"Van 2/4/2024 tot juni 2025, werken. HALTE NIET BEDIEND. Halte van bus 74: VORST NATIONAAL (Globelaan 8)\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"74\"}]", "priority": 4, "points": "[{\"id\": \"2939B\"}]"},{"content": "[{\"text\": [{\"en\": \"Subsidence. Bus 74 limited to DECROLY. Take bus 74 at DECROLY.\", \"fr\": \"Effondrement. Bus 74 limit\u00e9 \u00e0 DECROLY. Prenez le bus 74 \u00e0 DECROLY.\", \"nl\": \"Wegverzakking. Bus 74 beperkt tot DECROLY. Neem bus 74 aan DECROLY.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"74\"}]", "priority": 4, "points": "[{\"id\": \"2417\"}]"},{"content": "[{\"text\": [{\"en\": \"From Apr 2, 2024 to June 2025, works. STOP NOT SERVED. Stop of bus 74: av. du Globelaan 43.\", \"fr\": \"Du 2/4/2024 \u00e0 juin 2025, travaux. ARRET NON DESSERVI. Arr\u00eat du bus 74: avenue du Globe 43.\", \"nl\": \"Van 2/4/2024 tot juni 2025, werken. HALTE NIET BEDIEND. Halte van bus 74: Globelaan 43.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"74\"}]", "priority": 4, "points": "[{\"id\": \"2732\"}]"},{"content": "[{\"text\": [{\"en\": \"From Apr 2, 2024 to June 2025, works. STOP NOT SERVED. Stop of bus 74: FOREST NATIONAL (av. du Globelaan 43)\", \"fr\": \"Du 2/4/2024 \u00e0 juin 2025, travaux. ARRET NON DESSERVI. Arr\u00eat du bus 74: FOREST NATIONAL (avenue du Globe 43).\", \"nl\": \"Van 2/4/2024 tot juni 2025, werken. HALTE NIET BEDIEND. Halte van bus 74: VORST NATIONAAL (Globelaan 43)\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"74\"}]", "priority": 4, "points": "[{\"id\": \"2952B\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. As of Apr 15, bus 79 diverted from MICHEL-ANGE to MAELBEEK. Stop SCHUMAN moved rue Franklin.\", \"fr\": \"Travaux. D\u00e8s le 15/4, bus 79 d\u00e9vi\u00e9 depuis MICHEL-ANGE vers MAELBEEK. Arr\u00eat SCHUMAN d\u00e9plac\u00e9 rue Franklin.\", \"nl\": \"Werken. Vanaf 15/4, bus 79 omgeleid vanaf MICHELANGELO naar MAALBEEK. Halte SCHUMAN verplaatst Franklinstr.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"79\"}]", "priority": 6, "points": "[{\"id\": \"6450\"}, {\"id\": \"6055\"}, {\"id\": \"9853\"}, {\"id\": \"1462\"}, {\"id\": \"2043\"}, {\"id\": \"2042\"}, {\"id\": \"2041\"}, {\"id\": \"3902\"}, {\"id\": \"3903\"}, {\"id\": \"3904\"}, {\"id\": \"2028\"}, {\"id\": \"3905\"}, {\"id\": \"1533\"}, {\"id\": \"1531\"}, {\"id\": \"1464\"}, {\"id\": \"1463\"}, {\"id\": \"1320\"}, {\"id\": \"3920\"}, {\"id\": \"3911\"}, {\"id\": \"1339\"}]"},{"content": "[{\"text\": [{\"en\": \"Afterwork. Every Thursday after 4PM, stop moved to rue de Tr\u00e8ves, in front of the stop in the other direction\", \"fr\": \"Afterwork. Tous les jeudis apr\u00e8s 16h, arr\u00eat d\u00e9plac\u00e9 rue de Tr\u00e8ves, en face de l'arr\u00eat dans l'autre sens.\", \"nl\": \"Afterwork.Elke donderdag na 16u, halte verplaatst naar de Trierstraat, tegenover de halte in de andere richting.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"80\"}]", "priority": 4, "points": "[{\"id\": \"1233\"}]"},{"content": "[{\"text\": [{\"en\": \"On May 5 until 8PM, flea market. Tram 81 interrupted. Take the tram at the stop of tram 92 to FORT-JACO.\", \"fr\": \"Le 19/5 jusqu'\u00e0 20h, brocante. Tram 81 interrompu. Prenez le tram \u00e0 l'arr\u00eat du tram 92 vers FORT-JACO.\", \"nl\": \"Op 19/5 tot 20u, rommelmarkt. Tram 81 onderbroken. Neem de tram aan de halte van tram 92 naar FORT-JACO.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"81\"}]", "priority": 4, "points": "[{\"id\": \"6425F\"}]"},{"content": "[{\"text\": [{\"en\": \"May 5 until 8PM, flea market. T81 interrupted between JANSON and FLAGEY. Connection T-bus at LEVURE / GIST.\", \"fr\": \"19/5 jsq 20h, brocante. Tram 81 interrompu entre JANSON et FLAGEY. Correspondance T-bus \u00e0 LEVURE.\", \"nl\": \"19/5 tot 20u, rommel- markt. T81 onderbroken tussen JANSON en FLAGEY. Aansluiting T-bus aan GIST.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"81\"}]", "priority": 5, "points": "[{\"id\": \"6153\"}, {\"id\": \"2286G\"}, {\"id\": \"6157F\"}, {\"id\": \"6009\"}, {\"id\": \"6156F\"}, {\"id\": \"6158H\"}, {\"id\": \"6155F\"}, {\"id\": \"6462F\"}]"},{"content": "[{\"text\": [{\"en\": \"On May 5 until 8PM, flea market. STOP NOT SERVED. Take the T-bus at JANSON: chauss\u00e9e de Charleroisesteenweg 180.\", \"fr\": \"Le 19/5 jusqu'\u00e0 20h, brocante. ARRET NON DESSERVI. Prenez le T-bus \u00e0 JANSON: chauss\u00e9e de Charleroi 180.\", \"nl\": \"Op 19/5 tot 20u, rommelmarkt. HALTE NIET BEDIEND. Neem de T-bus aan JANSON: Charleroisesteenweg 180.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"81\"}]", "priority": 4, "points": "[{\"id\": \"2960F\"}]"},{"content": "[{\"text\": [{\"en\": \"On May 5 until 8PM, flea market. STOP NOT SERVED. Take the tram at JANSON, at the stop of tram 92 to FORT-JACO.\", \"fr\": \"Le 19/5 jusqu'\u00e0 20h, brocante. ARRET NON DESSERVI. Prenez le tram \u00e0 JANSON, \u00e0 l'arr\u00eat du tram 92 vers FORT-JACO.\", \"nl\": \"Op 19/5 tot 20u, rommelmarkt. HALTE NIET BEDIEND. Neem de tram aan JANSON, aan halte tram 92 naar FORT-JACO.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"81\"}]", "priority": 4, "points": "[{\"id\": \"2931F\"}]"},{"content": "[{\"text\": [{\"en\": \"On May 5 until 8PM, flea market. Tram 81 interrupted. Stop of the T-bus: rue Lesbroussart- straat 71-73.\", \"fr\": \"Le 19/5 jusqu'\u00e0 20h, brocante. Tram 81 interrompu. Arr\u00eat du T-bus : rue Lesbroussart 71-73.\", \"nl\": \"Op 19/5 tot 20u, rommel- markt. Tram 81 onderbroken. Halte T-bus: Lesbroussart- straat 71-73.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"81\"}]", "priority": 4, "points": "[{\"id\": \"2380F\"}]"},{"content": "[{\"text\": [{\"en\": \"On May 5 until 8PM, flea market. STOP NOT SERVED. Stop the T-bus and B54: rue Lesbroussart, before avenue Louise.\", \"fr\": \"19/5 jsq 20h, brocante. ARRET NON DESSERVI. Arr\u00eat du T-bus et B54 : rue Lesbroussart, avant avenue Louise.\", \"nl\": \"Op 19/5 tot 20u, rommelmarkt. HALTE NIET BEDIEND. Halte T-bus en B54: Lesbroussartstraat, voor Louizalaan.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"81\"}]", "priority": 4, "points": "[{\"id\": \"2972F\"}]"},{"content": "[{\"text\": [{\"en\": \"On May 5 until 8PM, flea market. Tram 81 replaced by a T-bus between JANSON and LEVURE / GIST.\", \"fr\": \"Le 19/5 jusqu'\u00e0 20h, brocante. Tram 81 remplac\u00e9 par des T-bus entre JANSON et LEVURE.\", \"nl\": \"Op 19/5 tot 20u, rommelmarkt. Tram 81 vervangen door T-bus tussen JANSON en GIST.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"81\"}]", "priority": 5, "points": "[{\"id\": \"6099\"}, {\"id\": \"6077F\"}, {\"id\": \"6121F\"}, {\"id\": \"3611F\"}, {\"id\": \"2539F\"}, {\"id\": \"3612F\"}, {\"id\": \"3613F\"}, {\"id\": \"3371F\"}, {\"id\": \"6858G\"}, {\"id\": \"0631\"}, {\"id\": \"6705F\"}, {\"id\": \"2260F\"}, {\"id\": \"6799F\"}, {\"id\": \"6106\"}, {\"id\": \"6860G\"}, {\"id\": \"2259F\"}, {\"id\": \"6856\"}, {\"id\": \"2257G\"}, {\"id\": \"6857\"}, {\"id\": \"6109\"}, {\"id\": \"2331F\"}]"},{"content": "[{\"text\": [{\"en\": \"On May 5 until 8PM, flea market. STOP NOT SERVED. Stop T-bus and bus 54: crossing Lesbroussart- Louise, on tram tracks.\", \"fr\": \"19/5 jsq 20h, brocante. ARRET NON DESSERVI. Arr\u00eat T-bus et B54: carrefour Lesbroussart- Louise, sur les voies.\", \"nl\": \"19/5 tot 20u,rommelmarkt HALTE NIET BEDIEND. Halte T-bus en B54: kruispunt Lesbroussart- Louiza, op tramsporen.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"81\"}]", "priority": 4, "points": "[{\"id\": \"2971F\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. Until 2026, stop not served. Stop of the T-bus: Grote Baan 227 (stop of De Lijn to Anderlecht).\", \"fr\": \"Travaux. Jsq 2026, arr\u00eat non desservi. Arr\u00eat du T-bus: Grand'Route 227 (arr\u00eat des bus De Lijn vers Anderlecht).\", \"nl\": \"Werken. Tot 2026, halte niet bediend. Halte van de T-bus: Grote Baan 227 (halte van De Lijn naar Anderlecht).\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"82\"}]", "priority": 4, "points": "[{\"id\": \"5732F\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. Until 2026, tram 82 and 97 interrupted. Stop of the T-bus and of bus 50: ch. de Neerstalsestwg 236.\", \"fr\": \"Travaux. Jsq 2026, tram 82 et 97 interrompus. Arr\u00eat du T-bus et du bus 50: chauss\u00e9e de Neerstalle 236\", \"nl\": \"Werken. Tot 2026, tram 82 en 97 onderbroken. Halte van de T-bus en van bus 50: Neerstalsesteenweg 236\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"82\"}]", "priority": 4, "points": "[{\"id\": \"5164F\"}]"},{"content": "[{\"text\": [{\"en\": \"Until 2026, works. T-bus 82/97 diverted. Stop T-bus 82/97: bd 2e Arm\u00e9e Britannique / Britse Tweedelegerlaan.\", \"fr\": \"Jsq 2026, travaux. T-bus 82/97 d\u00e9vi\u00e9. Arr\u00eat T-bus 82/97: bd 2e Arm\u00e9e Britannique, carrefour rue de la Station.\", \"nl\": \"Tot 2026, werken. T-bus 82/97 omgeleid. Halte T-bus 82/97: Britse Tweedelegerlaan, kruispunt Stationstraat.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"82\"}]", "priority": 4, "points": "[{\"id\": \"5719H\"}]"},{"content": "[{\"text\": [{\"en\": \"Until 2026,works.Tram 82 replaced by T-bus btw FOREST CENTRE / VORST CENTRUM and DROGENBOS. More info: stib-mivb.be.\", \"fr\": \"Jusqu'en 2026, travaux. Tram 82 remplac\u00e9 par des T-bus entre FOREST CENTRE et DROGENBOS. Info: stib.brussels.\", \"nl\": \"Tot 2026, werken. Tram 82 wordt vervangen door T-bus tussen VORST CENTRUM en DROGENBOS. Info: mivb.brussels.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"82\"}]", "priority": 4, "points": "[{\"id\": \"5163F\"}]"},{"content": "[{\"text\": [{\"en\": \"Jan 22, 6AM-end of June, works. Bus 86 diverted between GARE DE L'OUEST/ WESTSTATION and SUZAN DANIEL via ETANGS NOIRS.\", \"fr\": \"Du 22/1 \u00e0 6h jusqu'\u00e0 fin juin, travaux. Bus 86 d\u00e9vi\u00e9 entre GARE DE L'OUEST et SUZAN DANIEL via ETANGS NOIRS.\", \"nl\": \"Van 22/1 om 6u tot eind juni, werken. Bus 86 omgeleid tussen WESTSTATION-SUZAN DANIEL via ZWARTE VIJVERS.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"86\"}]", "priority": 5, "points": "[{\"id\": \"3238\"}, {\"id\": \"3234\"}, {\"id\": \"3253\"}, {\"id\": \"3252\"}, {\"id\": \"3282\"}, {\"id\": \"3281\"}]"},{"content": "[{\"text\": [{\"en\": \"As of Nov 16 at 6AM, works. Stop moved to av. Port / Havenln, in front of number 100 (moved backward of +/- 120m)\", \"fr\": \"D\u00e8s le 16/11 \u00e0 6h, travaux. Arr\u00eat d\u00e9plac\u00e9 avenue du Port, en face du num\u00e9ro 100 (recul\u00e9 de +/- 120m).\", \"nl\": \"Vanaf 16/11 om 6u,werken Halte verplaatst naar de Havenlaan, tegenover nr 100 (achteruitgebracht van +/- 120m)\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"86\"}]", "priority": 4, "points": "[{\"id\": \"2305\"}]"},{"content": "[{\"text\": [{\"en\": \"From May 6, works. STOP NOT SERVED. Take bus 89 to NEERPEDE at the stop of bus 53 to WESTLAND SHOPPING.\", \"fr\": \"D\u00e8s le 6/5, travaux. ARRET NON DESSERVI. Bus 89 vers NEERPEDE \u00e0 l'arr\u00eat du bus 53 vers WESTLAND SHOPPING.\", \"nl\": \"Vanaf 6/5, werken. HALTE NIET BEDIEND. Neem bus 89 naar NEERPEDE aan de halte van bus 53 naar WESTLAND SHOPPING.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"89\"}]", "priority": 4, "points": "[{\"id\": \"1261\"}]"},{"content": "[{\"text\": [{\"en\": \"From May 6, works. Bus 89 extended to NEERPEDE. Stop WESTLAND SHOPPING relocated.\", \"fr\": \"D\u00e8s le 6/5, travaux. Bus 89 prolong\u00e9 jusqu'\u00e0 NEERPEDE. Arr\u00eat WESTLAND SHOPPING d\u00e9plac\u00e9.\", \"nl\": \"Vanaf 6/5, werken. Bus 89 verlengd tot NEERPEDE. Halte WESTLAND SHOPPING verplaatst.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"89\"}]", "priority": 5, "points": "[{\"id\": \"2779\"}, {\"id\": \"2768\"}, {\"id\": \"3638\"}, {\"id\": \"1117\"}, {\"id\": \"1257\"}, {\"id\": \"2750\"}, {\"id\": \"2783\"}, {\"id\": \"2781\"}, {\"id\": \"1260\"}, {\"id\": \"3636\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. As of Apr 22 at 9.30AM, bus 89 diverted btw TRIANGLE and QUATRE- VENTS. For DUCHESSE, T82 at TRIANGLE.\", \"fr\": \"Travaux. D\u00e8s le 22/4 \u00e0 9h30, bus 89 d\u00e9vi\u00e9 entre TRIANGLE et QUATRE- VENTS. Pour DUCHESSE, tram 82 \u00e0 TRIANGLE.\", \"nl\": \"Werken. Vanaf 22/4 om 9. 30u, bus 89 omgeleid tussen DRIEHOEK en VIER WINDEN. Voor HERTOGIN, tram 82 aan DRIEHOEK.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"89\"}]", "priority": 5, "points": "[{\"id\": \"3347\"}, {\"id\": \"2301\"}, {\"id\": \"2595\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. As of Apr 22 at 9.30AM, bus 89 diverted btw TRIANGLE and QUATRE- VENTS. For DUCHESSE, T82 at TRIANGLE.\", \"fr\": \"Travaux. D\u00e8s le 22/4 \u00e0 9h30, bus 89 d\u00e9vi\u00e9 entre TRIANGLE et QUATRE- VENTS. Pour DUCHESSE, tram 82 \u00e0 TRIANGLE.\", \"nl\": \"Werken. Vanaf 22/4 om 9. 30u, bus 89 omgeleid tussen DRIEHOEK en VIER WINDEN. Voor HERTOGIN, tram 82 aan DRIEHOEK.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"89\"}]", "priority": 5, "points": "[{\"id\": \"1895\"}, {\"id\": \"3223B\"}, {\"id\": \"3222\"}, {\"id\": \"3221\"}]"},{"content": "[{\"text\": [{\"en\": \"From May 6, works. STOP NOT SERVED. Take bus 89 at the stop of bus 53 to HOPITAL MILITAIRE / MILITAIR HOSPITAAL.\", \"fr\": \"D\u00e8s le 6/5, travaux. ARRET NON DESSERVI. Prenez le bus 89 \u00e0 l'arr\u00eat du bus 53 vers HOPITAL MILITAIRE.\", \"nl\": \"Vanaf 6/5, werken. HALTE NIET BEDIEND. Neem bus 89 aan de halte van bus 53 naar MILITAIR HOSPITAAL.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"89\"}]", "priority": 4, "points": "[{\"id\": \"1203\"}]"},{"content": "[{\"text\": [{\"en\": \"Until 2026, works. As of Mar 11, tram 97 interrupted between WIELS and DIEWEG. Take tram 4 to go to GLOBE.\", \"fr\": \"Jsq 2026,travaux. D\u00e8s le 11/3, tram 97 interrompu entre WIELS et DIEWEG. Prenez le tram 4 pour rejoindre GLOBE.\", \"nl\": \"Tot 2026, werken. Vanaf 11/3, tram 97 onderbroken tussen WIELS en DIEWEG. Neem tram 4 om naar GLOBE te gaan.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"97\"}]", "priority": 4, "points": "[{\"id\": \"5916F\"}]"},{"content": "[{\"text\": [{\"en\": \"Until 2026, works. As of Mar 11, tram 97 interrupted to DIEWEG. For GLOBE, tram 4 at CARR. STALLE via T-bus.\", \"fr\": \"Jsq 2026,travaux. D\u00e8s le 11/3, tram 97 interrompu jsq DIEWEG. Pour GLOBE, tram 4 \u00e0 CARREFOUR STALLE via T-bus.\", \"nl\": \"Tot 2026, werken. Vanaf 11/3,tram 97 onderbroken tot DIEWEG. Voor GLOBE, neem tram 4 aan KRUISPT STALLE via T-bus.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"97\"}]", "priority": 4, "points": "[{\"id\": \"5722F\"}]"},{"content": "[{\"text\": [{\"en\": \"Until 2026, works. Stop not served. Stop of the T-bus: rue de la Soierie / Zijdeweverijstraat 4.\", \"fr\": \"Jusqu'en 2026, travaux. Arr\u00eat non desservi. Arr\u00eat du T-bus: rue de la Soierie 4.\", \"nl\": \"Tot 2026, werken. Halte niet bediend. Halte van de T-bus: Zijdeweverijstraat 4.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"97\"}]", "priority": 4, "points": "[{\"id\": \"5154F\"}]"},{"content": "[{\"text\": [{\"en\": \"Until 2026, works. Tram 97 interrupted to WIELS. Take tram 82 to go to WIELS.\", \"fr\": \"Jusqu'en 2026, travaux. Tram 97 interrompu jusqu'\u00e0 WIELS. Pour rejoindre WIELS, prenez le tram 82.\", \"nl\": \"Tot 2026, werken. Tram 97 onderbroken tot WIELS. Neem tram 82 om naar WIELS te gaan.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"97\"}]", "priority": 4, "points": "[{\"id\": \"5151\"}, {\"id\": \"2668\"}, {\"id\": \"5155\"}, {\"id\": \"2667F\"}]"},{"content": "[{\"text\": [{\"en\": \"Until 2026, works. As of Mar 11, tram 97 operated only btw LOUISE and WIELS. T-bus: av. Reine Marie-Henriette 1A\", \"fr\": \"Jsq 2026,travaux. D\u00e8s le 11/3, tram 97 circule uniquement entre LOUISE et WIELS. T-bus: av. Reine Marie-Henriette 1A\", \"nl\": \"Tot 2026, werken. Vanaf 11/3 rijdt tram 97 enkel tussen LOUIZA en WIELS. T-bus: Koningin Maria-Hendrikaln 1A\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"97\"}]", "priority": 5, "points": "[{\"id\": \"5115F\"}]"},{"content": "[{\"text\": [{\"en\": \"Until 2026, works. As of Mar 11, tram 97 interrupted between WIELS and DIEWEG. Take tram 4 to go to GLOBE.\", \"fr\": \"Jsq 2026,travaux. D\u00e8s le 11/3, tram 97 interrompu entre WIELS et DIEWEG. Prenez le tram 4 pour rejoindre GLOBE.\", \"nl\": \"Tot 2026, werken. Vanaf 11/3, tram 97 onderbroken tussen WIELS en DIEWEG. Neem tram 4 om naar GLOBE te gaan.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"97\"}]", "priority": 4, "points": "[{\"id\": \"5917F\"}]"},{"content": "[{\"text\": [{\"en\": \"Werken. 17/5, 21u-20/5, T-bus 19 diverted from GUILL. DE GREEF to DE WAND. HOP. BRUGMANN served by tram 51 93\", \"fr\": \"Travaux. 17/5, 21h-20/5, T-bus 19 d\u00e9vi\u00e9 depuis GUILL. DE GREEF vers DE WAND. HOP. BRUGMANN desservi par tram 51 93\", \"nl\": \"Werken. 17/5, 21u-20/5, T-bus 19 omgeleid vanaf GUILL. DE GREEF naar DE WAND. BRUGMANN-ZKH bediend door tram 51 93\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"T19\"}]", "priority": 5, "points": "[{\"id\": \"1767\"}, {\"id\": \"2515B\"}, {\"id\": \"6865\"}, {\"id\": \"6864\"}, {\"id\": \"1183\"}]"},{"content": "[{\"text\": [{\"en\": \"As of Oct 25, stop moved +/- 50m behind, side square Lain\u00e9square.\", \"fr\": \"D\u00e8s le 25/10, arr\u00eat recul\u00e9 de +/- 50m, c\u00f4t\u00e9 square Lain\u00e9\", \"nl\": \"Vanaf 25/10, werken. Halte achteruitgebracht van +/- 50m, kant Lain\u00e9square.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"T82\"}]", "priority": 4, "points": "[{\"id\": \"2023\"}]"},{"content": "[{\"text\": [{\"en\": \"Until 2026, works. Stop of T-bus 82/97: ch. de Neerstalsesteenweg in front of 348.\", \"fr\": \"Jusqu'en 2026, travaux. Arr\u00eat du T-bus 82/97: chauss\u00e9e de Neerstalle, en face du num\u00e9ro 348.\", \"nl\": \"Tot 2026, werken. Halte van T-bus 82/97: Neerstalsesteenweg, tegenover nummer 348.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"T82\"}]", "priority": 4, "points": "[{\"id\": \"3242\"}]"},{"content": "[{\"text\": [{\"en\": \"From Apr 3 at 6AM, works. STOP NOT SERVED. Bus 38 at GOSSART (avenue Winston Churchilllaan 187).\", \"fr\": \"D\u00e8s le 3/4 \u00e0 6h, travaux. ARRET NON DESSERVI. Bus 38 \u00e0 GOSSART (avenue Winston Churchill 187).\", \"nl\": \"Vanaf 3/4 om 6u, werken. HALTE NIET BEDIEND. Bus 38 aan GOSSART (Winston Churchilllaan 187).\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"38\"}]", "priority": 4, "points": "[{\"id\": \"1972\"}]"},{"content": "[{\"text\": [{\"en\": \"From Apr 3 at 6AM, works. STOP NOT SERVED. Take bus 38 and 41 at the previous stop, HOUZEAU.\", \"fr\": \"D\u00e8s le 3/4 \u00e0 6h, travaux. ARRET NON DESSERVI. Prenez les bus 38 et 41 \u00e0 l'arr\u00eat pr\u00e9c\u00e9dent, HOUZEAU.\", \"nl\": \"Vanaf 3/4 om 6u, werken. HALTE NIET BEDIEND. Neem bus 38 en 41 aan de vorige halte, HOUZEAU.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"38\"}]", "priority": 4, "points": "[{\"id\": \"1970\"}]"},{"content": "[{\"text\": [{\"en\": \"From Apr 3 at 6AM, works. Bus 38 diverted between LONGCHAMP and HOUZEAU via rue Edith Cavellstraat.\", \"fr\": \"D\u00e8s le 3/4 \u00e0 6h, travaux. Bus 38 d\u00e9vi\u00e9 entre LONGCHAMP et HOUZEAU via rue Edith Cavell.\", \"nl\": \"Vanaf 3/4 om 6u, werken. Bus 38 omgeleid tussen LONGCHAMP en HOUZEAU via Edith Cavellstraat.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"38\"}]", "priority": 5, "points": "[{\"id\": \"1913\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. As of April 7th, bus 38 diverted. Take bus 38 at the next stop, ROYALE / KONING.\", \"fr\": \"Travaux. D\u00e8s le 7/4, bus 38 d\u00e9vi\u00e9. Prenez le bus 38 \u00e0 l'arr\u00eat suivant, ROYALE.\", \"nl\": \"Werken. Vanaf 7/4, bus 38 omgeleid. Neem bus 38 aan de volgende halte, KONING.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"38\"}]", "priority": 4, "points": "[{\"id\": \"3502\"}]"},{"content": "[{\"text\": [{\"en\": \"From Apr 3 at 6AM, works. STOP NOT SERVED. Bus 38 at GOSSART (avenue Winston Churchilllaan 202).\", \"fr\": \"D\u00e8s le 3/4 \u00e0 6h, travaux. ARRET NON DESSERVI. Bus 38 \u00e0 GOSSART (avenue Winston Churchill 202).\", \"nl\": \"Vanaf 3/4 om 6u, werken. HALTE NIET BEDIEND. Bus 38 aan GOSSART (Winston Churchilllaan 202).\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"38\"}]", "priority": 4, "points": "[{\"id\": \"1918\"}]"},{"content": "[{\"text\": [{\"en\": \"From Apr 3 at 6AM, works. Bus 38 diverted between LONGCHAMP and HOUZEAU via rue Edith Cavellstraat.\", \"fr\": \"D\u00e8s le 3/4 \u00e0 6h, travaux. Bus 38 d\u00e9vi\u00e9 entre LONGCHAMP et HOUZEAU via rue Edith Cavell.\", \"nl\": \"Vanaf 3/4 om 6u, werken. Bus 38 omgeleid tussen LONGCHAMP en HOUZEAU via Edith Cavellstraat.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"38\"}]", "priority": 5, "points": "[{\"id\": \"1916\"}, {\"id\": \"1915\"}]"},{"content": "[{\"text\": [{\"en\": \"From Apr 3 at 6AM, works. STOP NOT SERVED. Temporary stop: chauss\u00e9e de Waterloosesteenweg 803, stop De Fr\u00e9 of TEC.\", \"fr\": \"D\u00e8s 3/4 \u00e0 6h, travaux. ARRET NON DESSERVI. Arr\u00eat provisoire: ch. de Waterloo 803, arr\u00eat De Fr\u00e9 des TEC.\", \"nl\": \"Vanaf 3/4 om 6u, werken. HALTE NIET BEDIEND. Tijdelijke halte: Waterloosesteenweg 803, halte De Fr\u00e9 van TEC.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"41\"}]", "priority": 5, "points": "[{\"id\": \"2763\"}]"},{"content": "[{\"text\": [{\"en\": \"From Apr 3 at 6AM, works. STOP NOT SERVED. Temporary stop: chauss\u00e9e de Waterloosesteenweg 965, stop of TEC.\", \"fr\": \"D\u00e8s le 3/4 \u00e0 6h, travaux. ARRET NON DESSERVI. Arr\u00eat provisoire: chauss\u00e9e de Waterloo 965, arr\u00eat TEC.\", \"nl\": \"Vanaf 3/4 om 6u, werken. HALTE NIET BEDIEND. Tijdelijke halte: Waterloosesteenweg 965, halte van TEC.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"41\"}]", "priority": 5, "points": "[{\"id\": \"2714\"}]"},{"content": "[{\"text\": [{\"en\": \"From Apr 3 at 6AM, works. Bus 41 diverted between VERT CHASSEUR / GROENE JAGER and HOUZEAU via rue Edith Cavell.\", \"fr\": \"D\u00e8s le 3/4 \u00e0 6h, travaux. Bus 41 d\u00e9vi\u00e9 entre VERT CHASSEUR et HOUZEAU via rue Edith Cavell.\", \"nl\": \"Vanaf 3/4 om 6u, werken. Bus 41 omgeleid tussen GROENE JAGER en HOUZEAU via Edith Cavellstraat.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"41\"}]", "priority": 5, "points": "[{\"id\": \"5451\"}, {\"id\": \"4452\"}, {\"id\": \"4454\"}, {\"id\": \"2107\"}, {\"id\": \"2018\"}, {\"id\": \"1754\"}, {\"id\": \"1753\"}, {\"id\": \"2016\"}, {\"id\": \"1752\"}, {\"id\": \"2762\"}, {\"id\": \"2079\"}, {\"id\": \"4455\"}, {\"id\": \"4456\"}, {\"id\": \"6468\"}, {\"id\": \"5458\"}, {\"id\": \"4358\"}, {\"id\": \"5459\"}, {\"id\": \"6439\"}, {\"id\": \"4449\"}, {\"id\": \"1725\"}, {\"id\": \"4407\"}]"},{"content": "[{\"text\": [{\"en\": \"From Mar 4, works. Bus 43 and N11 diverted. Weekdays before 8PM: B43 at BRAVES. Otherwise: bus at GRIOTTES.\", \"fr\": \"D\u00e8s le 4/3, travaux. Bus 43 et N11 d\u00e9vi\u00e9s. En semaine avant 20h: B43 \u00e0 BRAVES. Autres moments: bus \u00e0 GRIOTTES.\", \"nl\": \"Vanaf 4/3, werken. Bus 43 en N11 omgeleid. Weekdagen voor 20u: B43 aan DAPPEREN. Anders: bus aan NOORDKRIEKEN.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"43\"}]", "priority": 4, "points": "[{\"id\": \"1963\"}]"},{"content": "[{\"text\": [{\"en\": \"Enjoy your trip on our lines !\", \"fr\": \"Bon voyage sur nos lignes !\", \"nl\": \"Geniet van uw reis op onze lijnen !\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"44\"}]", "priority": 9, "points": "[{\"id\": \"9552\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. Until end of August, B46 not operated btw WTC-GLIBERT and PTE ANDERLECHT. For the center, bus 88 at WTC.\", \"fr\": \"Travaux. Jsq fin ao\u00fbt, B46 ne circule pas entre WTC-GLIBERT et PORTE D'ANDERLECHT. Pour le centre, bus 88 \u00e0 WTC.\", \"nl\": \"Werken. Tot einde augustus rijdt bus 46 niet tss WTC-GLIBERT en ANDERLECHTSEPT. Voor het centrum,neem B88 aan WTC\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"46\"}]", "priority": 5, "points": "[{\"id\": \"9025\"}, {\"id\": \"1896\"}, {\"id\": \"2209\"}]"},{"content": "[{\"text\": [{\"en\": \"Until end of August, works. Bus 46 interrupted. Take bus 46 at ANNEESSENS (via bus 33).\", \"fr\": \"Jusque fin ao\u00fbt, travaux. Bus 46 interrompu. Prenez le bus 46 \u00e0 ANNEESSENS (via bus 33).\", \"nl\": \"Tot einde augustus, werken. Bus 46 onderbroken. Neem bus 46 aan ANNEESSENS (via bus 33).\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"46\"}]", "priority": 4, "points": "[{\"id\": \"1895\"}]"},{"content": "[{\"text\": [{\"en\": \"Until end of August 2024, works. Stop not served. Walk to WTC-GLIBERT.\", \"fr\": \"Jusque fin ao\u00fbt 2024, travaux. Arr\u00eat non desservi. Continuez \u00e0 pied pour WTC-GLIBERT.\", \"nl\": \"Tot einde augustus 2024, werken. halte niet bediend. Ga te voet verder om naar WTC-GLIBERT te gaan.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"46\"}]", "priority": 4, "points": "[{\"id\": \"1894\"}]"},{"content": "[{\"text\": [{\"en\": \"Until Summer of 2024, works. As of Mar 4, stop of bus 47: Military Area, stop of bus 57 to GARE DU NORD.\", \"fr\": \"Jsq \u00e9t\u00e9 2024, travaux. D\u00e8s le 4/3, arr\u00eat du bus 47 : Domaine Militaire, arr\u00eat du bus 57 vers GARE DU NORD.\", \"nl\": \"Tot zomer 2024, werken. Vanaf 4/3, halte van bus 47: Militair Domein, halte van bus 57 naar NOORDSTATION..\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"47\"}]", "priority": 4, "points": "[{\"id\": \"3068\"}]"},{"content": "[{\"text\": [{\"en\": \"Until Summer of 2024, works. Stop not served. Take bus 47 or 57 at ANTOON VAN OSS (stop of bus 56 to BUDA).\", \"fr\": \"Jsq \u00e9t\u00e9 2024, travaux. Arr\u00eat non desservi. Prenez le bus 47 ou 57 \u00e0 ANTOON VAN OSS (arr\u00eat du bus 56 vers BUDA).\", \"nl\": \"Tot zomer 2024, werken. Halte niet bediend. Neem bus 47 of 57 aan ANTOON VAN OSS (halte van bus 56 naar BUDA).\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"47\"}]", "priority": 4, "points": "[{\"id\": \"1837\"}]"},{"content": "[{\"text\": [{\"en\": \"Until Summer of 2024, works. Stop not served. Take bus 47 at the stop of bus 56 to BUDA.\", \"fr\": \"Jusqu'\u00e0 l'\u00e9t\u00e9 2024, travaux. Arr\u00eat non desservi. Prenez le bus 47 \u00e0 l'arr\u00eat du bus 56 vers BUDA.\", \"nl\": \"Tot zomer 2024, werken. Halte niet bediend. Neem bus 47 aan de halte van bus 56 naar BUDA.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"47\"}]", "priority": 4, "points": "[{\"id\": \"2358\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. STOP NOT SERVED. B47: at the stop CROIX DE GUERRE of B56 (av. des Croix de Guerre)\", \"fr\": \"Travaux. ARRET NON DESSERVI. B47 : \u00e0 l'arr\u00eat CROIX DE GUERRE du B56 (av. des Croix de Guerre)\", \"nl\": \"Werken. HALTE NIET BEDIEND. B47: aan de halte OORLOGSKRUISEN van B56 (Oorlogskruisenlaan)\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"47\"}]", "priority": 4, "points": "[{\"id\": \"2362B\"}]"},{"content": "[{\"text\": [{\"en\": \"From Oct 18 9.30AM, stop not served. Go to the previous stop : HELDENPLEIN.\", \"fr\": \"A partir du 18/10 9h30, arr\u00eat non desservi. Rejoignez l'arr\u00eat pr\u00e9c\u00e9dent : HELDENPLEIN.\", \"nl\": \"Vanaf 18/10 9u30, halte niet bediend. Ga naar de vorige halte HELDENPLEIN.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"47\"}]", "priority": 4, "points": "[{\"id\": \"9787\"}]"},{"content": "[{\"text\": [{\"en\": \"Until Summer of 2024, works. Stop of bus 47: rue de Ransbeekstraat 201.\", \"fr\": \"Jusqu'\u00e0 l'\u00e9t\u00e9 2024, travaux. Arr\u00eat du bus 47: rue de Ransbeek 201.\", \"nl\": \"Tot zomer 2024, werken. Halte van bus 47: Ransbeekstraat 201.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"47\"}]", "priority": 4, "points": "[{\"id\": \"2360\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. Until 2026, tram 82 and 97 interrupted. Stop of the T-bus and of bus 50: ch. de Neerstalsestwg 236.\", \"fr\": \"Travaux. Jsq 2026, tram 82 et 97 interrompus. Arr\u00eat du T-bus et du bus 50: chauss\u00e9e de Neerstalle 236\", \"nl\": \"Werken. Tot 2026, tram 82 en 97 onderbroken. Halte van de T-bus en van bus 50: Neerstalsesteenweg 236\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"50\"}]", "priority": 4, "points": "[{\"id\": \"3604\"}]"},{"content": "[{\"text\": [{\"en\": \"Until 2026, works. Bus 50 and T-bus diverted between FOREST CENTRE / VORST CENTRUM and BEMPT.\", \"fr\": \"Jusqu'en 2026, travaux. Bus 50 et T-bus d\u00e9vi\u00e9s entre FOREST CENTRE et BEMPT.\", \"nl\": \"Tot 2026, werken. Bus 50 en T-bus omgeleid tussen VORST CENTRUM en BEMPT.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"50\"}]", "priority": 5, "points": "[{\"id\": \"5915\"}, {\"id\": \"2548\"}, {\"id\": \"2546\"}, {\"id\": \"2544\"}, {\"id\": \"2555\"}, {\"id\": \"1015\"}, {\"id\": \"2553\"}, {\"id\": \"3211\"}, {\"id\": \"2539\"}]"},{"content": "[{\"text\": [{\"en\": \"Until 2026, works. Bus 50 diverted. Stop bus 50: bd 2e Arm\u00e9e Britannique / Britse Tweedelegerlaan.\", \"fr\": \"Jsq 2026, travaux. Bus 50 d\u00e9vi\u00e9. Arr\u00eat bus 50: bd 2e Arm\u00e9e Britannique, carrefour rue de la Station.\", \"nl\": \"Tot 2026, werken. Bus 50 omgeleid. Halte bus 50: Britse Tweedelegerlaan, kruispunt Stationstraat.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"50\"}]", "priority": 4, "points": "[{\"id\": \"5719\"}]"},{"content": "[{\"text\": [{\"en\": \"From May 18, 5AM, works. STOP NOT SERVED. Stop of bus 52: avenue du Parc / Parklaan 26, in front of number 26.\", \"fr\": \"D\u00e8s le 18/5, 5h, travaux. ARRET NON DESSERVI. Arr\u00eat du bus 52: avenue du Parc, en face du num\u00e9ro 26.\", \"nl\": \"Vanaf 18/5, 5u, werken. HALTE NIET BEDIEND. Halte van bus 52: Parklaan, tegenover nummer 26.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"52\"}]", "priority": 4, "points": "[{\"id\": \"2334B\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. As of Apr 15 at 6AM, STOP NOT SERVED. Take bus 53 at BEYSEGHEM / BEIZEGEM.\", \"fr\": \"Travaux. D\u00e8s le 15/4 \u00e0 6h, ARRET NON DESSERVI. Prenez le bus 53 \u00e0 BEYSEGHEM.\", \"nl\": \"Werken. Vanaf 15/4 om 6u, HALTE NIET BEDIEND. Neem bus 53 aan BEIZEGEM.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"53\"}]", "priority": 4, "points": "[{\"id\": \"2819\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. As of Apr 15 at 6AM, bus 53 diverted between BEYSEGHEM / BEIZEGEM and PETER BENOIT.\", \"fr\": \"Travaux. D\u00e8s le 15/4 \u00e0 6h, bus 53 d\u00e9vi\u00e9 entre BEYSEGHEM et PETER BENOIT.\", \"nl\": \"Werken. Vanaf 15/4 om 6u, bus 53 omgeleid tussen BEIZEGEM en PETER BENOIT.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"53\"}]", "priority": 5, "points": "[{\"id\": \"2813B\"}, {\"id\": \"2815B\"}, {\"id\": \"2566B\"}, {\"id\": \"2572\"}, {\"id\": \"2571\"}, {\"id\": \"2570\"}, {\"id\": \"3085\"}, {\"id\": \"2171\"}, {\"id\": \"2647\"}, {\"id\": \"2569\"}, {\"id\": \"2547\"}, {\"id\": \"2568\"}, {\"id\": \"2567\"}, {\"id\": \"4132B\"}, {\"id\": \"2565\"}, {\"id\": \"2564\"}, {\"id\": \"2809\"}, {\"id\": \"2573B\"}, {\"id\": \"2648\"}, {\"id\": \"2824\"}, {\"id\": \"3637\"}, {\"id\": \"1767\"}, {\"id\": \"2811\"}, {\"id\": \"1204\"}, {\"id\": \"2810\"}, {\"id\": \"2575\"}, {\"id\": \"2817\"}, {\"id\": \"2816\"}, {\"id\": \"2814\"}, {\"id\": \"3605\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. As of Apr 15 at 6AM, STOP NOT SERVED. Take bus 53 at BEYSEGHEM / BEIZEGEM.\", \"fr\": \"Travaux. D\u00e8s le 15/4 \u00e0 6h, ARRET NON DESSERVI. Prenez le bus 53 \u00e0 BEYSEGHEM.\", \"nl\": \"Werken. Vanaf 15/4 om 6u, HALTE NIET BEDIEND. Neem bus 53 aan BEIZEGEM.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"53\"}]", "priority": 4, "points": "[{\"id\": \"2852\"}]"},{"content": "[{\"text\": [{\"en\": \"Until Summer of 2024, works. Stop not served. Stop of bus 53: place Peter Benoitplein 3\", \"fr\": \"Jusqu'\u00e0 l'\u00e9t\u00e9 2024, travaux. Arr\u00eat non desservi. Arr\u00eat du bus 53 : place Peter Benoit 3\", \"nl\": \"Tot zomer 2024, werken. Halte niet bediend. Halte van bus 53: Peter Benoitplein 3\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"53\"}]", "priority": 4, "points": "[{\"id\": \"2362B\"}]"},{"content": "[{\"text\": [{\"en\": \"On May 19 until 8PM, flea market. Bus 54 diverted between MA CAMPAGNE and BAILLI / BALJUW.\", \"fr\": \"Le 19/5 jusqu'\u00e0 20h, brocante. Bus 54 d\u00e9vi\u00e9 entre MA CAMPAGNE et BAILLI.\", \"nl\": \"Op 19/5 tot 20u, rommelmarkt. Bus 54 omgeleid tussen MA CAMPAGNE en BALJUW.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"54\"}]", "priority": 5, "points": "[{\"id\": \"3243\"}]"},{"content": "[{\"text\": [{\"en\": \"From Apr 2, 2024 to June 2025, works. STOP NOT SERVED. Take bus 54 at the next stop, FOREST NATIONAL.\", \"fr\": \"Du 2/4/2024 \u00e0 juin 2025, travaux. ARRET NON DESSERVI. Prenez le bus 54 \u00e0 l'arr\u00eat suivant, FOREST NATIONAL.\", \"nl\": \"Van 2/4/2024 tot juni 2025, werken. HALTE NIET BEDIEND. Neem bus 54 aan de volgende halte, VORST NATIONAAL.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"54\"}]", "priority": 4, "points": "[{\"id\": \"2952B\"}]"},{"content": "[{\"text\": [{\"en\": \"On May 19 until 8PM, flea market. Bus 54 diverted between BAILLI / BALJUW and MA CAMPAGNE.\", \"fr\": \"Le 19/5 jusqu'\u00e0 20h, brocante. Bus 54 d\u00e9vi\u00e9 entre BAILLI et MA CAMPAGNE.\", \"nl\": \"Op 19/5 tot 20u, rommelmarkt. Bus 54 omgeleid tussen BALJUW en MA CAMPAGNE.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"54\"}]", "priority": 4, "points": "[{\"id\": \"1734\"}, {\"id\": \"1780\"}, {\"id\": \"2929\"}, {\"id\": \"2928\"}, {\"id\": \"3518B\"}, {\"id\": \"3506\"}]"},{"content": "[{\"text\": [{\"en\": \"From Apr 2, 2024 to June 2025, works. STOP NOT SERVED. Stop of bus 54 and 74: avenue du Globelaan 8.\", \"fr\": \"Du 2/4/2024 \u00e0 juin 2025, travaux. ARRET NON DESSERVI. Arr\u00eat des bus 54 et 74: avenue du Globe 8.\", \"nl\": \"Van 2/4/2024 tot juni 2025, werken. HALTE NIET BEDIEND. Halte van bus 54 en 74: Globelaan 8.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"54\"}]", "priority": 4, "points": "[{\"id\": \"2616B\"}]"},{"content": "[{\"text\": [{\"en\": \"On May 19 until 8PM, flea market. Stop not served. Stop of bus 54: chauss\u00e9e de Waterloo / Waterloosesteenweg 394.\", \"fr\": \"Le 19/5 jusqu'\u00e0 20h, brocante. Arr\u00eat non desservi. Arr\u00eat du bus 54: chauss\u00e9e de Waterloo, 394.\", \"nl\": \"Op 19/5 tot 20u, rommelmarkt. Halte niet bediend. Halte van bus 54: Waterloosesteenweg 394.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"54\"}]", "priority": 4, "points": "[{\"id\": \"2932\"}]"},{"content": "[{\"text\": [{\"en\": \"On May 5 until 8PM, flea market. STOP NOT SERVED. Stop the T-bus and B54: rue Lesbroussart, before avenue Louise.\", \"fr\": \"19/5 jsq 20h, brocante. ARRET NON DESSERVI. Arr\u00eat du T-bus et B54 : rue Lesbroussart, avant avenue Louise.\", \"nl\": \"Op 19/5 tot 20u, rommelmarkt. HALTE NIET BEDIEND. Halte T-bus en B54: Lesbroussartstraat, voor Louizalaan.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"54\"}]", "priority": 4, "points": "[{\"id\": \"2972\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. As of Apr 15, bus 56 diverted. Take bus 56 at the previous stop, at the St-Cyr house.\", \"fr\": \"Travaux. D\u00e8s le 15/4, bus 56 d\u00e9vi\u00e9. Prenez le bus 56 \u00e0 l'arr\u00eat pr\u00e9c\u00e9dent, devant la maison Saint-Cyr.\", \"nl\": \"Werken. Vanaf 15/4, bus 56 omgeleid. Neem bus 56 aan de vorige halte, voor het St-Cyr-huis.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"56\"}]", "priority": 4, "points": "[{\"id\": \"1273\"}]"},{"content": "[{\"text\": [{\"en\": \"As of Nov 14, stop moved to avenue Van Praetlaan, after Van Praet bridge.\", \"fr\": \"D\u00e8s le 14/11, arr\u00eat d\u00e9plac\u00e9 avenue Van Praet, apr\u00e8s le pont Van Praet.\", \"nl\": \"Vanaf 14/11, halte verplaatst naar de Van Praetlaan, na het Van Praetbrug.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"56\"}]", "priority": 4, "points": "[{\"id\": \"6370\"}]"},{"content": "[{\"text\": [{\"en\": \"Until Summer of 2024, works. As of March 18, buses 56 and 57 serve this stop normally.\", \"fr\": \"Jusqu'\u00e0 l'\u00e9t\u00e9 2024, travaux. D\u00e8s le 18/3, les bus 56 et 57 desservent \u00e0 nouveau cet arr\u00eat.\", \"nl\": \"Tot zomer 2024, werken. Vanaf 18/3 bedienen bus 56 en 57 opnieuw deze halte.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"56\"}]", "priority": 5, "points": "[{\"id\": \"1839\"}]"},{"content": "[{\"text\": [{\"en\": \"Until Summer of 2024, works. Stop not served. Take bus 47 or 56 at ANTOON VAN OSS. For HOP MILITAIRE , walk.\", \"fr\": \"Jsq \u00e9t\u00e9 2024, travaux. Arr\u00eat non desservi. Bus 47 ou 56 \u00e0 ANTOON VAN OSS. Pour HOPITAL MILITAIRE, \u00e0 pied.\", \"nl\": \"Tot zomer 2024, werken. Halte niet bediend. Neem bus 47 of 56 aan ANTOON VAN OSS. Voor MILITAIR HOSPITAAL, ga te voet.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"56\"}]", "priority": 4, "points": "[{\"id\": \"1838\"}]"},{"content": "[{\"text\": [{\"en\": \"Until Summer of 2024, works. As of Mar 18, stop served normally by bus 56.\", \"fr\": \"Jusqu'\u00e0 l'\u00e9t\u00e9 2024, travaux. D\u00e8s le 18/3, arr\u00eat \u00e0 nouveau desservi par les bus 56.\", \"nl\": \"Tot zomer 2024, werken. Vanaf 18/3, halte opnieuw bediend door bus 56.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"56\"}]", "priority": 4, "points": "[{\"id\": \"2352\"}]"},{"content": "[{\"text\": [{\"en\": \"Until Summer of 2024, works. Stop not served. Take bus 57 at the stop of bus 56 to SCHUMAN.\", \"fr\": \"Jusqu'\u00e0 l'\u00e9t\u00e9 2024, travaux. Arr\u00eat non desservi. Prenez le bus 57 \u00e0 l'arr\u00eat du bus 56 vers SCHUMAN.\", \"nl\": \"Tot zomer 2024, werken. Halte niet bediend. Neem bus 57 aan de halte van bus 56 naar SCHUMAN.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"57\"}]", "priority": 4, "points": "[{\"id\": \"2317\"}]"},{"content": "[{\"text\": [{\"en\": \"Until Summer of 2024, works. Stop not served. Take bus 57 at the stop of bus 56 to BUDA.\", \"fr\": \"Jusqu'\u00e0 l'\u00e9t\u00e9 2024, travaux. Arr\u00eat non desservi. Prenez le bus 57 \u00e0 l'arr\u00eat du bus 56 vers BUDA.\", \"nl\": \"Tot zomer 2024, werken. Halte niet bediend. Neem bus 57 aan de halte van bus 56 naar BUDA.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"57\"}]", "priority": 4, "points": "[{\"id\": \"2358\"}]"},{"content": "[{\"text\": [{\"en\": \"Until Summer of 2024, works. Bus 57 diverted. Take bus 57 at ANTOON VAN OSS (stop of bus 56 to BUDA)\", \"fr\": \"Jusqu'\u00e0 l'\u00e9t\u00e9 2024, travaux. Bus 57 d\u00e9vi\u00e9. Prenez le bus 57 \u00e0 ANTOON VAN OSS (arr\u00eat du bus 56 vers BUDA).\", \"nl\": \"Tot zomer 2024, werken. Bus 57 omgeleid. Neem bus 57 aan ANTOON VAN OSS (halte van bus 56 naar BUDA).\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"57\"}]", "priority": 4, "points": "[{\"id\": \"1827\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. As of Apr 15, STOP NOT SERVED. Take bus 60 at PARC LEOPOLD (ch. Etterbeek, in front of number 166).\", \"fr\": \"Travaux. D\u00e8s le 15/4, ARRET NON DESSERVI. Bus 60 \u00e0 PARC LEOPOLD (chauss\u00e9e d'Etterbeek, en face du num\u00e9ro 166).\", \"nl\": \"Werken. Vanaf 15/4, HALTE NIET BEDIEND. Neem bus 60 aan LEOPOLDSPARK (Etterbeeksesteenweg, tegenover nummer 166)\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"60\"}]", "priority": 4, "points": "[{\"id\": \"1271B\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. As of Apr 15, STOP NOT SERVED. Take bus 60 at MAELBEEK / MAALBEEK.\", \"fr\": \"Travaux. D\u00e8s le 15/4, ARRET NON DESSERVI. Prenez le bus 60 \u00e0 MAELBEEK.\", \"nl\": \"Werken. Vanaf 15/4, HALTE NIET BEDIEND. Neem bus 60 aan MAALBEEK.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"60\"}]", "priority": 4, "points": "[{\"id\": \"1270B\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. As of Apr 15, bus 60 diverted between JOURDAN and AMBIORIX via MAELBEEK. Connection metro at MAELBEEK.\", \"fr\": \"Travaux. D\u00e8s le 15/4, bus 60 d\u00e9vi\u00e9 entre JOURDAN et AMBIORIX via MAELBEEK. Correspondance m\u00e9tro \u00e0 MAELBEEK.\", \"nl\": \"Werken. Vanaf 15/4, bus 60 omgeleid tussen JOURDAN en AMBIORIX via MAALBEEK. Aansluiting metro aan MAALBEEK.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"60\"}]", "priority": 6, "points": "[{\"id\": \"1986\"}]"},{"content": "[{\"text\": [{\"en\": \"Risk of subsidence. Stop of bus 65, 66 and N04 moved to chauss\u00e9e de Haecht/Haachtsesteenweg, next to number 162\", \"fr\": \"Risque d'effondrement. Arr\u00eat des bus 65, 66 et N04 d\u00e9plac\u00e9 chauss\u00e9e de Haecht, \u00e0 hauteur du num\u00e9ro 162.\", \"nl\": \"Risico op instorting. Halte van bus 65, 66 en N04 verplaatst naar de Haachtsesteenweg, ter hoogte van nummer 162.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"66\"}]", "priority": 4, "points": "[{\"id\": \"6418\"}]"},{"content": "[{\"text\": [{\"en\": \"Jan 8-Jun 28, works. Tram 7 replaced by T-bus between DOCKS BRUXSEL and HEEMBEEK. Info: stib-mivb.brussels\", \"fr\": \"8/1-28/6, travaux. Tram 7 remplac\u00e9 par des T-bus entre DOCKS BRUXSEL et HEEMBEEK. Info: stib. brussels.\", \"nl\": \"8/1-28/6, werken. Tram 7 vervangen door T-bus tussen DOCKS BRUXSEL en HEEMBEEK. info: mivb. brussels.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"7\"}]", "priority": 5, "points": "[{\"id\": \"2636F\"}, {\"id\": \"9056F\"}]"},{"content": "[{\"text\": [{\"en\": \"From Jan 7 at 9PM to Jun 28, works. Tram 7 does not serve this stop. Take tram 3 to go to VANDERKINDERE.\", \"fr\": \"Du 7/1 \u00e0 21h au 28/6, travaux. Tram 7 ne dessert pas cet arr\u00eat. Prenez le tram 3 pour rejoindre VANDERKINDERE.\", \"nl\": \"Van 7/1 om 21u tot en met 28/6, werken. Tram 7 bedient deze halte niet. Neem tram 3 om naar VANDERKINDERE te gaan.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"7\"}]", "priority": 4, "points": "[{\"id\": \"5219F\"}]"},{"content": "[{\"text\": [{\"en\": \"From Jan 8 to Jun 28, works. Tram 7 interrupted to HEEMBEEK. T-bus at the stop of bus 56 to BUDA.\", \"fr\": \"Du 8/1 au 28/6, travaux. Tram 7 interrompu jusqu'\u00e0 HEEMBEEK. T-bus \u00e0 l'arr\u00eat du bus 56 vers BUDA.\", \"nl\": \"8/1-28/6, werken. Tram 7 onderbroken tot HEEMBEEK. T-bus aan de halte van bus 56 naar BUDA.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"7\"}]", "priority": 5, "points": "[{\"id\": \"5759F\"}]"},{"content": "[{\"text\": [{\"en\": \"From Mar 18, works. STOP NOT SERVED. stop of bus 71: avenue de l'Universit\u00e9 / Hogeschoollaan 4-10.\", \"fr\": \"D\u00e8s le 18/3, travaux. ARRET NON DESSERVI. Arr\u00eat du bus 71: avenue de l'Universit\u00e9 4-10.\", \"nl\": \"Vanaf 18/3, werken. HALTE NIET BEDIEND. Halte van bus 71: Hogeschoollaan 4-10.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"71\"}]", "priority": 4, "points": "[{\"id\": \"3514\"}]"},{"content": "[{\"text\": [{\"en\": \"Subsidence. Bus 74 limited to DECROLY. Walk from DECROLY to UCCLE-STALLE / UKKEL-STALLE.\", \"fr\": \"Effondrement. Bus 74 limit\u00e9 \u00e0 DECROLY. Continuez \u00e0 pied depuis DECROLY jusqu'\u00e0 UCCLE STALLE.\", \"nl\": \"Wegverzakking. Bus 74 beperkt tot DECROLY. Ga te voet van DECROLY tot UKKEL-STALLE.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"74\"}]", "priority": 5, "points": "[{\"id\": \"2631\"}]"},{"content": "[{\"text\": [{\"en\": \"Subsidence. Bus 74 limited to DECROLY. Walk from DECROLY to UCCLE-STALLE / UKKEL-STALLE.\", \"fr\": \"Effondrement. Bus 74 limit\u00e9 \u00e0 DECROLY. Continuez \u00e0 pied depuis DECROLY jusqu'\u00e0 UCCLE STALLE.\", \"nl\": \"Wegverzakking. Bus 74 beperkt tot DECROLY. Ga te voet van DECROLY tot UKKEL-STALLE.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"74\"}]", "priority": 5, "points": "[{\"id\": \"3682\"}, {\"id\": \"3074\"}, {\"id\": \"5915\"}, {\"id\": \"2614\"}, {\"id\": \"2602\"}, {\"id\": \"2601\"}, {\"id\": \"2600\"}, {\"id\": \"2226\"}, {\"id\": \"2523\"}, {\"id\": \"2555\"}, {\"id\": \"1015\"}, {\"id\": \"2599\"}, {\"id\": \"2598\"}, {\"id\": \"2607\"}, {\"id\": \"2606\"}, {\"id\": \"2605\"}]"},{"content": "[{\"text\": [{\"en\": \"Apr 2, 2024-June 2025, works. Bus 74 diverted between FOREST NATIONAL and FOREST CENTRE. Info: stib-mivb.brussels\", \"fr\": \"Du 2/4/2024 \u00e0 juin 2025, travaux. Bus 74 d\u00e9vi\u00e9 entre FOREST NATIONAL et FOREST CENTRE. Info: stib.brussels.\", \"nl\": \"2/4/2024-juni 2025, werken. Bus 74 omgeleid tussen VORST NATIONAAL en VORST CENTRUM. Info: mivb.brussels\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"74\"}]", "priority": 5, "points": "[{\"id\": \"2632\"}, {\"id\": \"2453\"}]"},{"content": "[{\"text\": [{\"en\": \"From Apr 2, 2024 to June 2025, works. STOP NOT SERVED. Stop of bus 54 and 74: avenue du Globelaan 8.\", \"fr\": \"Du 2/4/2024 \u00e0 juin 2025, travaux. ARRET NON DESSERVI. Arr\u00eat des bus 54 et 74: avenue du Globe 8.\", \"nl\": \"Van 2/4/2024 tot juni 2025, werken. HALTE NIET BEDIEND. Halte van bus 54 en 74: Globelaan 8.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"74\"}]", "priority": 4, "points": "[{\"id\": \"2616B\"}]"},{"content": "[{\"text\": [{\"en\": \"From Jan 18, works. STOP NOT SERVED. Temporary stop: Avenue de Roodebeeklaan 45.\", \"fr\": \"D\u00e8s le 18/1, travaux. ARRET NON DESSERVI. Arr\u00eat provisoire: Avenue de Roodebeek 45.\", \"nl\": \"Vanaf 18/1, werken. HALTE NIET BEDIEND. Tijdelijke halte: Roodebeeklaan 45.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"79\"}]", "priority": 4, "points": "[{\"id\": \"1404\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. As of Apr 15, STOP NOT SERVED. Stop of bus 79: rue Archim\u00e8de / Archimedesstraat 16.\", \"fr\": \"Travaux. D\u00e8s le 15/4, ARRET NON DESSERVI. Arr\u00eat du bus 79: rue Archim\u00e8de 16.\", \"nl\": \"Werken. Vanaf 15/4, HALTE NIET BEDIEND. Halte van bus 79: Archimedesstraat 16.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"79\"}]", "priority": 4, "points": "[{\"id\": \"1474B\"}, {\"id\": \"2083\"}]"},{"content": "[{\"text\": [{\"en\": \"On May 5 until 8PM, flea market. STOP NOT SERVED. Stop of the T-bus: chauss\u00e9e de Charleroisesteenweg 180.\", \"fr\": \"Le 19/5 jusqu'\u00e0 20h, brocante. ARRET NON DESSERVI. Arr\u00eat du T-bus : chauss\u00e9e de Charleroi 180.\", \"nl\": \"Op 19/5 tot 20u, rommelmarkt. HALTE NIET BEDIEND. Halte van de T-bus: Charleroisesteenweg 180.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"81\"}]", "priority": 4, "points": "[{\"id\": \"6427F\"}]"},{"content": "[{\"text\": [{\"en\": \"On May 5 until 8PM, flea market. T81 interrupted. Stop of T81: avenue des Eperons d'Or, before place Flageyplein.\", \"fr\": \"19/5 jsq 20h, brocante. Tram 81 interrompu. Arr\u00eat du T81 : avenue des Eperons d'Or, avant carrefour place Flagey.\", \"nl\": \"Op 19/5 tot 20u, rommelmarkt. Tram 81 onderbroken. Halte van T81: Gulden-Sporenlaan, voor Flageyplein.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"81\"}]", "priority": 4, "points": "[{\"id\": \"3508F\"}]"},{"content": "[{\"text\": [{\"en\": \"On May 5 until 8PM, flea market. Tram 81 interrupted. Stop of the T-bus: rue Lesbroussart- straat 72-74.\", \"fr\": \"Le 19/5 jusqu'\u00e0 20h, brocante. Tram 81 interrompu. Arr\u00eat du T-bus : rue Lesbroussart 72-74.\", \"nl\": \"Op 19/5 tot 20u, rommel- markt. T81 onderbroken. Halte T-bus: Lesbroussartstraat 72-74.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"81\"}]", "priority": 4, "points": "[{\"id\": \"6120\"}]"},{"content": "[{\"text\": [{\"en\": \"On May 5 until 8PM, flea market. T81 interrupted. Stop of T-bus: place E. Flageyplein, stop of bus 71 to DE BROUCKERE.\", \"fr\": \"19/5 jsq 20h, brocante. Tram 81 interrompu. Arr\u00eat du T-bus : place Eug\u00e8ne Flagey, arr\u00eat du bus 71 DE BROUCKERE.\", \"nl\": \"Op 19/5 tot 20u, rommel- markt. T81 onderbroken. Halte van T-bus: E. Flagey- plein, halte bus 71 naar DE BROUCKERE.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"81\"}]", "priority": 4, "points": "[{\"id\": \"3572F\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. Until 2026, stop not served. Walk to DROGENBOS.\", \"fr\": \"Travaux. Jusqu'en 2026, arr\u00eat non desservi. Pour rejoindre DROGENBOS, continuez \u00e0 pied.\", \"nl\": \"Werken. Tot 2026, halte niet bediend. Ga te voet verder om naar DROGENBOS te gaan.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"82\"}]", "priority": 4, "points": "[{\"id\": \"5729\"}, {\"id\": \"5725\"}]"},{"content": "[{\"text\": [{\"en\": \"Works. Until 2026, stop not served. T-bus 82 to DROGENBOS at the previous stop, CARREFOUR STALLE.\", \"fr\": \"Travaux. Jusqu'en 2026, arr\u00eat non desservi. T-bus 82 vers DROGENBOS \u00e0 l'arr\u00eat pr\u00e9c\u00e9dent, CARREFOUR STALLE.\", \"nl\": \"Werken. Tot 2026, halte niet bediend. T-bus 82 naar DROGENBOS aan de vorige halte, KRUISPUNT STALLE.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"82\"}]", "priority": 4, "points": "[{\"id\": \"5724\"}]"},{"content": "[{\"text\": [{\"en\": \"Until 2026, works. Stop not served. Take tram 82 at FOREST CENTRE / VORST CENTRUM (stop to Drogenbos).\", \"fr\": \"Jusqu'en 2026, travaux. Arr\u00eat non desservi. Prenez le tram 82 \u00e0 FOREST CENTRE (arr\u00eat vers Drogenbos).\", \"nl\": \"Tot 2026, werken. Halte niet bediend. Neem tram 82 aan VORST CENTRUM (halte naar Drogenbos).\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"82\"}]", "priority": 4, "points": "[{\"id\": \"5152G\"}]"},{"content": "[{\"text\": [{\"en\": \"Jan 22, 6AM-end of June, works. Bus 86 diverted. Bus 86 at stop MERCHTEM of bus 20 to GARE DU NORD / NOORDSTATION.\", \"fr\": \"Du 22/1 \u00e0 6h jusqu'\u00e0 fin juin, travaux. Bus 86 d\u00e9vi\u00e9. Bus 86 \u00e0 l'arr\u00eat MERCHTEM du bus 20 vers GARE DU NORD.\", \"nl\": \"Van 22/1 om 6u tot eind juni, werken. Bus 86 omgeleid. B86 aan halte MERCHTEM van bus 20 naar NOORDSTATION.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"86\"}]", "priority": 4, "points": "[{\"id\": \"6755\"}]"},{"content": "[{\"text\": [{\"en\": \"From Jan 22 at 6AM to end of June, works. Bus 86 diverted. Stop of bus 86: rue A. Vandenpeereboomstraat 44\", \"fr\": \"Du 22/1 \u00e0 6h jusqu'\u00e0 fin juin, travaux. Bus 86 d\u00e9vi\u00e9. Arr\u00eat du bus 86: rue  A. Vandenpeereboom 44.\", \"nl\": \"Van 22/1 om 6u tot eind juni, werken. Bus 86 omgeleid. Halte van bus 86: A. Vandenpeereboomstraat 44\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"86\"}]", "priority": 4, "points": "[{\"id\": \"4595\"}, {\"id\": \"1242\"}]"},{"content": "[{\"text\": [{\"en\": \"From Mar 3 at 7AM, works. STOP NOT SERVED. Take bus 86 at the next stop DUCHESSE BRABANT / HERTOGIN BRABANT.\", \"fr\": \"D\u00e8s le 3/3 \u00e0 7h, travaux. ARRET NON DESSERVI. Prenez le bus 86 \u00e0 l'arr\u00eat suivant, DUCHESSE BRABANT.\", \"nl\": \"Vanaf 3/3 om 7u, werken. HALTE NIET BEDIEND. Neem bus 86 aan de volgende halte HERTOGIN BRABANT.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"86\"}]", "priority": 4, "points": "[{\"id\": \"6706\"}]"},{"content": "[{\"text\": [{\"en\": \"Jan 22, 6AM-end of June, works. B86 diverted. Stop of B86:ch.De Gand/ Gentsestwg, in front of number 219 (Stop B13).\", \"fr\": \"Du 22/1 \u00e0 6h jusqu'\u00e0 fin juin, travaux. Bus 86 d\u00e9vi\u00e9. Arr\u00eat du B86: ch. de Gand, en face du num\u00e9ro 219 (arr\u00eat B13).\", \"nl\": \"Van 22/1 om 6u tot eind juni, werken. Bus 86 omgeleid. Halte van B86: Gentsesteenweg,tegenover nr. 219 (halte bus 13).\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"86\"}]", "priority": 4, "points": "[{\"id\": \"6754\"}]"},{"content": "[{\"text\": [{\"en\": \"As of Nov 16 at 6AM, works. Stop moved to av. Port / Havenln, in front of number 100 (moved backward of +/- 120m)\", \"fr\": \"D\u00e8s le 16/11 \u00e0 6h, travaux. Arr\u00eat d\u00e9plac\u00e9 avenue du Port, en face du num\u00e9ro 100 (recul\u00e9 de +/- 120m).\", \"nl\": \"Vanaf 16/11 om 6u,werken Halte verplaatst naar de Havenlaan, tegenover nr 100 (achteruitgebracht van +/- 120m)\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"88\"}]", "priority": 4, "points": "[{\"id\": \"2305\"}]"},{"content": "[{\"text\": [{\"en\": \"From Dec 4, works. STOP NOT SERVED. Stop of bus 88: rue du Progr\u00e8s / Vooruitgangstraat 64.\", \"fr\": \"D\u00e8s le 4/12, travaux. ARRET NON DESSERVI. Arr\u00eat du bus 88: rue du Progr\u00e8s 64.\", \"nl\": \"Vanaf 4/12, werken. HALTE NIET BEDIEND. Halte van bus 88: Vooruitgangstraat 64.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"88\"}]", "priority": 4, "points": "[{\"id\": \"3400\"}]"},{"content": "[{\"text\": [{\"en\": \"From Dec 4, works. STOP NOT SERVED. Stop of bus 58 and 88 : rue du Progr\u00e8s, after crossing rue des Charbonniers.\", \"fr\": \"D\u00e8s le 4/12, travaux. ARRET NON DESSERVI. Arr\u00eat des bus 58 et 88 : rue du Progr\u00e8s, apr\u00e8s rue des Charbonniers.\", \"nl\": \"Vanaf 4/12, werken. HALTE NIET BEDIEND. Halte bus 58 en 88 : Vooruitgangstraat, na Koolbrandersstraat.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"88\"}]", "priority": 4, "points": "[{\"id\": \"1083\"}]"},{"content": "[{\"text\": [{\"en\": \"Until end of August, works. Bus 89 diverted. For the city center, take metro 1 or 5 at STE-CATHERINE.\", \"fr\": \"Jusque fin ao\u00fbt, travaux. Bus 89 d\u00e9vi\u00e9. Pour le centre-ville, prenez le m\u00e9tro 1 ou 5 \u00e0 SAINTE-CATHERINE.\", \"nl\": \"Tot einde augustus, werken. Bus 89 omgeleid. Om naar het stadscentrum te gaan, neem M 1 5 aan SINT-KATELIJNE.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"89\"}]", "priority": 4, "points": "[{\"id\": \"3261\"}]"},{"content": "[{\"text\": [{\"en\": \"Until end of August, works. Bus 89 diverted btw PTE DE NINOVE and BOURSE, and interrupted bt BOURSE and CENTRAL ST\", \"fr\": \"Jsq fin ao\u00fbt, travaux. Bus 89 d\u00e9vi\u00e9 entre PORTE DE NINOVE et BOURSE, et interrompu entre BOURSE et GARE CENTRALE.\", \"nl\": \"Tot einde augustus, werken. Bus 89 omgeleid tss NINOOFSEPOORT en BEURS, en onderbroken tss BEURS en CENTR ST\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"89\"}]", "priority": 5, "points": "[{\"id\": \"2754\"}, {\"id\": \"2776\"}, {\"id\": \"2748B\"}, {\"id\": \"4595\"}, {\"id\": \"1178\"}, {\"id\": \"2784\"}, {\"id\": \"2782\"}, {\"id\": \"6648\"}]"},{"content": "[{\"text\": [{\"en\": \"Until end of August 2024, works. Stop not served. Take bus 29 or 71 at DE BROUCKERE to go to CENTRAL STATION.\", \"fr\": \"Jsq fin ao\u00fbt 2024, travaux. Arr\u00eat non desservi. Prenez le bus 29 ou 71 \u00e0 DE BROUCKERE pour GARE CENTRALE.\", \"nl\": \"Tot einde augustus 2024, werken. halte niet bediend. Neem bus 29 of 71 aan DE BROUCKERE om naar CENTR. ST. te gaan\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"89\"}]", "priority": 4, "points": "[{\"id\": \"1894\"}]"},{"content": "[{\"text\": [{\"en\": \"From Mar 5 at 9AM, works. STOP NOT SERVED. Temporary stop: avenue Jean & Pierre Carsoellaan 4.\", \"fr\": \"D\u00e8s le 5/3 \u00e0 9h, travaux. ARRET NON DESSERVI. Arr\u00eat provisoire: avenue Jean et Pierre Carsoel 4.\", \"nl\": \"Vanaf 5/3 om 9u, werken. HALTE NIET BEDIEND. Tijdelijke halte: Jean en Pierre Carsoellaan 4.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"92\"}]", "priority": 4, "points": "[{\"id\": \"6931H\"}]"},{"content": "[{\"text\": [{\"en\": \"From Mar 18, works. STOP NOT SERVED. stop of bus 95: chauss\u00e9e de Boondael / Boondaalsesteenweg, before roundabout.\", \"fr\": \"D\u00e8s le 18/3, travaux. ARRET NON DESSERVI. Arr\u00eat du bus 95: chauss\u00e9e de Boondael, avant le rond-point.\", \"nl\": \"Vanaf 18/3, werken. HALTE NIET BEDIEND. Halte van bus 95: Boondaalsesteenweg, voor rondpunt.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"95\"}]", "priority": 4, "points": "[{\"id\": \"3514\"}]"},{"content": "[{\"text\": [{\"en\": \"Afterwork. Every Thursday after 4PM, stop moved to rue de Tr\u00e8ves, in front of the stop in the other direction\", \"fr\": \"Afterwork. Tous les jeudis apr\u00e8s 16h, arr\u00eat d\u00e9plac\u00e9 rue de Tr\u00e8ves, en face de l'arr\u00eat dans l'autre sens.\", \"nl\": \"Afterwork.Elke donderdag na 16u, halte verplaatst naar de Trierstraat, tegenover de halte in de andere richting.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"95\"}]", "priority": 4, "points": "[{\"id\": \"1233\"}]"},{"content": "[{\"text\": [{\"en\": \"From Mar 25 until Jun 30, works. STOP NOT SERVED. Stop of bus 95: bd. Gen. Jacqueslaan 235.\", \"fr\": \"Du 25/3 au 30/6, travaux. ARRET NON DESSERVI. Arr\u00eat du bus 95: boulevard G\u00e9n\u00e9ral Jacques, 235.\", \"nl\": \"Van 25/3 tot en met 30/6, werken. HALTE NIET BEDIEND. Halte van bus 95:  Generaal Jacqueslaan 235.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"95\"}]", "priority": 4, "points": "[{\"id\": \"4363\"}]"},{"content": "[{\"text\": [{\"en\": \"From Mar 18, works. STOP NOT SERVED. Temporary stop: avenue de la Couronne / Kroonlaan 439-443.\", \"fr\": \"D\u00e8s le 18/3, travaux. ARRET NON DESSERVI. Arr\u00eat provisoire: avenue de la Couronne 439-443.\", \"nl\": \"Vanaf 18/3, werken. HALTE NIET BEDIEND. Tijdelijke halte: Kroonlaan 439-443.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"95\"}]", "priority": 4, "points": "[{\"id\": \"3558\"}]"},{"content": "[{\"text\": [{\"en\": \"Until 2026, works. Tram 97 interrupted. T-bus to CARREFOUR / KRUISPUNT STALLE at the stop of bus 54 to TRONE/TROON\", \"fr\": \"Jusqu'en 2026, travaux. Tram 97 interrompu. T-bus vers CARREFOUR STALLE \u00e0 l'arr\u00eat du bus 54 vers TRONE.\", \"nl\": \"Tot 2026, werken. Tram 97 onderbroken. T-bus naar KRUISPUNT STALLE aan de halte van bus 54 naar TROON.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"97\"}]", "priority": 4, "points": "[{\"id\": \"5121F\"}]"},{"content": "[{\"text\": [{\"en\": \"Until 2026, works. As of Mar 11, tram 97 interrupted btw WIELS and DIEWEG. Take T92 at MARLOW to go to DIEWEG\", \"fr\": \"Jsq 2026,travaux. D\u00e8s le 11/3, tram 97 interrompu entre WIELS et DIEWEG. Prenez le T92 \u00e0 MARLOW pour aller \u00e0 DIEWEG\", \"nl\": \"Tot 2026, werken. Vanaf 11/3,tram 97 onderbroken tss WIELS en DIEWEG. Neem tram 92 aan MARLOW om naar DIEWEG te gaan\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"97\"}]", "priority": 4, "points": "[{\"id\": \"1985G\"}]"},{"content": "[{\"text\": [{\"en\": \"Until 2026, works. As of Mar 11, tram 97 operated only btw LOUISE and WIELS.T-bus to CARREFOUR STALLE at ROCHEFORT.\", \"fr\": \"Jsq 2026,travaux. D\u00e8s le 11/3, tram 97 circule uniquement entre LOUISE et WIELS.T-bus vers CARR STALLE \u00e0 ROCHEFORT.\", \"nl\": \"Tot 2026, werken. Vanaf 11/3 rijdt tram 97 enkel tussen LOUIZA en WIELS. T-bus naar KRUISPUNT STALLE aan ROCHEFORT.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"97\"}]", "priority": 5, "points": "[{\"id\": \"6078\"}, {\"id\": \"6428F\"}, {\"id\": \"5018F\"}, {\"id\": \"5016F\"}, {\"id\": \"2404F\"}, {\"id\": \"6314\"}, {\"id\": \"2336G\"}, {\"id\": \"6162\"}]"},{"content": "[{\"text\": [{\"en\": \"Until 2026, works. As of Mar 11, tram 97 interrupted between WIELS and DIEWEG. Take tram 4 to go to GLOBE.\", \"fr\": \"Jsq 2026,travaux. D\u00e8s le 11/3, tram 97 interrompu entre WIELS et DIEWEG. Prenez le tram 4 pour rejoindre GLOBE.\", \"nl\": \"Tot 2026, werken. Vanaf 11/3, tram 97 onderbroken tussen WIELS en DIEWEG. Neem tram 4 om naar GLOBE te gaan.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"97\"}]", "priority": 4, "points": "[{\"id\": \"5723G\"}]"},{"content": "[{\"text\": [{\"en\": \"Until 2026, works. As of Mar 11, T97 operated only btw LOUISE and WIELS. T82 at WIELS or T-bus at PIERRE DECOSTER\", \"fr\": \"Jsq 2026, travaux. D\u00e8s le 11/3, T97  uniquement entre LOUISE et WIELS. Tram 82 \u00e0 WIELS ou T-bus \u00e0 PIERRE DECOSTER.\", \"nl\": \"Tot 2026, werken. Vanaf 11/3 rijdt T97 enkel tss LOUIZA en WIELS.Neem T82 aan WIELS of de T-bus aan PIERRE DECOSTER.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"97\"}]", "priority": 5, "points": "[{\"id\": \"5116\"}]"},{"content": "[{\"text\": [{\"en\": \"Until 2026, works. As of Mar 11, tram 97 interrupted to DIEWEG. For GLOBE, tram 4 at CARR. STALLE via T-bus\", \"fr\": \"Jsq 2026,travaux. D\u00e8s le 11/3, tram 97 interrompu jsq DIEWEG. Pour GLOBE, tram 4 \u00e0 CARREFOUR STALLE via T-bus.\", \"nl\": \"Tot 2026, werken. Vanaf 11/3,T97 onderbroken tot DIEWEG. Voor GLOBE, neem T4 aan KRUISPUNT STALLE via T-bus.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"97\"}]", "priority": 4, "points": "[{\"id\": \"5163F\"}]"},{"content": "[{\"text\": [{\"en\": \"Until 2026, works. T97 interrupted to WIELS. Stop of the T-bus to ROCHEFORT: r. Soierie / Zijdeweverijstraat 9\", \"fr\": \"Jusqu'en 2026, travaux. Tram 97 interrompu jusqu'\u00e0 WIELS. Arr\u00eat du T-bus vers ROCHEFORT: rue de la Soierie 9.\", \"nl\": \"Tot 2026, werken. Tram 97 onderbroken tot WIELS. Halte van de T-bus naar ROCHEFORT: Zijdeweverijstraat 9.\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"97\"}]", "priority": 4, "points": "[{\"id\": \"5156F\"}]"},{"content": "[{\"text\": [{\"en\": \"Until 2026, works. As of Mar 11, tram 97 interrupted btw WIELS and DIEWEG. Take tram 92 to go to DIEWEG\", \"fr\": \"Jsq 2026,travaux. D\u00e8s le 11/3, tram 97 interrompu entre WIELS et DIEWEG. Prenez le tram 92 pour rejoindre DIEWEG\", \"nl\": \"Tot 2026, werken. Vanaf 11/3,tram 97 onderbroken tss WIELS en DIEWEG. Neem tram 92 om naar DIEWEG te gaan\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"97\"}]", "priority": 4, "points": "[{\"id\": \"2765\"}, {\"id\": \"2764G\"}]"},{"content": "[{\"text\": [{\"en\": \"Works.From May 17 at 9PM until May 20, STOP NOT SERVED. T-bus to SIMONIS at CIM. / KERKH. JETTE, via tram 51 or 93.\", \"fr\": \"Travaux. Du 17/5 \u00e0 21h au 20/5, ARRET NON DESSERVI. T-bus vers SIMONIS \u00e0 CIM. DE JETTE, via tram 51 ou 93.\", \"nl\": \"Werken. Van 17/5 om 21u tot 20/5, HALTE NIET BEDIEND. T-bus naar SIMONIS aan KERKHOF VAN JETTE, via tram 51 of 93\"}], \"type\": \"Description\"}]", "type": "LongText", "lines": "[{\"id\": \"T19\"}]", "priority": 4, "points": "[{\"id\": \"2802\"}]"}]
+[
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. As of Apr 15, B12 diverted btw LUXEMBOURG and MEISER via MAELBEEK. Stop SCHUMAN moved rue Archim\u00e8destr. 16.\", \"fr\": \"Travaux. D\u00e8s le 15/4,B12 d\u00e9vi\u00e9 entre LUXEMBOURG et MEISER via MAELBEEK. Arr\u00eat SCHUMAN d\u00e9plac\u00e9 rue Archim\u00e8de 16.\", \"nl\": \"Werken. Vanaf 15/4, bus 12 omgeleid ts LUXEMBURG en MEISER via MAALBEEK. Halte SCHUMAN verplaatst Archimedesstraat 16.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"12\"}]",
+        "priority": 6,
+        "points": "[{\"id\": \"6433\"}, {\"id\": \"1780\"}, {\"id\": \"1131B\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. As of Apr 15, STOP NOT SERVED. Stop of bus 12: rue Franklinstraat 2a.\", \"fr\": \"Travaux. D\u00e8s le 15/4, ARRET NON DESSERVI. Arr\u00eat du bus 12: rue Franklin, 2a.\", \"nl\": \"Werken. Vanaf 15/4, HALTE NIET BEDIEND. Halte van bus 12: Franklinstraat 2a.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"12\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"1270B\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Dec 4, works. STOP NOT SERVED. Take bus 14 and 57 under the CCN building, at the terminus of bus 61.\", \"fr\": \"D\u00e8s le 4/12, travaux. ARRET NON DESSERVI. Prenez le bus 14 et 57 sous le b\u00e2timent CCN, au terminus du bus 61.\", \"nl\": \"Vanaf 4/12, werken. HALTE NIET BEDIEND. Neem bus 14 en 57 onder het CCN-gebouw, aan eindhalte bus 61.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"14\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"1082\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Sep 5 6AM, works. STOP NOT SERVED. Temporary stop: av. Charles Michiels across no. 205\", \"fr\": \"D\u00e8s le 5/9 6h, travaux. ARRET NON DESSERVI. Arr\u00eat provisoire : av. Charles Michiels face au num. 205\", \"nl\": \"Vanaf 5/9 6u, werken. HALTE NIET BEDIEND. Tijdelijke halte: Charles Michielslaan tegenover nr. 205\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"17\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"4294\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. May 17, 9PM-May 20, tram 19 interrupted. T-bus to SIMONIS at the stop of bus 88 to UZ-VUB.\", \"fr\": \"Travaux. 17/5, 21h-20/5, tram 19 interrompu. T-bus vers SIMONIS \u00e0 l'arr\u00eat du bus 88 vers UZ-VUB.\", \"nl\": \"Werken. 17/5, 21u-20/5, tram 19 onderbroken. T-bus naar SIMONIS aan de halte van bus 88 naar UZ-VUB.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"19\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"5093F\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. May 17, 9PM-May 20, STOP NOT SERVED. T-bus to SIMONIS at GUILLAUME DE GREEF (stop of bus 88 to UZ-VUB).\", \"fr\": \"Travaux. 17/5, 21h-20/5, ARRET NON DESSERVI. T-bus vers SIMONIS \u00e0 GUILL. DE GREEF (arr\u00eat du bus 88 vers UZ-VUB).\", \"nl\": \"Werken. 17/5, 21u-20/5, HALTE NIET BEDIEND. T-bus naar SIMONIS aan GUILL. DE GREEF (halte van bus 88 naar UZ-VUB).\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"19\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"5003\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. May 17, 9PM-May 20, tram 19 replaced by a T-bus to DE WAND.T-bus at PR. LEOPOLD (stop of bus 88 to UZ-VUB).\", \"fr\": \"Travaux. 17/5, 21h-20/5, tram 19 remplac\u00e9 par des T-bus jsq DE WAND. T-bus \u00e0 PRINCE LEOPOLD (arr\u00eat du bus 88 vers UZ-VUB).\", \"nl\": \"Werken. 17/5, 21u-20/5, tram 19 vervangen door T-bus tot DE WAND. T-bus aan PRINS LEOPOLD (halte van bus 88 naar UZ-VUB)\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"19\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"5082\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Wroks. Until mid-2024, stop not served. T-bus at LEOPOLD I (bd de Smet de Naeyer 54, stop of bus 14 to UZ-VUB).\", \"fr\": \"Travaux. Jusque mi-2024, arr\u00eat non desservi. T-bus \u00e0 LEOPOLD I (bd de Smet de Naeyer 54, arr\u00eat du bus 14 vers UZ-VUB).\", \"nl\": \"Werken. Tot midden 2024, halte niet bediend. T-bus aan LEOPOLD I (de Smet de Naeyerlaan 54, halte B14 naar UZ-VUB).\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"19\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"6866F\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. May 17, 9PM-May 20, tram 19 replaced by a T-bus to DE WAND. T-bus at the stop of bus 88 to DE BROUCKERE.\", \"fr\": \"Travaux. 17/5, 21h-20/5, tram 19 remplac\u00e9 par des T-bus jusqu'\u00e0 DE WAND. T-bus \u00e0 l'arr\u00eat du bus 88 vers DE BROUCKERE.\", \"nl\": \"Werken. 17/5, 21u-20/5, tram 19 vervangen door T-bus tot DE WAND. T-bus aan de halte van bus 88 naar DE BROUCKERE.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"19\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"5092F\"}, {\"id\": \"5090F\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. As of Apr 15, bus 21 diverted. Take bus 21 at MAELBEEK / MAALBEEK (stop of bus 64 to PORTE DE NAMUR / NAAMSEPOORT).\", \"fr\": \"Travaux. D\u00e8s le 15/4, bus 21 d\u00e9vi\u00e9. Prenez le bus 21 \u00e0 MAELBEEK (arr\u00eat du bus 64 vers PORTE DE NAMUR).\", \"nl\": \"Werken. Vanaf 15/4, bus 21 omgeleid. Neem bus 21 aan MAALBEEK (halte van bus 64 naar NAAMSEPOORT) .\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"21\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"1476\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. As of April 7th, STOP NOT SERVED. To go to DE BROUCKERE, take metro lines 1 or 5.\", \"fr\": \"Travaux. D\u00e8s le 7/4, ARRET NON DESSERVI. Pour rejoindre DE BROUCKERE, prenez le m\u00e9tro 1 ou 5.\", \"nl\": \"Werken. Vanaf 7/4, HALTE NIET BEDIEND. Om naar DE BROUCKERE te gaan, neem metrolijn 1 of 5.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"29\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"6447\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Jan 8 to Jun 28, works. After CHURCHILL, tram 3 continues on line 7 direction HEYSEL / HEIZEL.\", \"fr\": \"Du 8/1 au 28/6, travaux. Apr\u00e8s CHURCHILL, tram 3 continue sur la ligne 7 direction HEYSEL.\", \"nl\": \"Van 8/1 tot en met 28/6, werken. Na CHURCHILL rijdt tram 3 verder op lijn 7 richting HEIZEL.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"3\"}]",
+        "priority": 6,
+        "points": "[{\"id\": \"6253\"}, {\"id\": \"6178\"}, {\"id\": \"2318G\"}, {\"id\": \"5221F\"}, {\"id\": \"0611\"}, {\"id\": \"0501\"}, {\"id\": \"0601\"}, {\"id\": \"0621\"}, {\"id\": \"0511\"}, {\"id\": \"0531\"}, {\"id\": \"2338F\"}, {\"id\": \"6422F\"}, {\"id\": \"0705\"}, {\"id\": \"0706\"}, {\"id\": \"0703\"}, {\"id\": \"5714\"}, {\"id\": \"2543F\"}, {\"id\": \"0704\"}, {\"id\": \"0702\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Jan 7, 9PM-Jun 28, works. Tram 3 replaced by T-bus. Stop T-bus: av. Croix du Feu, crossing av. Buissonnets\", \"fr\": \"7/1, 21h-28/6, travaux. Tram 3 remplac\u00e9 par des T-bus. Arr\u00eat du T-bus: av. Croix du Feu, carrefour av.Buissonnets\", \"nl\": \"7/1, 21u-28/6, werken. Tram 3 vervangen door T- bus. Halte T-bus: Vuurkruisenlaan, kruispunt Braambosjesln.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"3\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"5772\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Jan 7, 9PM-Jun 28,works. Stop not served. Stop T-bus to DOCKS BRUXSEL: av. Croix du Feu, crossing av. Pagodes.\", \"fr\": \"7/1, 21h-28/6, travaux. Arr\u00eat non desservi.Arr\u00eat du T-bus vers DOCKS BRUXSEL: av. Croix du Feu, carr. av. Pagodes.\", \"nl\": \"7/1, 21u-28/6, werken. Halte niet bediend.Halte van de T-bus naar DOCKS BRUXSEL: Vuurkruisenln, kruispt Pagodenln.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"3\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"5706\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Jan 7, 9PM-Jun 28, works. Tram 3 replaced by T-bus. Stop T-bus: av. Croix du Feu, after rue De Wandstraat.\", \"fr\": \"7/1, 21h-28/6, travaux. Tram 3 remplac\u00e9 par des T-bus. Arr\u00eat du T-bus: avenue des Croix du Feu, apr\u00e8s la rue De Wand.\", \"nl\": \"7/1, 21u-28/6, werken. Tram 3 vervangen door T-bus. Halte T-bus: Vuurkruisenlaan, na de De Wandstraat.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"3\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"5806\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Jan 15, works. STOP NOT SERVED. Stop of bus 34: chauss\u00e9e de Wavre / Waversesteenweg 1303.\", \"fr\": \"D\u00e8s le 15/1, travaux. ARRET NON DESSERVI. Arr\u00eat du bus 34: chauss\u00e9e de Wavre 1303.\", \"nl\": \"Vanaf 15/1, werken. HALTE NIET BEDIEND. Halte van bus 34: Waversesteenweg 1303.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"34\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"1718B\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Mar 5 at 9AM, works. STOP NOT SERVED. Temporary stop: avenue Jean & Pierre Carsoellaan 4.\", \"fr\": \"D\u00e8s le 5/3 \u00e0 9h, travaux. ARRET NON DESSERVI. Arr\u00eat provisoire: avenue Jean et Pierre Carsoel 4.\", \"nl\": \"Vanaf 5/3 om 9u, werken. HALTE NIET BEDIEND. Tijdelijke halte: Jean en Pierre Carsoellaan 4.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"37\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"6931B\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Apr 3 at 6AM, works. Bus 38 diverted between LONGCHAMP and HOUZEAU via rue Edith Cavellstraat.\", \"fr\": \"D\u00e8s le 3/4 \u00e0 6h, travaux. Bus 38 d\u00e9vi\u00e9 entre LONGCHAMP et HOUZEAU via rue Edith Cavell.\", \"nl\": \"Vanaf 3/4 om 6u, werken. Bus 38 omgeleid tussen LONGCHAMP en HOUZEAU via Edith Cavellstraat.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"38\"}]",
+        "priority": 5,
+        "points": "[{\"id\": \"1914\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Apr 3 at 6AM, works. Bus 38 diverted between HOUZEAU and LONGCHAMP via rue Edith Cavellstraat.\", \"fr\": \"D\u00e8s le 3/4 \u00e0 6h, travaux. Bus 38 d\u00e9vi\u00e9 entre HOUZEAU et LONGCHAMP via rue Edith Cavell.\", \"nl\": \"Vanaf 3/4 om 6u, werken. Bus 38 omgeleid tussen HOUZEAU en LONGCHAMP via Edith Cavellstraat.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"38\"}]",
+        "priority": 5,
+        "points": "[{\"id\": \"1943\"}, {\"id\": \"4076\"}, {\"id\": \"1969\"}, {\"id\": \"1968\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. As of April 7th, stop of bus 38 moved to the Cantersteen, at the stop of bus 52 to FOREST / VORST (BERVOETS)\", \"fr\": \"Travaux. D\u00e8s le 7/4, arr\u00eat du bus 38 d\u00e9plac\u00e9 Cantersteen, \u00e0 l'arr\u00eat du bus 52 vers FOREST (BERVOETS).\", \"nl\": \"Werken. Vanaf 7/4, halte van bus 38 verplaatst naar de Kantersteen, aan de halte van bus 52 naar VORST (BERVOETS).\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"38\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"6443\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Apr 3 at 6AM, works. STOP NOT SERVED. Temporary stop: avenue Winston Churchilllaan 202.\", \"fr\": \"D\u00e8s le 3/4 \u00e0 6h, travaux. ARRET NON DESSERVI. Arr\u00eat provisoire: avenue Winston Churchill 202.\", \"nl\": \"Vanaf 3/4 om 6u, werken. HALTE NIET BEDIEND. Tijdelijke halte: Winston Churchilllaan 202.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"38\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"1973\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Apr 3 at 6AM, works. STOP NOT SERVED. Take bus 38 and 41 at the next stop, HOUZEAU.\", \"fr\": \"D\u00e8s le 3/4 \u00e0 6h, travaux. ARRET NON DESSERVI. Prenez les bus 38 et 41 \u00e0 l'arr\u00eat suivant, HOUZEAU.\", \"nl\": \"Vanaf 3/4 om 6u, werken. HALTE NIET BEDIEND. Neem bus 38 en 41 aan de volgende halte, HOUZEAU.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"38\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"1920\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. As of Mar 27, STOP MOVED. Stop of bus 41: rue des C\u00e8dres / Cederlaan 5.\", \"fr\": \"Travaux. D\u00e8s le 27/3, ARRET DEPLACE. Arr\u00eat du bus 41: rue des C\u00e8dres, 5.\", \"nl\": \"Werken. Vanaf 27/3, HALTE VERPLAATST. Halte van bus 41: Cederlaan 5.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"41\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"4310\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Apr 3 at 6AM, works. Bus 41 diverted between HOUZEAU and VERT CHASSEUR / GROENE JAGER via rue Edith Cavell.\", \"fr\": \"D\u00e8s le 3/4 \u00e0 6h, travaux. Bus 41 d\u00e9vi\u00e9 entre HOUZEAU et VERT CHASSEUR via rue Edith Cavell.\", \"nl\": \"Vanaf 3/4 om 6u, werken. Bus 41 omgeleid tussen HOUZEAU en GROENE JAGER via Edith Cavellstraat.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"41\"}]",
+        "priority": 5,
+        "points": "[{\"id\": \"1943\"}, {\"id\": \"4076\"}, {\"id\": \"1969\"}, {\"id\": \"1968\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Mar 4, works. Bus 43 diverted between CABRIS / GEITJES and GRIOTTES / NOORDKRIEKEN.\", \"fr\": \"D\u00e8s le 4/3, travaux. Bus 43 d\u00e9vi\u00e9 entre CABRIS et GRIOTTES.\", \"nl\": \"Vanaf 4/3, werken. Bus 43 omgeleid tussen GEITJES en NOORDKRIEKEN.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"43\"}]",
+        "priority": 5,
+        "points": "[{\"id\": \"2144\"}, {\"id\": \"2142\"}, {\"id\": \"2140\"}, {\"id\": \"2161\"}, {\"id\": \"2109B\"}, {\"id\": \"1953\"}, {\"id\": \"2143B\"}, {\"id\": \"2168\"}, {\"id\": \"2157\"}, {\"id\": \"2146\"}, {\"id\": \"2147B\"}, {\"id\": \"2156\"}, {\"id\": \"2167\"}, {\"id\": \"2145\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Mar 4, works. Bus 43 and N11 diverted. Take the bus at HOMBORCH (via B43 at stop B43 VIVIER D'OIE or B37).\", \"fr\": \"D\u00e8s le 4/3, travaux. Bus 43 et N11 d\u00e9vi\u00e9s. Prenez le bus \u00e0 HOMBORCH (via B43 \u00e0 l'arr\u00eat du B43 VIVIER D'OIE ou B37).\", \"nl\": \"Vanaf 4/3, werken. Bus 43 en N11 omgeleid. Neem de bus aan HOMBORCH (via B43 aan halte B43 DIESDELLE of B37).\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"43\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"1954\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Mar 4, works. Bus 43 diverted. Take the bus at HOMBORCH (via B43 from this stop on weekdays before 8PM).\", \"fr\": \"D\u00e8s le 4/3, travaux. Bus 43 d\u00e9vi\u00e9. Prenez le bus \u00e0 HOMBORCH (via B43 depuis cet arr\u00eat en semaine avant 20h).\", \"nl\": \"Vanaf 4/3, werken. Bus 43 omgeleid. Neem de bus aan HOMBORCH (via B43 vanaf deze halte op weekdagen voor 20u).\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"43\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"1944\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Mar 4, works. Bus 43 and N11 diverted. Take the bus at HOMBORCH (via B43 from this stop on weekdays or B37).\", \"fr\": \"D\u00e8s le 4/3, travaux. Bus 43 et N11 d\u00e9vi\u00e9s. Prenez le bus \u00e0 HOMBORCH (via B43 depuis cet arr\u00eat en semaine ou B37).\", \"nl\": \"Vanaf 4/3, werken. Bus 43 en N11 omgeleid. Neem de bus aan HOMBORCH (via B43 vanaf deze halte op weekdagen of B37).\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"43\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"1955\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Mar 4, works. Bus 43 and N11 diverted. Take the bus at HOMBORCH (via B43 from this stop on weekdays or B37).\", \"fr\": \"D\u00e8s le 4/3, travaux. Bus 43 et N11 d\u00e9vi\u00e9s. Prenez le bus \u00e0 HOMBORCH (via B43 depuis cet arr\u00eat en semaine ou B37).\", \"nl\": \"Vanaf 4/3, werken. Bus 43 en N11 omgeleid. Neem de bus aan HOMBORCH (via B43 vanaf deze halte op weekdagen of B37).\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"43\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"1936\"}, {\"id\": \"1935\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Mar 4, works. Bus 43 diverted between GRIOTTES and HOMBORCH. B43 HOMBORCH extended to BRAVES.\", \"fr\": \"D\u00e8s le 4/3, travaux. Bus 43 d\u00e9vi\u00e9 entre GRIOTTES et HOMBORCH. B43 barr\u00e9 HOMBORCH prolong\u00e9 jusqu'\u00e0 BRAVES.\", \"nl\": \"Vanaf 4/3, werken. Bus 43 omgeleid tussen NOORDKRIEKEN en HOMBORCH. B43 HOMBORCH rijdt tot DAPPEREN.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"43\"}]",
+        "priority": 5,
+        "points": "[{\"id\": \"2165\"}, {\"id\": \"1250\"}, {\"id\": \"1921\"}, {\"id\": \"1932\"}, {\"id\": \"1931\"}, {\"id\": \"1942\"}, {\"id\": \"5817\"}, {\"id\": \"1984B\"}, {\"id\": \"2355\"}, {\"id\": \"4854C\"}, {\"id\": \"1929\"}, {\"id\": \"1926B\"}, {\"id\": \"1937\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. Until end of August, bus 46 not operated btw WTC-GLIBERT and CENTRAL STATION. Walk to WTC-GLIBERT\", \"fr\": \"Travaux. Jsq fin ao\u00fbt, bus 46 ne circule pas entre WTC-GLIBERT et GARE CENTRALE. Allez \u00e0 pied \u00e0 WTC-GLIBERT\", \"nl\": \"Werken. Tot einde augustus rijdt bus 46 niet tss WTC- GLIBERT en CENTRAAL STATION. Ga te voet naar WTC-GLIBERT.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"46\"}]",
+        "priority": 5,
+        "points": "[{\"id\": \"2269\"}, {\"id\": \"2587\"}, {\"id\": \"3075\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"As of Sep 13 at 6AM, works. Stop moved to rue de Laeken / Lakensestraat, next to numbers 57-59.\", \"fr\": \"D\u00e8s le 13/9 \u00e0 6h, travaux. Arr\u00eat d\u00e9plac\u00e9 rue de Laeken, \u00e0 hauteur des num\u00e9ros 57-59.\", \"nl\": \"Vanaf 13/9 om 6u, werken. Halte verplaatst naar de Lakensestraat, ter hoogte van huisnummer 57-59.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"46\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"3465\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Until end of August, works. Stop not served. Take bus 46 at the next stop, PORTE D'ANDERLECHT\", \"fr\": \"Jusque fin ao\u00fbt, travaux. Arr\u00eat non desservi. Prenez le bus 46 \u00e0 l'arr\u00eat suivant, PORTE D'ANDERLECHT.\", \"nl\": \"Tot einde augustus, werken. Halte niet bediend. Neem bus 46 aan de volgende halte, ANDERLECHTSEPOORT.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"46\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"2213\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Until end August 2024, works. B46 diverted to ANNEESSENS. Stops between BUANDERIE and WTC-GLIBERT not served.\", \"fr\": \"Jsq fin ao\u00fbt 2024, travaux. Bus 46 d\u00e9vi\u00e9 vers ANNEESSENS. Arr\u00eats entre BUANDERIE et WTC- GLIBERT non desservis.\", \"nl\": \"Tot einde augustus 2024, werken. Bus 46 omgeleid naar ANNEESSENS. Haltes tussen WASHUIS en WTC-GLIBERT niet bediend\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"46\"}]",
+        "priority": 5,
+        "points": "[{\"id\": \"2405\"}, {\"id\": \"2259\"}, {\"id\": \"2264\"}, {\"id\": \"2262\"}, {\"id\": \"2261\"}, {\"id\": \"2260\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Until Summer of 2024, works. Bus 47 diverted from RAMIER / BOSDUIF to DOCKS BRUXSEL via avenue des Croix de Guerre\", \"fr\": \"Jsq \u00e9t\u00e9 2024, travaux. Bus 47 d\u00e9vi\u00e9 depuis RAMIER vers DOCKS BRUXSEL via avenue des Croix de Guerre.\", \"nl\": \"Tot zomer 2024, werken. Bus 47 omgeleid vanaf BOSDUIF naar DOCKS BRUXSEL via Oorlogskruisenlaan.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"47\"}]",
+        "priority": 5,
+        "points": "[{\"id\": \"2361\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. STOP NOT SERVED. Bus 47-56 at the stop VERGER (avenue des Croix de Guerre)\", \"fr\": \"Travaux. ARRET NON DESSERVI. Bus 47-56 \u00e0 l'arr\u00eat VERGER (avenue des Croix de Guerre)\", \"nl\": \"Werken. HALTE NIET BEDIEND. Bus 47-56 aan de halte BOOMGAARD (Oorlogskruisenlaan)\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"47\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"1974\"}, {\"id\": \"1967\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Until Summer of 2024, works. Stop of bus 47 and 56: avenue des Croix de Guerre / Oorlogskruisenlaan 78.\", \"fr\": \"Jusqu'\u00e0 l'\u00e9t\u00e9 2024, travaux. Arr\u00eat des bus 47 et 56 : avenue des Croix de Guerre 78.\", \"nl\": \"Tot zomer 2024, werken. Halte van bus 47 en 56: Oorlogskruisenlaan 78.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"47\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"2299\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Feb 6, works. STOP NOT SERVED. Temporary stop: Vlierkensstraat 94.\", \"fr\": \"D\u00e8s le 6/2, travaux. ARRET NON DESSERVI. Arr\u00eat provisoire: Vlierkensstraat 94.\", \"nl\": \"Vanaf 6/2, werken. HALTE NIET BEDIEND. Tijdelijke halte: Vlierkensstraat 94.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"47\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"2841\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Until Summer of 2024, works. Stop not served. Take bus 47 at the stop of bus 56 to SCHUMAN.\", \"fr\": \"Jusqu'\u00e0 l'\u00e9t\u00e9 2024, travaux. Arr\u00eat non desservi. Prenez le bus 47 \u00e0 l'arr\u00eat du bus 56 vers SCHUMAN.\", \"nl\": \"Tot zomer 2024, werken. Halte niet bediend. Neem bus 47 aan de halte van bus 56 naar SCHUMAN.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"47\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"2317\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Until Summer of 2024, works. Stop not served. Take bus 47 at ANTOON VAN OSS (stop of bus 56 to BUDA).\", \"fr\": \"Jsq \u00e9t\u00e9 2024, travaux. Arr\u00eat non desservi. Prenez le bus 47 \u00e0 ANTOON VAN OSS (arr\u00eat du bus 56 vers BUDA).\", \"nl\": \"Tot zomer 2024, werken. Halte niet bediend. Neem bus 47 aan ANTOON VAN OSS (halte van bus 56 naar BUDA).\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"47\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"2359\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Until Summer of 2024, works. Stop not served. Take bus 47 at ANTOON VAN OSS (stop of bus 56 to SCHUMAN).\", \"fr\": \"Jsq \u00e9t\u00e9 2024, travaux. Arr\u00eat non desservi. Prenez le bus 47 \u00e0 ANTOON VAN OSS (arr\u00eat du bus 56 vers SCHUMAN).\", \"nl\": \"Tot zomer 2024, werken. Halte niet bediend. Neem bus 47 aan ANTOON VAN OSS (halte van bus 56 naar SCHUMAN).\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"47\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"2316\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Until Summer of 2024, works. Stop not served. Stop of bus 47: av. Marlylaan, next to Verano.\", \"fr\": \"Jusqu'\u00e0 l'\u00e9t\u00e9 2024, travaux. Arr\u00eat non desservi. Arr\u00eat du bus 47: avenue du Marly, pr\u00e8s de Verano.\", \"nl\": \"Tot zomer 2024, werken. Halte niet bediend. Halte van bus 47: Marlylaan, naast Verano.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"47\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"2315\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Until 2026, works. Stop not served. Stop of bus 50: rue de la Soierie / Zijdeweverijstraat 4.\", \"fr\": \"Jusqu'en 2026, travaux. Arr\u00eat non desservi. Arr\u00eat du bus 50: rue de la Soierie 4.\", \"nl\": \"Tot 2026, werken. Halte niet bediend. Halte van bus 50: Zijdeweverijstraat 4.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"50\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"3602\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Until 2026, works. Bus 50 diverted. Stop of bus 50: rue des Abbesses / Abdissenstraat, in front of number 1.\", \"fr\": \"Jusqu'en 2026, travaux. Bus 50 d\u00e9vi\u00e9. Arr\u00eat du bus 50: rue des Abbesses, en face du num\u00e9ro 1.\", \"nl\": \"Tot 2026, werken. Bus 50 omgeleid. Halte van bus 50: Abdissenstraat, tegenover nummer 1.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"50\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"5161\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Until 2026, works. Bus 50 diverted between BEMPT and FOREST CENTRE/VORST CENTRUM.\", \"fr\": \"Jusqu'en 2026, travaux. Bus 50 d\u00e9vi\u00e9 entre BEMPT et FOREST CENTRE.\", \"nl\": \"Tot 2026, werken. Bus 50 omgeleid tussen BEMPT en VORST CENTRUM.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"50\"}]",
+        "priority": 5,
+        "points": "[{\"id\": \"9685\"}, {\"id\": \"9683\"}, {\"id\": \"9678\"}, {\"id\": \"9679\"}, {\"id\": \"9677\"}, {\"id\": \"2661\"}, {\"id\": \"9658\"}, {\"id\": \"2662B\"}, {\"id\": \"9659\"}, {\"id\": \"9682\"}, {\"id\": \"2659\"}, {\"id\": \"9680\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From May 2 at 5AM, works. STOP NOT SERVED. Temporary stop: Karel Gilsonstraat, 2.\", \"fr\": \"D\u00e8s le 2/5 \u00e0 5h,travaux. ARRET NON DESSERVI. Arr\u00eat provisoire: Karel Gilsonstraat, 2.\", \"nl\": \"Vanaf 2/5 om 5u, werken. HALTE NIET BEDIEND. Tijdelijke halte: Karel Gilsonstraat, 2.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"50\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"9651\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. Until 2026, stop not served. Stop of T-bus 82 and of bus 50: rue de la Soierie / Zijdeweverijstraat 9.\", \"fr\": \"Travaux. Jusqu'en 2026, arr\u00eat non desservi. Arr\u00eat du T-bus 82 et du bus 50 : rue de la Soierie 9.\", \"nl\": \"Werken. Tot 2026, halte niet bediend. Halte van T-bus 82 en van bus 50: Zijdeweverijstraat 9.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"50\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"3603\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Until Summer of 2024, works. Bus 53 diverted. Stop of bus 53: rue Bruynstraat, after the military area.\", \"fr\": \"Jsq \u00e9t\u00e9 2024, travaux. Bus 53 d\u00e9vi\u00e9. Arr\u00eat du bus 53 : rue Bruyn, apr\u00e8s le domaine militaire.\", \"nl\": \"Tot zomer 2024, werken. Bus 53 omgeleid. Halte van bus 53: Bruynstraat, na het militair domein.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"53\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"2352\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. As of Apr 15 at 6AM, bus 53 diverted between PETER BENOIT and BEYSEGHEM / BEIZEGEM.\", \"fr\": \"Travaux. D\u00e8s le 15/4 \u00e0 6h, bus 53 d\u00e9vi\u00e9 entre PETER BENOIT et BEYSEGHEM.\", \"nl\": \"Werken. Vanaf 15/4 om 6u, bus 53 omgeleid tussen PETER BENOIT en BEIZEGEM.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"53\"}]",
+        "priority": 5,
+        "points": "[{\"id\": \"3001B\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. As of Apr 15 at 6AM, bus 53 diverted between PETER BENOIT and BEYSEGHEM / BEIZEGEM.\", \"fr\": \"Travaux. D\u00e8s le 15/4 \u00e0 6h, bus 53 d\u00e9vi\u00e9 entre PETER BENOIT et BEYSEGHEM.\", \"nl\": \"Werken. Vanaf 15/4 om 6u, bus 53 omgeleid tussen PETER BENOIT en BEIZEGEM.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"53\"}]",
+        "priority": 5,
+        "points": "[{\"id\": \"2823B\"}, {\"id\": \"2766\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"On May 19 until 8PM, flea market. Bus 54 diverted between MA CAMPAGNE and BAILLI / BALJUW.\", \"fr\": \"Le 19/5 jusqu'\u00e0 20h, brocante. Bus 54 d\u00e9vi\u00e9 entre MA CAMPAGNE et BAILLI.\", \"nl\": \"Op 19/5 tot 20u, rommelmarkt. Bus 54 omgeleid tussen MA CAMPAGNE en BALJUW.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"54\"}]",
+        "priority": 5,
+        "points": "[{\"id\": \"2955\"}, {\"id\": \"2965\"}, {\"id\": \"2953\"}, {\"id\": \"2957A\"}, {\"id\": \"2951\"}, {\"id\": \"2456\"}, {\"id\": \"2954B\"}, {\"id\": \"2959\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"On May 19 until 8PM, flea market. Bus 54 diverted between MA CAMPAGNE and BAILLI / BALJUW.\", \"fr\": \"Le 19/5 jusqu'\u00e0 20h, brocante. Bus 54 d\u00e9vi\u00e9 entre MA CAMPAGNE et BAILLI.\", \"nl\": \"Op 19/5 tot 20u, rommelmarkt. Bus 54 omgeleid tussen MA CAMPAGNE en BALJUW.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"54\"}]",
+        "priority": 5,
+        "points": "[{\"id\": \"5915\"}, {\"id\": \"1015\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"On May 5 until 8PM, flea market. STOP NOT SERVED. Take bus 54 at JANSON: chauss\u00e9e de Charleroisesteenweg 180.\", \"fr\": \"Le 19/5 jusqu'\u00e0 20h, brocante. ARRET NON DESSERVI. Prenez le bus 54 \u00e0 JANSON: chauss\u00e9e de Charleroi 180.\", \"nl\": \"Op 19/5 tot 20u, rommelmarkt. HALTE NIET BEDIEND. Neem bus 54 aan JANSON: Charleroisesteenweg 180.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"54\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"2960\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Apr 2, 2024 to June 2025, works. STOP NOT SERVED. Stop of bus 54: FOREST NATIONAL (av. du Globelaan 8).\", \"fr\": \"Du 2/4/2024 \u00e0 juin 2025, travaux. ARRET NON DESSERVI. Arr\u00eat des bus 54: FOREST NATIONAL. (avenue du Globe 8).\", \"nl\": \"Van 2/4/2024 tot juni 2025, werken. HALTE NIET BEDIEND. Halte van bus 54: VORST NATIONAAL (Globelaan 8)\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"54\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"2939B\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Until Summer of 2024, works. Stop of bus 47 and 56: av. Croix de Guerre, at the other side of Delhaize.\", \"fr\": \"Jusqu'\u00e0 l'\u00e9t\u00e9 2024, travaux. Arr\u00eat des bus 47 et 56 : avenue des Croix de Guerre, de l'autre c\u00f4t\u00e9 du Delhaize\", \"nl\": \"Tot zomer 2024, werken. Halte van bus 47 en 56: Oorlogskruisenlaan, aan de andere kant van de Delhaize.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"56\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"1974\"}, {\"id\": \"1967\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Until Summer of 2024, works. Stop not served. Stop of bus 56: place Peter Benoitplein 3\", \"fr\": \"Jusqu'\u00e0 l'\u00e9t\u00e9 2024, travaux. Arr\u00eat non desservi. Arr\u00eat du bus 56 : place Peter Benoit 3\", \"nl\": \"Tot zomer 2024, werken. Halte niet bediend. Halte van bus 56: Peter Benoitplein 3\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"56\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"1987\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. As of Apr 15, bus 56 diverted. Take bus 56 at the stop of bus 64 to BORDET STATION.\", \"fr\": \"Travaux. D\u00e8s le 15/4, bus 56 d\u00e9vi\u00e9. Prenez le bus 56 \u00e0 l'arr\u00eat du bus 64 vers BORDET STATION.\", \"nl\": \"Werken. Vanaf 15/4, bus 56 omgeleid. Neem bus 56 aan de halte van bus 64 naar BORDET STATION.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"56\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"2068\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Until Summer of 2024, works. Bus 56 diverted between VAN PRAET and PETER BENOIT via avenue des Croix de Guerre.\", \"fr\": \"Jusqu'\u00e0 l'\u00e9t\u00e9 2024, travaux. Bus 56 d\u00e9vi\u00e9 entre VAN PRAET et PETER BENOIT via avenue des Croix de Guerre.\", \"nl\": \"Tot zomer 2024, werken. Bus 56 omgeleid tussen VAN PRAET en PETER BENOIT via Oorlogskruisenlaan.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"56\"}]",
+        "priority": 5,
+        "points": "[{\"id\": \"2098\"}, {\"id\": \"3451\"}, {\"id\": \"6190\"}, {\"id\": \"9296\"}, {\"id\": \"2051\"}, {\"id\": \"6082\"}, {\"id\": \"2898\"}, {\"id\": \"2106\"}, {\"id\": \"1006\"}, {\"id\": \"2367\"}, {\"id\": \"3412\"}, {\"id\": \"2101\"}, {\"id\": \"6459\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Until Summer of 2024, works. As of March 18, buses 56 and 57 serve this stop normally.\", \"fr\": \"Jusqu'\u00e0 l'\u00e9t\u00e9 2024, travaux. D\u00e8s le 18/3, les bus 56 et 57 desservent \u00e0 nouveau cet arr\u00eat.\", \"nl\": \"Tot zomer 2024, werken. Vanaf 18/3 bedienen bus 56 en 57 opnieuw deze halte.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"56\"}]",
+        "priority": 5,
+        "points": "[{\"id\": \"2829B\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Until Summer of 2024, works. Stop not served. Take bus 47 or 57 at ANTOON VAN OSS (stop of bus 56 to BUDA).\", \"fr\": \"Jsq \u00e9t\u00e9 2024, travaux. Arr\u00eat non desservi. Prenez le bus 47 ou 57 \u00e0 ANTOON VAN OSS (arr\u00eat du bus 56 vers BUDA).\", \"nl\": \"Tot zomer 2024, werken. Halte niet bediend. Neem bus 47 of 57 aan ANTOON VAN OSS (halte van bus 56 naar BUDA).\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"57\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"1837\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Until Summer of 2024, works. Stop not served. Take bus 57 at ANTOON VAN OSS (stop of bus 56 to BUDA).\", \"fr\": \"Jsq \u00e9t\u00e9 2024, travaux. Arr\u00eat non desservi. Prenez le bus 57 \u00e0 ANTOON VAN OSS (arr\u00eat du bus 56 vers BUDA).\", \"nl\": \"Tot zomer 2024, werken. Halte niet bediend. Neem bus 57 aan ANTOON VAN OSS (halte van bus 56 naar BUDA).\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"57\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"2359\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Until Summer 2024,works. B57 divtd btw MARLY and ANT VAN OSS. As of Oct 16, B57 divtd btw MARLY and HOP. MILITAIRE\", \"fr\": \"Jsq \u00e9t\u00e9 2024, travaux. Bus 57 d\u00e9vi\u00e9 entre MARLY et ANT VAN OSS. D\u00e8s le 16/10, B57 d\u00e9vi\u00e9 entre MARLY et HOP MILITAIRE.\", \"nl\": \"Tot zomer 2024, werken. Bus 57 omgeleid ts MARLY en ANT VAN OSS. Vanaf 16/10, B57 omgeleid tss MARLY en MILITAIR HOSP.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"57\"}]",
+        "priority": 5,
+        "points": "[{\"id\": \"1090\"}, {\"id\": \"2327\"}, {\"id\": \"2305\"}, {\"id\": \"2326\"}, {\"id\": \"1356\"}, {\"id\": \"3058\"}, {\"id\": \"1052\"}, {\"id\": \"1051\"}, {\"id\": \"2308\"}, {\"id\": \"2868\"}, {\"id\": \"3061\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Until Summer of 2024, works. Stop not served. Take bus 57 at ANTOON VAN OSS (stop of bus 56 to SCHUMAN).\", \"fr\": \"Jsq \u00e9t\u00e9 2024, travaux. Arr\u00eat non desservi. Prenez le bus 57 \u00e0 ANTOON VAN OSS (arr\u00eat du bus 56 vers SCHUMAN).\", \"nl\": \"Tot zomer 2024, werken. Halte niet bediend. Neem bus 57 aan ANTOON VAN OSS (halte van bus 56 naar SCHUMAN).\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"57\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"2316\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Until Summer of 2024, works. Stop not served. Stop of bus 57: chauss\u00e9e de Vilvorde, next to ropery Barrois\", \"fr\": \"Jsq \u00e9t\u00e9 2024, travaux. Arr\u00eat non desservi. Arr\u00eat du bus 57: ch\u00e9e de Vilvorde, le long de la corderie Barrois\", \"nl\": \"Tot zomer 2024, werken. Halte niet bediend. Halte B57: Vilvoordsestwg, naast de touwslagerij Barrois\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"57\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"3003\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Until Summer of 2024, works. Stop not served. Stop of bus 57: MARLY (moved to ch. Vilvorde, next to number 150)\", \"fr\": \"Jsq \u00e9t\u00e9 2024, travaux. Arr\u00eat non desservi.Arr\u00eat du bus 57: MARLY (d\u00e9plac\u00e9 ch. Vilvorde, en face du num\u00e9ro 150)\", \"nl\": \"Tot zomer 2024, werken. Halte niet bediend. Halte van bus 57:MARLY (verplaatst Vilvoordsest tegenover nr. 150)\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"57\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"2315\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Feb 8, works. STOP NOT SERVED. Temporary stop: Place de Houffalizeplein 2-6.\", \"fr\": \"D\u00e8s le 8/2, travaux. ARRET NON DESSERVI. Arr\u00eat provisoire: Place de Houffalize 2-6.\", \"nl\": \"Vanaf 8/2, werken. HALTE NIET BEDIEND. Tijdelijke halte: Houffalizeplein 2-6.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"59\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"3110\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. As of Apr 15, bus 60 diverted between JOURDAN and AMBIORIX via MAELBEEK. Connection metro at MAELBEEK.\", \"fr\": \"Travaux. D\u00e8s le 15/4, bus 60 d\u00e9vi\u00e9 entre JOURDAN et AMBIORIX via MAELBEEK. Correspondance m\u00e9tro \u00e0 MAELBEEK.\", \"nl\": \"Werken. Vanaf 15/4, bus 60 omgeleid tussen JOURDAN en AMBIORIX via MAALBEEK. Aansluiting metro aan MAALBEEK.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"60\"}]",
+        "priority": 6,
+        "points": "[{\"id\": \"1980\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. As of Apr 15, bus 60 diverted between JOURDAN and AMBIORIX via MAELBEEK. Connection metro at MAELBEEK.\", \"fr\": \"Travaux. D\u00e8s le 15/4, bus 60 d\u00e9vi\u00e9 entre JOURDAN et AMBIORIX via MAELBEEK. Correspondance m\u00e9tro \u00e0 MAELBEEK.\", \"nl\": \"Werken. Vanaf 15/4, bus 60 omgeleid tussen JOURDAN en AMBIORIX via MAALBEEK. Aansluiting metro aan MAALBEEK.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"60\"}]",
+        "priority": 6,
+        "points": "[{\"id\": \"3158B\"}, {\"id\": \"3160\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Mar 11, works. Bus 60 diverted. Temporary stop: chauss\u00e9e de Saint- Job/Sint-Jobsesteenweg, in front of nr. 390.\", \"fr\": \"D\u00e8s le 11/3, travaux. Bus 60 d\u00e9vi\u00e9. Arr\u00eat provisoire: chauss\u00e9e de Saint-Job, face au num\u00e9ro 390.\", \"nl\": \"Vanaf 11/3, werken. Bus 60 omgeleid. Tijdelijke halte: Sint-Jobsesteenweg, tegenover nr. 390.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"60\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"1738\"}, {\"id\": \"2705\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. As of Apr 15, bus 60 diverted between JOURDAN and AMBIORIX via MAELBEEK. Connection metro at MAELBEEK.\", \"fr\": \"Travaux. D\u00e8s le 15/4, bus 60 d\u00e9vi\u00e9 entre JOURDAN et AMBIORIX via MAELBEEK. Correspondance m\u00e9tro \u00e0 MAELBEEK.\", \"nl\": \"Werken. Vanaf 15/4, bus 60 omgeleid tussen JOURDAN en AMBIORIX via MAALBEEK. Aansluiting metro aan MAALBEEK.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"60\"}]",
+        "priority": 6,
+        "points": "[{\"id\": \"6112\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. As of Apr 15, STOP NOT SERVED. Walk to AMBIORIX.\", \"fr\": \"Travaux. D\u00e8s le 15/4, ARRET NON DESSERVI. Pour rejoindre AMBIORIX, continuez \u00e0 pied.\", \"nl\": \"Werken. Vanaf 15/4, HALTE NIET BEDIEND. Ga te voet verder om naar AMBIORIX te gaan.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"60\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"1418B\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Mar 11, works. Bus 60 diverted. Temporary stop: chauss\u00e9e de Saint- Job/Sint-Jobsesteenweg 265.\", \"fr\": \"D\u00e8s le 11/3, travaux. Bus 60 d\u00e9vi\u00e9. Arr\u00eat provisoire: chauss\u00e9e de Saint-Job 265.\", \"nl\": \"Vanaf 11/3, werken. Bus 60 omgeleid. Tijdelijke halte: Sint-Jobsesteenweg 265.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"60\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"2704\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. As of April 7th, stop served only by bus 66. Take bus 29, 63 or 65 at the stop of bus 71 to DELTA.\", \"fr\": \"Travaux. D\u00e8s le 7/4, arr\u00eat uniquement desservi par bus 66. Bus 29, 63 ou 65 \u00e0 l'arr\u00eat du bus 71 vers DELTA.\", \"nl\": \"Werken. Vanaf 7/4, halte enkel bediend door bus 66. Neem bus 29, 63 of 65 aan de halte van bus 71 naar DELTA.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"63\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"6445\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Risk of subsidence. Stop of bus 65, 66 and N04 moved to chauss\u00e9e de Haecht/Haachtsesteenweg, next to number 162\", \"fr\": \"Risque d'effondrement. Arr\u00eat des bus 65, 66 et N04 d\u00e9plac\u00e9 chauss\u00e9e de Haecht, \u00e0 hauteur du num\u00e9ro 162.\", \"nl\": \"Risico op instorting. Halte van bus 65, 66 en N04 verplaatst naar de Haachtsesteenweg, ter hoogte van nummer 162.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"65\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"6418\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Jan 7, 9PM-Jun 28, works. Stop not served. To continue to HEYSEL / HEIZEL, take tram 3 direction CHURCHILL.\", \"fr\": \"7/1, 21h-28/6, travaux. Arr\u00eat non desservi. Pour continuer vers HEYSEL, prenez le tram 3 direction CHURCHILL.\", \"nl\": \"7/1, 21u-28/6, werken. Halte niet bediend. Om naar HEIZEL te reizen, neem tram 3 richting CHURCHILL.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"7\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"6421F\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Jan 7, 9PM-Jun 28,works. Tram 3 and 7 replaced by T-bus to DOCKS BRUXSEL. T-bus at this stop.\", \"fr\": \"7/1, 21h-28/6, travaux. Tram 3 et 7 remplac\u00e9s par des T-bus jusqu'\u00e0 DOCKS BRUXSEL. T-bus \u00e0 cet arr\u00eat.\", \"nl\": \"7/1, 21u-28/6, werken. Tram 3 en 7 vervangen door T-bus tot DOCKS BRUXSEL. T-bus aan deze halte.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"7\"}]",
+        "priority": 5,
+        "points": "[{\"id\": \"5707\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Jan 8-Jun 28, works. Tram 7 interrupted btw HEEMBEEK and DOCKS BXL. T-bus to DOCKS BXL at stop of B83 to VAL MARIA\", \"fr\": \"8/1-28/6, travaux. T7 interrompu de HEEMBEEK \u00e0 DOCKS BXL. T-bus vers DOCKS BXL \u00e0 l'arr\u00eat du B83 vers VAL MARIA.\", \"nl\": \"8/1-28/6, werken. T7 onderbroken tss HEEMBEEK en DOCKS BRUXSEL. T-bus naar DOCKS BRUXSEL aan halte B83 naar MARI\u00cbND.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"7\"}]",
+        "priority": 5,
+        "points": "[{\"id\": \"5700G\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. As of April 7th, STOP NOT SERVED. To go to DE BROUCKERE, take metro lines 1 or 5.\", \"fr\": \"Travaux. D\u00e8s le 7/4, ARRET NON DESSERVI. Pour rejoindre DE BROUCKERE, prenez le m\u00e9tro 1 ou 5.\", \"nl\": \"Werken. Vanaf 7/4, HALTE NIET BEDIEND. Om naar DE BROUCKERE te gaan, neem metrolijn 1 of 5.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"71\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"6447\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Mar 18, works. STOP NOT SERVED. Temporary stop: avenue de la Couronne / Kroonlaan 439-443.\", \"fr\": \"D\u00e8s le 18/3, travaux. ARRET NON DESSERVI. Arr\u00eat provisoire: avenue de la Couronne 439-443.\", \"nl\": \"Vanaf 18/3, werken. HALTE NIET BEDIEND. Tijdelijke halte: Kroonlaan 439-443.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"71\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"3558\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Mar 18, works. STOP NOT SERVED. stop of bus 72: avenue de l'Universit\u00e9 / Hogeschoollaan 4-10.\", \"fr\": \"D\u00e8s le 18/3, travaux. ARRET NON DESSERVI. Arr\u00eat du bus 72: avenue de l'Universit\u00e9 4-10.\", \"nl\": \"Vanaf 18/3, werken. HALTE NIET BEDIEND. Halte van bus 72: Hogeschoollaan 4-10.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"72\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"3514\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Subsidence. Bus 74 limited to DECROLY. Take bus 74 at DECROLY.\", \"fr\": \"Effondrement. Bus 74 limit\u00e9 \u00e0 DECROLY. Prenez le bus 74 \u00e0 DECROLY.\", \"nl\": \"Wegverzakking. Bus 74 beperkt tot DECROLY. Neem bus 74 aan DECROLY.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"74\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"2452\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Apr 2, 2024 to June 2025, works. STOP NOT SERVED. Stop of bus 74: chauss\u00e9e de Bruxelles / Brusselsesteenweg 84.\", \"fr\": \"Du 2/4/2024 \u00e0 juin 2025, travaux. ARRET NON DESSERVI. Arr\u00eat du bus 74: chauss\u00e9e de Bruxelles 84.\", \"nl\": \"Van 2/4/2024 tot juni 2025, werken. HALTE NIET BEDIEND. Halte van bus 74: Brusselsesteenweg 84.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"74\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"5152\"}, {\"id\": \"5161\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Subsidence. Bus 74 limited to DECROLY. Walk to UCCLE-STALLE / UKKEL-STALLE.\", \"fr\": \"Effondrement. Bus 74 limit\u00e9 \u00e0 DECROLY. Continuez \u00e0 pied jusqu'\u00e0 UCCLE STALLE.\", \"nl\": \"Wegverzakking. Bus 74 beperkt tot DECROLY. Ga te voet tot UKKEL-STALLE.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"74\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"2416\"}, {\"id\": \"2415\"}, {\"id\": \"2414\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Apr 20, works. Stop not served. Take B74 next to number 26 (100m before this stop).\", \"fr\": \"D\u00e8s le 20/4, travaux. Arr\u00eat non desservi. Arr\u00eat du B74 \u00e0  hauteur du num\u00e9ro 26 (100 m avant cet arr\u00eat).\", \"nl\": \"Vanaf 20/4, werken. Halte niet bediend. Neem B74 ter hoogte van nummer 26 (100m voor deze halte).\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"74\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"2225\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. Until 2026, stop not served. Stop of T-bus 82 and of bus 50: rue de la Soierie / Zijdeweverijstraat 9.\", \"fr\": \"Travaux. Jusqu'en 2026, arr\u00eat non desservi. Arr\u00eat du T-bus 82 et du bus 50 : rue de la Soierie 9.\", \"nl\": \"Werken. Tot 2026, halte niet bediend. Halte van T-bus 82 en van bus 50: Zijdeweverijstraat 9.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"82\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"5156F\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Until 2026, works. Tram 82 replaced by T-bus to FOREST CENTRE. T-bus at this stop.\", \"fr\": \"Jusqu'en 2026, travaux. Tram 82 remplac\u00e9 par des T-bus jusqu'\u00e0 FOREST CENTRE. T-bus \u00e0 cet arr\u00eat.\", \"nl\": \"Tot 2026, werken. Tram 82 vervangen door T-bus tot VORST CENTRUM. T-bus aan deze halte.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"82\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"5756F\"}, {\"id\": \"1258G\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Until 2026, works. Tram 82 interrupted. Take tram 82 at the stop in the other direction.\", \"fr\": \"Jusqu'en 2026, travaux. Tram 82 interrompu. Prenez le tram 82 \u00e0 l'arr\u00eat dans l'autre sens.\", \"nl\": \"Tot 2026, werken. Tram 82 onderbroken. Neem tram 82 aan de halte in de andere richting.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"82\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"5161F\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Until 2026, works. Tram 82 interrupted. T-bus to DROGENBOS at the stop of bus 54 to TRONE/TROON.\", \"fr\": \"Jusqu'en 2026, travaux. Tram 82 interrompu. T-bus vers DROGENBOS \u00e0 l'arr\u00eat du bus 54 vers TRONE.\", \"nl\": \"Tot 2026, werken. Tram 82 onderbroken. T-bus naar DROGENBOS aan de halte van bus 54 naar TROON.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"82\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"5121F\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Until 2026, works. Stop not served. Stop of the T-bus: rue de la Soierie / Zijdeweverijstraat 4.\", \"fr\": \"Jusqu'en 2026, travaux. Arr\u00eat non desservi. Arr\u00eat du T-bus: rue de la Soierie 4.\", \"nl\": \"Tot 2026, werken. Halte niet bediend. Halte van de T-bus: Zijdeweverijstraat 4.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"82\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"5154F\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. Until 2026, tram 82 replaced by T-bus between DROGENBOS and FOREST CENTRE / VORST CENTRUM.\", \"fr\": \"Travaux. Jusqu'en 2026, tram 82 remplac\u00e9 par des T-bus entre DROGENBOS et FOREST CENTRE. T-bus \u00e0 cet arr\u00eat.\", \"nl\": \"Werken. Tot 2026, tram 82 vervangen door T-bus tussen DROGENBOS en VORST CENTRUM. T-bus aan deze halte.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"82\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"5753F\"}, {\"id\": \"5751\"}, {\"id\": \"5754\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Until 2026, works. Tram 82 replaced by T-bus between FOREST CENTRE / VORST CENTRUM and DROGENBOS.\", \"fr\": \"Jusqu'en 2026, travaux. Tram 82 remplac\u00e9 par des T-bus entre FOREST CENTRE et DROGENBOS. Info: stib.brussels.\", \"nl\": \"Tot 2026, werken. Tram 82 vervangen door T-bus tussen VORST CENTRUM en DROGENBOS. Info: mivb. brussels.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"82\"}]",
+        "priority": 5,
+        "points": "[{\"id\": \"2603\"}, {\"id\": \"5718\"}, {\"id\": \"0631\"}, {\"id\": \"5120\"}, {\"id\": \"2539F\"}, {\"id\": \"5123\"}, {\"id\": \"2548F\"}, {\"id\": \"2604F\"}, {\"id\": \"2544F\"}, {\"id\": \"5119\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. Until 2026, tram 82 replaced by T-bus btw FOREST CENTRE / VORST CENTRUM and DROGENBOS. T-bus at this stop.\", \"fr\": \"Travaux. Jusqu'en 2026, tram 82 remplac\u00e9 par des T-bus entre FOREST CENTRE et DROGENBOS. T-bus \u00e0 cet arr\u00eat.\", \"nl\": \"Werken. Tot 2026, tram 82 vervangen door T-bus tussen VORST CENTRUM en DROGENBOS. T-bus aan deze halte.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"82\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"5722F\"}, {\"id\": \"5723G\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Jan 22 at 6AM to end of June, works. Bus 86 diverted. Take the bus at the previous stop GARE DE L'OUEST.\", \"fr\": \"Du 22/1 \u00e0 6h jusqu'\u00e0 fin juin, travaux. Bus 86 d\u00e9vi\u00e9. Prenez le bus \u00e0 l'arr\u00eat pr\u00e9c\u00e9dent GARE DE  L'OUEST.\", \"nl\": \"Van 22/1 om 6u tot eind juni, werken. Bus 86 omgeleid. Neem de bus aan vorige halte WESTSTATION.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"86\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"3257\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Jan 22 at 6AM to end of June, works. Bus 86 diverted. B86 at the stop RIBAUCOURT of bus 20 to GARE DU NORD.\", \"fr\": \"Du 22/1 \u00e0 6h jusqu'\u00e0 fin juin, travaux. Bus 86 d\u00e9vi\u00e9. Bus 86 \u00e0 l'arr\u00eat RIBAUCOURT du bus 20 vers GARE DU NORD.\", \"nl\": \"Van 22/1 om 6u tot eind juni, werken. Bus 86 omgeleid. Bus 86 aan de halte RIBAUCOURT van bus 20 naar NOORDSTATION.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"86\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"4253\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. From Apr 23 until Jun 2, bus 13 and 88 diverted. Take bus 13 or 88 at the stop of bus 820 to UZ Brussel.\", \"fr\": \"Travaux; Du 23/4 au 2/6, bus 13 et 88 d\u00e9vi\u00e9s. Prenez le bus 13 ou 88 \u00e0 l'arr\u00eat du bus 820 vers UZ Brussel.\", \"nl\": \"Werken. Van 23/4 tot en met 2/6, bus 13 en 88 omgeleid. Neem bus 13 of 88 aan de halte van bus 820 naar UZ Brussel.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"88\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"1721\"}, {\"id\": \"1328\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Feb 2 7AM, works. STOP NOT SERVED. Temporary halte: Boulevard Emile Jacqmainlaan 82-94.\", \"fr\": \"D\u00e8s le 8/2 7h, travaux. ARRET NON DESSERVI. Arr\u00eat provisoire: Boulevard Emile Jacqmain 82-94.\", \"nl\": \"Vanaf 8/2 7u, werken. HALTE NIET BEDIEND. Tijdelijke halte: Emile Jacqmainlaan 82-94.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"88\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"2070\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Until end of August, works. Bus 89 diverted. To continue to CENTRAL STATION, take bus 29 71\", \"fr\": \"Jusque fin ao\u00fbt, travaux. Bus 89 d\u00e9vi\u00e9. Pour continuer vers GARE CENTRALE, prenez le bus 29 ou 71.\", \"nl\": \"Tot einde augustus, werken. Bus 89 omgeleid. Om verder naar CENTRAAL STATION te reizen, neem bus 29 of 71.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"89\"}]",
+        "priority": 5,
+        "points": "[{\"id\": \"1820\"}, {\"id\": \"2296\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. As of Apr 22 at 9.30AM, bus 89 diverted. Stop of bus 89: rue des Quatre-Vents / Vier Windenstraat 141\", \"fr\": \"Travaux. D\u00e8s le 22/4 \u00e0 9h30, bus 89 d\u00e9vi\u00e9. Arr\u00eat du bus 89: rue des Quatre-Vents, 141.\", \"nl\": \"Werken. Vanaf 22/4 om 9. 30u, bus 89 omgeleid. Halte van bus 89: Vier Windenstraat 141\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"89\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"4594\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Until end of August, works. Bus 89 diverted. For the city center, take metro 1 or 5 at COMTE DE FLANDRE.\", \"fr\": \"Jusque fin ao\u00fbt, travaux. Bus 89 d\u00e9vi\u00e9. Pour le centre-ville, prenez le m\u00e9tro 1 ou 5 \u00e0 COMTE DE FLANDRE.\", \"nl\": \"Tot einde augustus, werken. Bus 89 omgeleid. Om naar het stadscentrum te gaan, neem M 1 5 aan GRAAF VAN VLAANDEREN.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"89\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"3259C\"}, {\"id\": \"3260\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. As of Apr 22 at 9.30AM, bus 89 diverted. Stop of bus 89: rue Delaunoystraat 15.\", \"fr\": \"Travaux. D\u00e8s le 22/4 \u00e0 9h30, bus 89 d\u00e9vi\u00e9. Arr\u00eat du bus 89: rue Delaunoy, 15.\", \"nl\": \"Werken. Vanaf 22/4 om 9. 30u, bus 89 omgeleid. Halte van bus 89: Delaunoystraat 15.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"89\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"3228\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. From May 17 at 9PM until May 20, T-bus 19 does not serve HOP. BRUGMANN. Connection to T-bus 19 at CIM. JETTE.\", \"fr\": \"Travaux. 17/5, 21h-20/5, T-bus 19 ne dessert pas HOPITAL BRUGMANN. Correspondance T-bus 19 \u00e0 CIMETIERE DE JETTE.\", \"nl\": \"17/5, 21u-20/5, werken. T-bus 19 bedient BRUGMANN-ZKH. niet. Aansluiting met T-bus 19 aan KERKHOF VAN JETTE.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"93\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"5400\"}, {\"id\": \"5402\"}, {\"id\": \"5399F\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Mar 25-Jun 30, works. STOP NOT SERVED. Stop of bus 95: CIMETIERE D'IXELLES / BEGR. VAN ELSENE.\", \"fr\": \"25/3-30/6,travaux. ARRET NON DESSERVI. Arr\u00eat du bus 95: CIM. D'IXELLES (ch\u00e9e de Boondael, avant le rond-point).\", \"nl\": \"25/3-30/6, werken. HALTE NIET BEDIEND. Halte van bus 95: BEGR. VAN ELSENE (Boondaalsestwg, voor de rotonde)\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"95\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"4362\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"As of September 21, works. Stop moved to av. de la Fauconnerie / Valkerijlaan, next to number 53a.\", \"fr\": \"D\u00e8s le 21/9, travaux. Arr\u00eat d\u00e9plac\u00e9 avenue de la Fauconnerie, \u00e0 hauteur du num\u00e9ro 53a.\", \"nl\": \"Vanaf 21/9, werken. Halte verplaatst naar de Valkerijlaan, ter hoogte van huisnummer 53a.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"95\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"4314\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Mar 25 until Jun 30, works. STOP NOT SERVED. Stop of bus 95: av. Couronne / Kroonln, in front of number 384\", \"fr\": \"Du 25/3 au 30/6, travaux. ARRET NON DESSERVI. Arr\u00eat du bus 95: av. de la Couronne, en face du num\u00e9ro 384.\", \"nl\": \"Van 25/3 tot en met 30/6, werken. HALTE NIET BEDIEND. Halte van bus 95: Kroonlaan, tegenover nummer 384\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"95\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"4306\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Mar 25 until Jun 30, works. Bus 95 diverted btw CIMETIERE D'IXELLES and ETTERBEEK GARE\", \"fr\": \"Du 25/3 au 30/6, travaux. Bus 95 d\u00e9vi\u00e9 entre CIMETIERE D'IXELLES et  ETTERBEEK GARE.\", \"nl\": \"Van 25/3 tot en met 30/6, werken. Bus 95 omgeleid tussen BEGRAAFPLAATS VAN ELSENE en ETTERBEEK STATION.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"95\"}]",
+        "priority": 5,
+        "points": "[{\"id\": \"4360\"}, {\"id\": \"4351\"}, {\"id\": \"1455\"}, {\"id\": \"4355\"}, {\"id\": \"4357\"}, {\"id\": \"4358\"}, {\"id\": \"4359\"}, {\"id\": \"4348\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. As of Mar 27, STOP MOVED. Stop of bus 95: rue des Thuyas / Thujastraat 5.\", \"fr\": \"Travaux. D\u00e8s le 27/3, ARRET DEPLACE. Arr\u00eat du bus 95: rue des Thuyas, 5.\", \"nl\": \"Werken. Vanaf 27/3, HALTE VERPLAATST. Halte van bus 95: Thujastraat 5.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"95\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"4310\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Until 2026, works. As of Mar 11, T97 interrupted btw DIEWEG and WIELS. Take T4 to CARR. STALLE, and then the T-bus.\", \"fr\": \"Jsq 2026,travaux. D\u00e8s le 11/3, T97 interrompu entre DIEWEG et WIELS. T4 jsq CARREFOUR STALLE, et ensuite le T-bus.\", \"nl\": \"Tot 2026,werken. Vanaf 11/3, T97 onderbroken tss DIEWEG en WIELS. Neem T4 tot KRUISPUNT STALLE, en de T-bus.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"97\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"2708G\"}, {\"id\": \"5952F\"}, {\"id\": \"2709F\"}, {\"id\": \"2710G\"}, {\"id\": \"1984G\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Until 2026, works. T-bus 82/97 diverted. Stop T-bus 82/97: bd 2e Arm\u00e9e Britannique / Britse Tweedelegerlaan.\", \"fr\": \"Jsq 2026, travaux. T-bus 82/97 d\u00e9vi\u00e9. Arr\u00eat T-bus 82/97: bd 2e Arm\u00e9e Britannique, carrefour rue de la Station.\", \"nl\": \"Tot 2026, werken. T-bus 82/97 omgeleid. Halte T-bus 82/97: Britse Tweedelegerlaan, kruispunt Stationstraat.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"97\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"5719H\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Until 2026, works. Tram 97 interrupted to WIELS. Stop of the T-bus to ROCHEFORT: r. Abbesses / Abdissenstr.\", \"fr\": \"Jusqu'en 2026, travaux. Tram 97 interrompu jusqu'\u00e0 WIELS. Arr\u00eat du T-bus vers ROCHEFORT: rue des Abbesses.\", \"nl\": \"Tot 2026, werken. Tram 97 onderbroken tot WIELS. Halte van de T-bus naar ROCHEFORT: Abdissenstraat.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"97\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"5152G\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Until 2026, works. Tram 97 interrupted to WIELS. Stop of the T-bus to ROCHEFORT: ch. Neerstalsestwg 236\", \"fr\": \"Jsq 2026, travaux. Tram 97 interrompu jsq WIELS. Arr\u00eat du T-bus vers ROCHEFORT: chauss\u00e9e de Neerstalle, 236\", \"nl\": \"Tot 2026, werken. Tram 97 onderbroken tot WIELS. Halte van de T-bus naar ROCHEFORT: Neerstalsesteenweg,236\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"97\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"5164F\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Until 2026, works. Tram 97 interrupted between CARREFOUR STALLE en WIELS. T-bus to ROCHEFORT at this stop.\", \"fr\": \"Jusqu'en 2026, travaux. Tram 97 interrompu entre CARREFOUR STALLE et WIELS. T-bus vers ROCHEFORT \u00e0 cet arr\u00eat.\", \"nl\": \"Tot 2026, werken. T97 onderbroken tussen KRUISPT STALLE en WIELS. T-bus naar ROCHEFORT aan deze halte.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"97\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"5756F\"}, {\"id\": \"1258G\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From May 18, 5AM, works. STOP NOT SERVED. Stop of tram 97: avenue du Parc / Parklaan 26, in front of number 26.\", \"fr\": \"D\u00e8s le 18/5, 5h, travaux. ARRET NON DESSERVI. Arr\u00eat du tram 97: avenue du Parc, en face du num\u00e9ro 26.\", \"nl\": \"Vanaf 18/5, 5u, werken. HALTE NIET BEDIEND. Halte van tram 97: Parklaan, tegenover nummer 26.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"97\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"2334F\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Until 2026, works. T97 interrupted to WIELS. T97 at WIELS via T82, or at ROCHEFORT via T-bus (stop: r. Abbesses)\", \"fr\": \"Jsq 2026, travaux. T97 interrompu jsq WIELS. T97 \u00e0 WIELS via T82, ou \u00e0 ROCHEFORT via T-bus (arr\u00eat: r. Abbesses).\", \"nl\": \"Tot 2026, werken. T97 onderbroken tot WIELS. T97 aan WIELS via T82, of aan ROCHEFORT via T-bus, halte: Abdissenst\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"97\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"5161F\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Until 2026, works. T-bus 82/97 diverted between BEMPT and FOREST CENTRE/VORST CENTRUM.\", \"fr\": \"Jusqu'en 2026, travaux. T-bus 82/97 d\u00e9vi\u00e9 entre BEMPT et FOREST CENTRE.\", \"nl\": \"Tot 2026, werken. Bus T-bus 82/97 omgeleid tussen BEMPT en VORST CENTRUM.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"T82\"}]",
+        "priority": 5,
+        "points": "[{\"id\": \"3405\"}, {\"id\": \"7472\"}, {\"id\": \"7474\"}, {\"id\": \"7465\"}, {\"id\": \"3255\"}, {\"id\": \"5755\"}, {\"id\": \"5756\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Until 2026, works. Bus 50 and T-bus diverted between FOREST CENTRE / VORST CENTRUM and BEMPT.\", \"fr\": \"Jusqu'en 2026, travaux. Bus 50 et T-bus d\u00e9vi\u00e9s entre FOREST CENTRE et BEMPT.\", \"nl\": \"Tot 2026, werken. Bus 50 en T-bus omgeleid tussen VORST CENTRUM en BEMPT.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"T82\"}]",
+        "priority": 5,
+        "points": "[{\"id\": \"3196\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. As of Apr 15, bus 12 diverted btw MEISER and LUXEMBOURG via MAELBEEK. Stop SCHUMAN moved rue Franklinstr.\", \"fr\": \"Travaux. D\u00e8s le 15/4, bus 12 d\u00e9vi\u00e9 entre MEISER et LUXEMBOURG via MAELBEEK. Arr\u00eat SCHUMAN d\u00e9plac\u00e9 rue Franklin.\", \"nl\": \"Werken. Vanaf 15/4, bus 12 omgeleid tss MEISER en LUXEMBURG via MAALBEEK. Halte SCHUMAN verplaatst Franklinstr.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"12\"}]",
+        "priority": 6,
+        "points": "[{\"id\": \"3017\"}, {\"id\": \"2695\"}, {\"id\": \"5048\"}, {\"id\": \"9600B\"}, {\"id\": \"2250\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Bus 17: From Sep 5 6AM, works. Diversion between BRILLANT/BRILJANT and BEAULIEU via Michiels\", \"fr\": \"Bus 17: D\u00e8s le 5/9 6h, travaux. D\u00e9viation entre BRILLANT et BEAULIEU via Michiels\", \"nl\": \"Bus 17: Vanaf 5/9 6u, werken. Omleiding tussen BRILJANT en BEAULIEU via Michiels\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"17\"}]",
+        "priority": 6,
+        "points": "[{\"id\": \"9059\"}, {\"id\": \"4351\"}, {\"id\": \"4341\"}, {\"id\": \"1455\"}, {\"id\": \"4287\"}, {\"id\": \"4355\"}, {\"id\": \"4357\"}, {\"id\": \"4358\"}, {\"id\": \"4348\"}, {\"id\": \"4292\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. As of Mar 27, STOP MOVED. Stop of bus 17: rue des Thuyas / Thujastraat 5.\", \"fr\": \"Travaux. D\u00e8s le 27/3, ARRET DEPLACE. Arr\u00eat du bus 17: rue des Thuyas, 5.\", \"nl\": \"Werken. Vanaf 27/3, HALTE VERPLAATST. Halte van bus 17: Thujastraat 5.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"17\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"4310\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. May 17, 9PM-May 20, tram 19 replaced by a T-bus to SIMONIS. T-bus at the stop of bus 53 to WESTLAND SHOPPING.\", \"fr\": \"Travaux. 17/5, 21h-20/5, tram 19 remplac\u00e9 par des T-bus jsq SIMONIS. T-bus \u00e0 l'arr\u00eat du bus 53 vers WESTLAND SHOPPING.\", \"nl\": \"Werken. 17/5, 21u-20/5, tram 19 vervangen door T-bus tot SIMONIS. T-bus aan de halte van bus 53 naar WESTLAND SHOPPING.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"19\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"5001F\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. From May 17 at 9PM until May 20, tram 19 does not serve this stop. To go to DE WAND, take tram 7.\", \"fr\": \"Travaux. Du 17/5 \u00e0 21h au 20/5, tram 19 ne dessert pas cet arr\u00eat. Pour DE WAND, prenez le tram 7.\", \"nl\": \"Werken. Van 17/5 om 21u tot 20/5 bedient tram 19 deze halte niet. Om naar DE WAND te gaan, neem tram 7.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"19\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"2636F\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. Until mid-2024, T19 interrupted at this stop. Stop of T-bus 19: av. Jette 232 (next to this stop)\", \"fr\": \"Travaux. Jusque mi-2024, T19 interrompu \u00e0 cet arr\u00eat. Arr\u00eat du T-bus 19: av. de Jette, 232 (\u00e0 c\u00f4t\u00e9 de cet arr\u00eat).\", \"nl\": \"Werken. Tot midden 2024, T19 onderbroken aan deze halte. Halte van T-bus 19: Jetselaan 232 (naast deze halte)\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"19\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"6865F\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. Until mid-2024, stop not served. T-bus at VERBEYST (bd de Smet de Naeyer 234, stop of bus 14 to UZ-VUB).\", \"fr\": \"Travaux. Jusque mi-2024, arr\u00eat non desservi. T-bus \u00e0 VERBEYST (bd de Smet de Naeyer 234, arr\u00eat B14 vers UZ-VUB).\", \"nl\": \"Werken. Tot midden 2024, halte niet bediend. T-bus aan VERBEYST (de Smet de Naeyerlaan 234, halte B14 naar UZ-VUB).\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"19\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"6867F\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. Until mid-2024, tram 19 replaced by T-bus btw DE WAND and MIROIR / SPIEGEL. Take T-bus at CIM. DE JETTE.\", \"fr\": \"Travaux. Jusque mi-2024, tram 19 remplac\u00e9 par des T-bus entre DE WAND et MIROIR. Prenez le T-bus \u00e0 CIMETIERE DE JETTE.\", \"nl\": \"Werken. Tot midden 2024, tram 19 vervangen door T-bus tss DE WAND en SPIEGEL. Neem de T-bus aan KERKHOF VAN JETTE\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"19\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"6800F\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. Until mid-2024, stop not served. T-bus at LEOPOLD I (bd de Smet de Naeyer 59), or T19 at MIROIR.\", \"fr\": \"Travaux, jusque mi-2024, arr\u00eat non desservi. T-bus \u00e0 LEOPOLD I (bd de Smet de Naeyer 59), ou T19 \u00e0 MIROIR.\", \"nl\": \"Werken. Tot midden 2024, halte niet bediend. T-bus aan LEOPOLD I (de Smet de Naeyerlaan 59), of T19 aan SPIEGEL.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"19\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"6804F\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. May 17, 9PM-May 20, STOP NOT SERVED. T-bus to SIMONIS at CIM. / KERKH. JETTE, via bus 88 from PR. LEOPOLD.\", \"fr\": \"Travaux. 17/5, 21h-20/5, ARRET NON DESSERVI. T-bus vers SIMONIS \u00e0 CIM. JETTE, via bus 88 depuis PRINCE LEOPOLD.\", \"nl\": \"Werken. 17/5, 21u-20/5, HALTE NIET BEDIEND. T-bus naar SIMONIS aan KERKH. JETTE, via bus 88 vanaf PRINS LEOPOLD.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"19\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"4955F\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Dec 4, works. STOP NOT SERVED. Take bus 20 at the previous stop, GARE DU NORD / NOORDSTATION.\", \"fr\": \"D\u00e8s le 4/12, travaux. ARRET NON DESSERVI. Prenez le bus 20 \u00e0 l'arr\u00eat pr\u00e9c\u00e9dent, GARE DU NORD.\", \"nl\": \"Vanaf 4/12, werken. HALTE NIET BEDIEND. Neem bus 20 aan de vorige halte, NOORDSTATION.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"20\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"3400\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. As of Apr 15, bus 21 diverted btw TREVES and MICHEL-ANGE via MAELBEEK. Stop SCHUMAN moved rue Archim\u00e8de.\", \"fr\": \"Travaux. D\u00e8s le 15/4,bus 21 d\u00e9vi\u00e9 entre TREVES et MICHEL-ANGE via MAELBEEK. Arr\u00eat SCHUMAN d\u00e9plac\u00e9 rue Archim\u00e8de.\", \"nl\": \"Werken. Vanaf 15/4, bus 21 omgeleid tss TRIER en MICHELANGELO via MAALBEEK. Halte SCHUMAN verplaatst Archimedesstr\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"21\"}]",
+        "priority": 6,
+        "points": "[{\"id\": \"1132\"}, {\"id\": \"1262B\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. As of Apr 15, STOP NOT SERVED. Stop of bus 21: rue Archim\u00e8de / Archimedesstraat 16.\", \"fr\": \"Travaux. D\u00e8s le 15/4, ARRET NON DESSERVI. Arr\u00eat du bus 21: rue Archim\u00e8de 16.\", \"nl\": \"Werken. Vanaf 15/4, HALTE NIET BEDIEND. Halte van bus 21: Archimedesstraat 16.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"21\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"2083\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. As of Apr 15, bus 21 diverted btw MICHEL- ANGE and TOULOUSE via MAELBEEK. Stop SCHUMAN moved rue Franklin.\", \"fr\": \"Travaux. D\u00e8s le 15/4,bus 21 d\u00e9vi\u00e9 entre MICHEL- ANGE et TOULOUSE via MAELBEEK. Arr\u00eat SCHUMAN d\u00e9plac\u00e9 rue Franklin.\", \"nl\": \"Werken. Vanaf 15/4, bus 21 omgeleid tss MICHELANGELO en TOULOUSE via MAALBEEK. SCHUMAN verplaatst Franklinstr.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"21\"}]",
+        "priority": 6,
+        "points": "[{\"id\": \"6454\"}, {\"id\": \"3199\"}, {\"id\": \"3361\"}, {\"id\": \"3904\"}, {\"id\": \"3905\"}, {\"id\": \"3425\"}, {\"id\": \"3458\"}, {\"id\": \"3707\"}, {\"id\": \"3204\"}, {\"id\": \"3468\"}, {\"id\": \"3203\"}, {\"id\": \"3214\"}, {\"id\": \"3367\"}, {\"id\": \"1464\"}, {\"id\": \"3466\"}, {\"id\": \"2695\"}, {\"id\": \"1463\"}, {\"id\": \"3201\"}, {\"id\": \"4500\"}, {\"id\": \"3911\"}, {\"id\": \"4505\"}, {\"id\": \"2924\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Jan 18, works. STOP NOT SERVED. Temporary stop: Avenue de Roodebeeklaan 45.\", \"fr\": \"D\u00e8s le 18/1, travaux. ARRET NON DESSERVI. Arr\u00eat provisoire: Avenue de Roodebeek 45.\", \"nl\": \"Vanaf 18/1, werken. HALTE NIET BEDIEND. Tijdelijke halte: Roodebeeklaan 45.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"28\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"1404\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From FEB 2, works. Stop SAINT-JOSSE moved, go to the temporary stop: chauss\u00e9e de Louvain 73.\", \"fr\": \"D\u00e8s le 26/2, travaux. Arr\u00eat SAINT-JOSSE d\u00e9plac\u00e9, allez \u00e0 l'arr\u00eat provisoire : chauss\u00e9e de Louvain 73.\", \"nl\": \"Vanaf 26/2, werken. Halte SINT-JOOST verplaatst, ga naar de tijdelijke halte: Leuvensesteenweg 73.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"29\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"1570\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. STOP NOT OPERATED. Temporary stop: rue de Pavie / Paviastraat 53.\", \"fr\": \"Travaux. ARRET NON DESSERVI. Arr\u00eat provisoire: rue de Pavie 53.\", \"nl\": \"Werken. HALTE NIET BEDIEND. Tijdelijke halte: Paviastraat 53.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"29\"}]",
+        "priority": 5,
+        "points": "[{\"id\": \"1568\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Bus 29: works. Stop CLOVIS not served. Temporary stop: rue de Pavie / Paviastraat 53.\", \"fr\": \"Bus 29 : travaux. Arr\u00eat CLOVIS non desservi. Arr\u00eat provisoire: rue de Pavie 53.\", \"nl\": \"Bus 29: werken. Halte CLOVIS niet bediend. Tijdelijke halte: Paviastraat 53.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"29\"}]",
+        "priority": 6,
+        "points": "[{\"id\": \"6454\"}, {\"id\": \"1561\"}, {\"id\": \"1550\"}, {\"id\": \"1385\"}, {\"id\": \"1560\"}, {\"id\": \"1558\"}, {\"id\": \"1557\"}, {\"id\": \"1567\"}, {\"id\": \"1578\"}, {\"id\": \"1566\"}, {\"id\": \"1554\"}, {\"id\": \"1565B\"}, {\"id\": \"1553\"}, {\"id\": \"3367\"}, {\"id\": \"1552\"}, {\"id\": \"3910\"}, {\"id\": \"1528\"}, {\"id\": \"1559\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. As of April 7th, stop served only by bus 66. Take bus 29, 63 or 65 at the stop of bus 71 to DELTA.\", \"fr\": \"Travaux. D\u00e8s le 7/4, arr\u00eat uniquement desservi par bus 66. Bus 29, 63 ou 65 \u00e0 l'arr\u00eat du bus 71 vers DELTA.\", \"nl\": \"Werken. Vanaf 7/4, halte enkel bediend door bus 66. Neem bus 29, 63 of 65 aan de halte van bus 71 naar DELTA.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"29\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"6445\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Jan 7, 9PM-Jun 28,works. Tram 3 and 7 replaced by T-bus to DOCKS BRUXSEL. T-bus at this stop.\", \"fr\": \"7/1, 21h-28/6, travaux. Tram 3 et 7 remplac\u00e9s par des T-bus jusqu'\u00e0 DOCKS BRUXSEL. T-bus \u00e0 cet arr\u00eat.\", \"nl\": \"7/1, 21u-28/6, werken. Tram 3 en 7 vervangen door T-bus tot DOCKS BRUXSEL. T-bus aan deze halte.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"3\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"5707\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Jan 7, 9PM-Jun 28, works. Stop not served. Stop  T-bus to ESPLANADE : av. Croix du Feu, crossing r. Heembeek.\", \"fr\": \"7/1, 21h-28/6, travaux. Arr\u00eat non desservi.Arr\u00eat T-bus vers ESPLANADE:av. Croix du Feu, carrefour rue de Heembeek.\", \"nl\": \"7/1, 21u-28/6, werken. Halte niet bediend.Halte T-bus naar ESPLANADE : Vuurkruisenlaan, kruispunt Heembeeklaan.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"3\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"5771\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Jan 7, 9PM-Jun 28,works. Tram 3 interrupted btw ESPLANADE and DOCKS BRUXSEL. Stop of the T-bus: av. Araucarialn.\", \"fr\": \"7/1, 21h-28/6, travaux. Tram 3 interrompu entre ESPLANADE et DOCKS BRUXSEL. Arr\u00eat du T-bus: avenue de l'Araucaria.\", \"nl\": \"7/1, 21u-28/6, werken. Tram 3 onderbroken tss ESPLANADE en DOCKS BRUXSEL. Halte van de T-bus: Araucarialaan.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"3\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"5704F\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Jan 7, 9PM-Jun 28, works.Tram 3 diverted to the stop DOCKS BRUXSEL of tram 7 and replaced by T-bus to ESPLANADE.\", \"fr\": \"7/1, 21h-28/6, travaux. Tram 3 d\u00e9vi\u00e9 vers l'arr\u00eat DOCKS BRUXSEL du tram 7 et remplac\u00e9 par des T-bus jsq ESPLANADE.\", \"nl\": \"7/1, 21u-28/6, werken. Tram 3 omgeleid naar de halte DOCKS BRUXSEL van tram 7 en vervangen door T-bus tot ESPLANADE.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"3\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"2337F\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Jan 7 at 9PM to Jun 28, works. Tram 3 replaced by T-bus. Stop T-bus: av. Croix du Feu / Vuurkruisenln, 211-213\", \"fr\": \"Du 7/1 \u00e0 21h au 28/6, travaux. Tram 3 remplac\u00e9 par des T-bus. Arr\u00eat du T-bus: avenue des Croix du Feu, 211-213\", \"nl\": \"Van 7/1 om 21u tot en met 28/6, werken. Tram 3 vervangen door T-bus. Halte T-bus: Vuurkruisenlaan, 211-213\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"3\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"5773\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From jan 15, works. STOP NOT SERVED. Take bus 34 at the stop CLESSE of bus 72 to ADEPS.\", \"fr\": \"D\u00e8s le 15/1, travaux. ARRET NON DESSERVI. Prenez le bus 34 \u00e0 l'arr\u00eat CLESSE du bus 72 vers ADEPS.\", \"nl\": \"Vanaf 15/1, werken. HALTE NIET BEDIEND. Neem bus 34 aan de halte CLESSE van bus 72 naar ADEPS.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"34\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"1719\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. As of Apr 15, STOP NOT SERVED. Stop of bus 12: rue Archim\u00e8de / Archimedesstraat 16.\", \"fr\": \"Travaux. D\u00e8s le 15/4, ARRET NON DESSERVI. Arr\u00eat du bus 12: rue Archim\u00e8de 16.\", \"nl\": \"Werken. Vanaf 15/4, HALTE NIET BEDIEND. Halte van bus 12: Archimedesstraat 16.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"12\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"1418B\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. From Apr 23 until Jun 2, bus 13 and 88 diverted. Take bus 13 or 88 at the stop of bus 820 to UZ Brussel.\", \"fr\": \"Travaux; Du 23/4 au 2/6, bus 13 et 88 d\u00e9vi\u00e9s. Prenez le bus 13 ou 88 \u00e0 l'arr\u00eat du bus 820 vers UZ Brussel.\", \"nl\": \"Werken. Van 23/4 tot en met 2/6, bus 13 en 88 omgeleid. Neem bus 13 of 88 aan de halte van bus 820 naar UZ Brussel.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"13\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"1721\"}, {\"id\": \"1328\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Sep 5 6AM, works. STOP NOT SERVED. Bus 17 diverted between BRILLANT and BEAULIEU via Michiels\", \"fr\": \"D\u00e8s le 5/9 6h, travaux. ARRET NON DESSERVI. Bus 17 d\u00e9vi\u00e9 entre BRILLANT et BEAULIEU via Michiels\", \"nl\": \"Vanaf 5/9 6u, werken. HALTE NIET BEDIEND. Bus 17 omgeleid tussen BRILJANT en BEAULIEU via Michiels\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"17\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"4295\"}, {\"id\": \"4296\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Sep 5 6AM, works. STOP NOT SERVED. Temporary stop: rue du Brillant (across stop towards Heiligenborre)\", \"fr\": \"D\u00e8s le 5/9 6h, travaux. ARRET NON DESSERVI. Arr\u00eat provisoire: rue du Brillant (face \u00e0 l'arr\u00eat vers Heiligenborre)\", \"nl\": \"Vanaf 5/9 6u, werken. HALTE NIET BEDIEND. Tijdelijke halte: Briljantstraat (tgnover halte > Heiligenborre)\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"17\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"4293\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. Until mid-2024, T19 replaced by T-bus btw MIROIR and CIMETIERE DE JETTE. T-bus at stop of bus 13 to UZ-VUB.\", \"fr\": \"Travaux. Jsq mi-2024, T19 remplac\u00e9 par T-bus entre MIROIR et CIM. JETTE. T-bus \u00e0 l'arr\u00eat du bus 13 vers UZ-VUB.\", \"nl\": \"Werken. Tot midden 2024, T19 vervangen door T-bus tss SPIEGEL en KERKH. JETTE.  T-bus aan halte van B13 naar UZ-VUB.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"19\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"0471\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. Until mid-2024, T19 interrupted at MIROIR. Stop of T-bus 19: av. Jette 126 (next to this stop)\", \"fr\": \"Travaux. Jusque mi-2024, T19 interrompu \u00e0 MIROIR. Arr\u00eat du T-bus 19: av. de Jette, 126 (\u00e0 c\u00f4t\u00e9 de cet arr\u00eat).\", \"nl\": \"Werken. Tot midden 2024, T19 onderbroken aan SPIEGEL. Halte van T-bus 19: Jetselaan 126 (naast deze halte)\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"19\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"6864F\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. Until mid-2024, stop not served. Take tram 19 at CIMETIERE DE JETTE / KERKHOF VAN JETTE.\", \"fr\": \"Travaux. Jusque mi-2024, arr\u00eat non desservi. Prenez le tram 19 \u00e0 CIMETIERE DE JETTE.\", \"nl\": \"Werken. Tot midden 2024, halte niet bediend. Neem tram 19 aan KERKHOF VAN JETTE.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"19\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"6869G\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. May 17, 9PM-May 20, tram 19 replaced by a T-bus to DE WAND.T-bus at PR. LEOPOLD (stop of bus 88 to UZ-VUB).\", \"fr\": \"Travaux. 17/5, 21h-20/5, tram 19 remplac\u00e9 par des T-bus jsq DE WAND. T-bus \u00e0 PRINCE LEOPOLD (arr\u00eat du bus 88 vers UZ-VUB).\", \"nl\": \"Werken. 17/5, 21u-20/5, tram 19 vervangen door T-bus tot DE WAND. T-bus aan PRINS LEOPOLD (halte van bus 88 naar UZ-VUB)\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"19\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"4958F\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. Until mid-2024, stop not served. T-bus at VERBEYST (bd de Smet de Naeyer 211, stop of bus 14 to GARE DU NORD).\", \"fr\": \"Travaux, jusque mi-2024, arr\u00eat non desservi.T-bus \u00e0 VERBEYST (bd de Smet de Naeyer 211, arr\u00eat B14 vers GARE DU NORD).\", \"nl\": \"Werken. Tot midden 2024, halte niet bediend. T-bus aan VERBEYST (de Smet de Naeyerlaan 211, halte B14 naar NOORDST.)\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"19\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"6803F\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. From May 17 at 9PM until May 20, STOP NOT SERVED. T-bus to SIMONIS at DE WAND via tram 7.\", \"fr\": \"Travaux. Du 17/5 \u00e0 21h au 20/5, ARRET NON DESSERVI. T-bus vers SIMONIS \u00e0 DE WAND via tram 7.\", \"nl\": \"Werken. Van 17/5 om 21u tot 20/5, HALTE NIET BEDIEND. T-bus naar SIMONIS aan DE WAND via tram 7.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"19\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"2637F\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. Until mid-2024, T19 replaced by T-bus between MIROIR and CIMETIERE DE JETTE.\", \"fr\": \"Travaux. Jusque mi-2024, tram 19 remplac\u00e9 par des T-bus entre MIROIR et CIMETIERE DE JETTE.\", \"nl\": \"Werken. Tot midden 2024, tram 19 vervangen door T-bus tussen SPIEGEL en KERKHOF VAN JETTE.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"19\"}]",
+        "priority": 5,
+        "points": "[{\"id\": \"1306F\"}, {\"id\": \"5105F\"}, {\"id\": \"1094F\"}, {\"id\": \"1111\"}, {\"id\": \"5104F\"}, {\"id\": \"5103\"}, {\"id\": \"5102F\"}, {\"id\": \"1064\"}, {\"id\": \"5108\"}, {\"id\": \"5109\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. As of Apr 15, STOP NOT SERVED. Stop of bus 21: rue Franklinstraat 2a.\", \"fr\": \"Travaux. D\u00e8s le 15/4, ARRET NON DESSERVI. Arr\u00eat du bus 21: rue Franklin, 2a.\", \"nl\": \"Werken. Vanaf 15/4, HALTE NIET BEDIEND. Halte van bus 21: Franklinstraat 2a.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"21\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"1270B\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. As of Apr 15, bus 21 diverted. Take bus 21 at the stop of bus 64 to BORDET STATION.\", \"fr\": \"Travaux. D\u00e8s le 15/4, bus 21 d\u00e9vi\u00e9. Prenez le bus 21 \u00e0 l'arr\u00eat du bus 64 vers BORDET STATION.\", \"nl\": \"Werken. Vanaf 15/4, bus 21 omgeleid. Neem bus 21 aan de halte van bus 64 naar BORDET STATION.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"21\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"1133\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. As of Apr 15, STOP NOT SERVED. Take bus 21 at MAELBEEK / MAALBEEK (stop of bus 64 to BORDET STATION).\", \"fr\": \"Travaux. D\u00e8s le 15/4, ARRET NON DESSERVI. Prenez le bus 21 \u00e0 MAELBEEK (halte van bus 64 naar BORDET STATION).\", \"nl\": \"Werken. Vanaf 15/4, HALTE NIET BEDIEND. Neem bus 21 aan MAALBEEK (arr\u00eat du bus 64 vers BORDET STATION).\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"21\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"1416\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Jan 7, 9PM-Jun 28, works. Tram 3 replaced by T-bus between DOCKS BRUXSEL and ESPLANADE. Info: stib-mivb.brussels\", \"fr\": \"7/1, 21h-28/6, travaux. Tram 3 remplac\u00e9 par des T-bus entre DOCKS BRUXSEL et ESPLANADE. Info: stib.brussels.\", \"nl\": \"7/1, 21u-28/6, werken. Tram 3 vervangen door T-bus tussen DOCKS BRUXSEL en ESPLANADE. info: mivb.brussels.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"3\"}]",
+        "priority": 5,
+        "points": "[{\"id\": \"5219F\"}, {\"id\": \"6179\"}, {\"id\": \"2537F\"}, {\"id\": \"0722\"}, {\"id\": \"9986F\"}, {\"id\": \"6424F\"}, {\"id\": \"0606\"}, {\"id\": \"6177F\"}, {\"id\": \"0626\"}, {\"id\": \"0516\"}, {\"id\": \"6209\"}, {\"id\": \"0725\"}, {\"id\": \"0726\"}, {\"id\": \"0616\"}, {\"id\": \"0506\"}, {\"id\": \"2200F\"}, {\"id\": \"0723\"}, {\"id\": \"0526\"}, {\"id\": \"0724\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Jan 7, 9PM-Jun 28, works. Stop not served. T-bus to ESPLANADE at the stop of bus 56 to BUDA.\", \"fr\": \"7/1, 21h-28/6, travaux. Arr\u00eat non desservi. T-bus vers ESPLANADE \u00e0 l'arr\u00eat du bus 56 vers BUDA.\", \"nl\": \"7/1, 21u-28/6, werken. Halte niet bediend. T-bus naar ESPLANADE aan de halte van bus 56 naar BUDA.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"3\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"5770F\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Jan 7 at 9PM to Jun 28, works. Terminus not served. Stop of the T-bus: av. de Meysse, in front of number 125.\", \"fr\": \"Du 7/1 \u00e0 21h au 28/6, travaux. Terminus non desservi. Arr\u00eat du T-bus: avenue de Meysse, en face du num\u00e9ro 125.\", \"nl\": \"7/1, 21u-28/6, werken. Eindpunt niet bediend. Halte van de T-bus: Meiseselaan, tegenover nummer 125.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"3\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"5701\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Jan 7, 9PM-Jun 28,works. Tram 3 interrupted btw ESPLANADE and DOCKS BRUXSEL. T-bus at stop of bus 83 to VAL MARIA\", \"fr\": \"7/1, 21h-28/6, travaux. Tram 3 interrompu entre ESPLANADE et DOCKS BRUXSEL. T-bus \u00e0 l'arr\u00eat du bus 83 vers VAL MARIA\", \"nl\": \"7/1, 21u-28/6, werken. Tram 3 onderbroken tss ESPLANADE en DOCKS BRUXSEL. T-bus halte van bus 83 naar MARI\u00cbNDAAL.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"3\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"5700G\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Jan 7, 9PM-Jun 28,works. Tram 3 interrupted btw ESPLANADE and DOCKS BRUXSEL. Stop of the T-bus: next to this stop\", \"fr\": \"7/1, 21h-28/6, travaux. Tram 3 interrompu entre ESPLANADE et DOCKS BRUXSEL. Arr\u00eat du T-bus: \u00e0 c\u00f4t\u00e9 de cet arr\u00eat.\", \"nl\": \"7/1, 21u-28/6, werken. Tram 3 onderbroken tss ESPLANADE en DOCKS BRUXSEL. Halte van de T-bus: naast deze halte.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"3\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"5705\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Jan 15, works. STOP NOT SERVED. Stop of bus 34: boulevard du Souverain / Vorstlaan 159.\", \"fr\": \"D\u00e8s le 15/1, travaux. ARRET NON DESSERVI. Arr\u00eat du bus 34: boulevard du Souverain 159.\", \"nl\": \"Vanaf 15/1, werken. HALTE NIET BEDIEND. Halte van bus 34: Vorstlaan 159.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"34\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"1731\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Afterwork. Every Thursday after 4PM, stop moved to rue de Tr\u00e8ves, in front of the stop in the other direction\", \"fr\": \"Afterwork. Tous les jeudis apr\u00e8s 16h, arr\u00eat d\u00e9plac\u00e9 rue de Tr\u00e8ves, en face de l'arr\u00eat dans l'autre sens.\", \"nl\": \"Afterwork.Elke donderdag na 16u, halte verplaatst naar de Trierstraat, tegenover de halte in de andere richting.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"34\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"1233\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Jan 15, works. Bus 34 diverted between HANKAR and BERGOJE via DEMEY.\", \"fr\": \"D\u00e8s le 15/1, travaux. Bus 34 d\u00e9vi\u00e9 entre HANKAR et BERGOJE via DEMEY.\", \"nl\": \"Vanaf 15/1, werken. Bus 34 omgeleid tussen HANKAR en BERGOJE via DEMEY.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"34\"}]",
+        "priority": 5,
+        "points": "[{\"id\": \"1712\"}, {\"id\": \"1733\"}, {\"id\": \"2291B\"}, {\"id\": \"6433\"}, {\"id\": \"1729\"}, {\"id\": \"1728\"}, {\"id\": \"1706\"}, {\"id\": \"1716\"}, {\"id\": \"1715\"}, {\"id\": \"1714\"}, {\"id\": \"1824\"}, {\"id\": \"1713\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Jan 15, works. STOP NOT SERVED. Take bus 34 at the stop RO(O)DENBERG of bus 72 to ADEPS.\", \"fr\": \"D\u00e8s le 15/1, travaux. ARRET NON DESSERVI. Prenez le bus 34 \u00e0 l'arr\u00eat ROODENBERG du bus 72 vers ADEPS.\", \"nl\": \"Vanaf 15/1, werken. HALTE NIET BEDIEND. Neem bus 34 aan de halte RODENBERG van bus 72 naar ADEPS.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"34\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"1720B\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Apr 3 at 6AM, works. Bus 38 diverted between LONGCHAMP and HOUZEAU via rue Edith Cavellstraat.\", \"fr\": \"D\u00e8s le 3/4 \u00e0 6h, travaux. Bus 38 d\u00e9vi\u00e9 entre LONGCHAMP et HOUZEAU via rue Edith Cavell.\", \"nl\": \"Vanaf 3/4 om 6u, werken. Bus 38 omgeleid tussen LONGCHAMP en HOUZEAU via Edith Cavellstraat.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"38\"}]",
+        "priority": 5,
+        "points": "[{\"id\": \"1910\"}, {\"id\": \"3503\"}, {\"id\": \"1909\"}, {\"id\": \"6433\"}, {\"id\": \"3122\"}, {\"id\": \"1906\"}, {\"id\": \"1729\"}, {\"id\": \"1903\"}, {\"id\": \"1912\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Apr 3 at 6AM, works. STOP NOT SERVED. Bus 38 at the stop LANGEVELD of bus 60 to AMBIORIX.\", \"fr\": \"D\u00e8s le 3/4 \u00e0 6h, travaux. ARRET NON DESSERVI. Bus 38 \u00e0 l'arr\u00eat LANGEVELD du bus 60 vers AMBIORIX.\", \"nl\": \"Vanaf 3/4 om 6u, werken. HALTE NIET BEDIEND. Bus 38 aan halte LANGEVELD van bus 60 naar AMBIORIX.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"38\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"1919\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Afterwork. Every Thursday after 4PM, stop moved to rue de Tr\u00e8ves, in front of the stop in the other direction\", \"fr\": \"Afterwork. Tous les jeudis apr\u00e8s 16h, arr\u00eat d\u00e9plac\u00e9 rue de Tr\u00e8ves, en face de l'arr\u00eat dans l'autre sens.\", \"nl\": \"Afterwork.Elke donderdag na 16u, halte verplaatst naar de Trierstraat, tegenover de halte in de andere richting.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"38\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"1233\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Apr 3 at 6AM, works. STOP NOT SERVED. Bus 38 at the stop LANGEVELD of bus 60 to UCCLE CALEVOET.\", \"fr\": \"D\u00e8s le 3/4 \u00e0 6h, travaux. ARRET NON DESSERVI. Bus 38 \u00e0 l'arr\u00eat LANGEVELD du bus 60 vers UCCLE CALEVOET.\", \"nl\": \"Vanaf 3/4 om 6u, werken. HALTE NIET BEDIEND. Bus 38 aan halte LANGEVELD van bus 60 naar UKKEL KALEVOET.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"38\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"1971\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"fr\": \"Bon voyage sur nos lignes !\", \"nl\": \"Een goede reis op onze lijnen gewenst!\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"39\"}]",
+        "priority": 9,
+        "points": "[{\"id\": \"5519\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Apr 3 at 6AM, works. STOP NOT SERVED. Take bus 38 and 41 at the next stop, HOUZEAU.\", \"fr\": \"D\u00e8s le 3/4 \u00e0 6h, travaux. ARRET NON DESSERVI. Prenez les bus 38 et 41 \u00e0 l'arr\u00eat suivant, HOUZEAU.\", \"nl\": \"Vanaf 3/4 om 6u, werken. HALTE NIET BEDIEND. Neem bus 38 en 41 aan de volgende halte, HOUZEAU.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"41\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"1920\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Apr 3 at 6AM, works. STOP NOT SERVED. Take bus 38 and 41 at the previous stop, HOUZEAU.\", \"fr\": \"D\u00e8s le 3/4 \u00e0 6h, travaux. ARRET NON DESSERVI. Prenez les bus 38 et 41 \u00e0 l'arr\u00eat pr\u00e9c\u00e9dent, HOUZEAU.\", \"nl\": \"Vanaf 3/4 om 6u, werken. HALTE NIET BEDIEND. Neem bus 38 en 41 aan de vorige halte, HOUZEAU.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"41\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"1970\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Mar 4, works. Bus 43 and N11 diverted. Take the bus at GRIOTTES / NOORDKRIEKEN.\", \"fr\": \"D\u00e8s le 4/3, travaux. Bus 43 et N11 d\u00e9vi\u00e9s. Prenez le bus \u00e0 GRIOTTES.\", \"nl\": \"Vanaf 4/3, werken. Bus 43 en N11 omgeleid. Neem de bus aan NOORDKRIEKEN.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"43\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"1957B\"}, {\"id\": \"1933B\"}, {\"id\": \"1939\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"As from 21 Sept, works. Stop moved +-60m forwards.\", \"fr\": \"D\u00e8s le 21/9, travaux. Arr\u00eat avanc\u00e9 de +-60m.\", \"nl\": \"Vanaf 21/9, werken. Halte +-60m vooruitgebracht.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"45\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"3462\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. Until end of August, bus 46 not operated btw WTC-GLIBERT and CENTRAL STATION. Walk to the center.\", \"fr\": \"Travaux. Jsq fin ao\u00fbt, bus 46 ne circule pas entre WTC-GLIBERT et GARE CENTRALE.Pour le centre, continuez \u00e0 pied\", \"nl\": \"Werken. Tot einde augustus rijdt bus 46 niet tss WTC-GLIBERT en CENTRAAL STATION. Voor het centrum, ga te voet.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"46\"}]",
+        "priority": 5,
+        "points": "[{\"id\": \"2835\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Jan 22 at 7AM, works. STOP NOT SERVED. Stop of bus 46: rue de Laeken / Lakensestraat 34.\", \"fr\": \"D\u00e8s le 22/1 \u00e0 7h, travaux. ARRET NON DESSERVI. Arr\u00eat du bus 46: rue de Laeken 34.\", \"nl\": \"Van 22/1 om 7u, werken. HALTE NIET BEDIEND. Halte van bus 46: Lakensestraat 34.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"46\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"3469\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Until Summer of 2024, works. Stop not served. Stop of bus 47: CROIX DE GUERRE / OORLOGSKRUISEN.\", \"fr\": \"Jusqu'\u00e0 l'\u00e9t\u00e9 2024, travaux. Arr\u00eat non desservi. Arr\u00eat du bus 47 : CROIX DE GUERRE.\", \"nl\": \"Tot zomer 2024, werken. Halte niet bediend. Halte van bus 47: OORLOGSKRUISEN.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"47\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"1987\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Oct 7, works. STOP NOT OPERATED. Temporary stop: David Terniersstraat 115\", \"fr\": \"D\u00e8s le 7/10, travaux. ARRET NON DESSERVI. Arr\u00eat provisoire : David Terniersstraat 115\", \"nl\": \"Vanaf 7/10, werken. HALTE NIET BEDIEND. Tijdelijke halte: David Terniersstraat 115\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"47\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"9627\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Until Summer of 2024, works. As of Mar 3, STOP NOT SERVED. Stop of bus 47 57: ANTOON VAN OSS.\", \"fr\": \"Jusqu'\u00e0 l'\u00e9t\u00e9 2024, travaux. D\u00e8s le 4/3, ARRET NON DESSERVI. Arr\u00eat des bus 47 57 : ANTOON VAN OSS.\", \"nl\": \"Tot zomer 2024, werken. Vanaf 4/3, HALTE NIET BEDIEND. Halte van bus 47 57: ANTOON VAN OSS\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"47\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"1827\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Feb 7, works. STOP NOT SERVED. Temporary stop: Vlierkensstraat 174.\", \"fr\": \"D\u00e8s le 7/2, travaux. ARRET NON DESSERVI. Arr\u00eat provisoire: Vlierkensstraat 174.\", \"nl\": \"Vanaf 7/2, werken. HALTE NIET BEDIEND. Tijdelijke halte: Vlierkensstraat 174.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"47\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"9605\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Until Summer of 2024, works. Stop not served. Stop of bus 47: VERGER / BOOMGAARD (av. Croix de Guerre/Oorlogskruisenln)\", \"fr\": \"Jusqu'\u00e0 l'\u00e9t\u00e9 2024, travaux. Arr\u00eat non desservi. Arr\u00eat du bus 47 : VERGER (avenue des Croix de Guerre).\", \"nl\": \"Tot zomer 2024, werken. Halte niet bediend. Halte van bus 47: BOOMGAARD (Oorlogskruisenlaan).\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"47\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"2312\"}, {\"id\": \"2363\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Jan 9th at 6AM, works. STOP UNSERVED. Go to the stop HOP. MILITAIR(E) HOSP. from B53.\", \"fr\": \"D\u00e8s le 9/1 \u00e0 6h, travaux. ARRET NON DESSERVI. Aller \u00e0 l'arr\u00eat HOP. MILITAIRE du B53.\", \"nl\": \"Vanaf 9/1 om 6u, werken. HALTE NIET BEDIEND. Ga naar de halte MILITAIR HOSP. van B53.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"47\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"3067\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Until Summer of 2024, works. Bus 47 diverted btw VTM and RAMIER. As of Mar 18, stop HOPITAL MILITAIRE in rue Bruyn.\", \"fr\": \"Jsq \u00e9t\u00e9 2024, travaux. Bus 47 d\u00e9vi\u00e9 entre VTM et RAMIER. D\u00e8s le 18/3, arr\u00eat HOPITAL MILITAIRE rue Bruyn.\", \"nl\": \"Tot zomer 2024, werken. Bus 47 omgeleid tussen VTM en BOSDUIF. Vanaf 18/3,halte MILITAIR HOSP in de Bruynstraat.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"47\"}]",
+        "priority": 5,
+        "points": "[{\"id\": \"9634\"}, {\"id\": \"9784B\"}, {\"id\": \"9786\"}, {\"id\": \"9632\"}, {\"id\": \"9606\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Until Summer of 2024, works. Stop not served. Take bus 47 or 56 at ANTOON VAN OSS. For HOP MILITAIRE , walk.\", \"fr\": \"Jsq \u00e9t\u00e9 2024, travaux. Arr\u00eat non desservi. Bus 47 ou 56 \u00e0 ANTOON VAN OSS. Pour HOPITAL MILITAIRE, \u00e0 pied.\", \"nl\": \"Tot zomer 2024, werken. Halte niet bediend. Neem bus 47 of 56 aan ANTOON VAN OSS. Voor MILITAIR HOSPITAAL, ga te voet.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"47\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"1838\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Until Summer of 2024, works. B47 diverted btw CHEMIN VERT and ANT VAN OSS. As of Mar 3, diverted to H. MILITAIRE\", \"fr\": \"Jsq \u00e9t\u00e9 2024, travaux. B47 d\u00e9vi\u00e9 entre CHEMIN VERT et ANTOON VAN OSS. D\u00e8s le 4/3, d\u00e9vi\u00e9 jsq HOPITAL MILITAIRE.\", \"nl\": \"Tot zomer 2024, werken. Bus 47 omgeleid tss GROENWEG en ANTOON VAN OSS. Vanaf 4/3, omgeleid tot MILITAIR HOSPITAAL\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"47\"}]",
+        "priority": 5,
+        "points": "[{\"id\": \"2314\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Apr 20, works. Stop not served. Take B49 next to number 26 (100m before this stop).\", \"fr\": \"D\u00e8s le 20/4, travaux. Arr\u00eat non desservi. Arr\u00eat du B49 \u00e0  hauteur du num\u00e9ro 26 (100 m avant cet arr\u00eat).\", \"nl\": \"Vanaf 20/4, werken. Halte niet bediend. Neem B49 ter hoogte van nummer 26 (100m voor deze halte).\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"49\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"2225\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Apr 22 at 12PM, works. STOP NOT SERVED. Stop of bus 50: avenue Paul Gilsonlaan, just before this stop.\", \"fr\": \"D\u00e8s 22/4 \u00e0 12h, travaux. ARRET NON DESSERVI. Arr\u00eat du bus 50: avenue Paul Gilson, peu avant cet arr\u00eat.\", \"nl\": \"Vanaf 22/4 om 12u, werken. HALTE NIET BEDIEND. Halte van bus 50: Paul Gilsonlaan, net voor deze halte.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"50\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"2609\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Until 2026, works. Bus 50 diverted to FOREST CENTRE / VORST CENTRUM. Stop of bus 50: r. Abbesses / Abdissenstr.\", \"fr\": \"Jusqu'en 2026, travaux. Bus 50 d\u00e9vi\u00e9 jusqu'\u00e0 FOREST CENTRE. Arr\u00eat du bus 50: rue des Abbesses.\", \"nl\": \"Tot 2026, werken. Bus 50 omgeleid tot VORST CENTRUM. Halte van bus 50: Abdissenstraat.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"50\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"5152\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. From May 17 at 9PM until May 20, T-bus 19 does not serve HOP. BRUGMANN. Connection to T-bus 19 at CIM. JETTE.\", \"fr\": \"Travaux. 17/5, 21h-20/5, T-bus 19 ne dessert pas HOPITAL BRUGMANN. Correspondance T-bus 19 \u00e0 CIMETIERE DE JETTE.\", \"nl\": \"17/5, 21u-20/5, werken. T-bus 19 bedient BRUGMANN-ZKH. niet. Aansluiting met T-bus 19 aan KERKHOF VAN JETTE.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"51\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"5402\"}, {\"id\": \"5399F\"}, {\"id\": \"1290\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Until Summer of 2024, works. Stop not served. Stop of bus 53: KRUIPWEG (rue du Paturage / Weilandstraat).\", \"fr\": \"Jusqu'\u00e0 l'\u00e9t\u00e9 2024, travaux. Arr\u00eat non desservi. Arr\u00eat du bus 53 : KRUIPWEG (rue du Paturage)\", \"nl\": \"Tot zomer 2024, werken. Halte niet bediend. Halte van bus 53: KRUIPWEG (Weilandstraat)\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"53\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"2312\"}, {\"id\": \"2363\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"On May 5 until 8PM, flea market. STOP NOT SERVED. Stop T-bus and bus 54: crossing Lesbroussart- Louise, on tram tracks.\", \"fr\": \"19/5 jsq 20h, brocante. ARRET NON DESSERVI. Arr\u00eat T-bus et B54: carrefour Lesbroussart- Louise, sur les voies.\", \"nl\": \"19/5 tot 20u,rommelmarkt HALTE NIET BEDIEND. Halte T-bus en B54: kruispunt Lesbroussart- Louiza, op tramsporen.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"54\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"2971\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Apr 2, 2024 to June 2025, works. STOP NOT SERVED. To go to BERVOETS, take bus 50 or T-bus at FOREST CENTRE.\", \"fr\": \"Du 2/4/2024 \u00e0 juin 2025, travaux. ARRET NON DESSERVI. Pour rejoindre BERVOETS, bus 50 ou T-bus \u00e0 FOREST CENTRE.\", \"nl\": \"Van 2/4/2024 tot juni 2025, werken. HALTE NIET BEDIEND. Voor BERVOETS, neem bus 50 of de T-bus aan VORST CENTRUM.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"54\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"5152\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. From Apr 2 until June 2025, STOP NOT SERVED. Take bus 54 at the previous stop, FOREST CENTRE.\", \"fr\": \"Travaux. Du 2/4 \u00e0 juin 2025, ARRET NON DESSERVI. Prenez le bus 54 \u00e0 l'arr\u00eat pr\u00e9c\u00e9dent, FOREST CENTRE.\", \"nl\": \"Werken. Vanaf 2/4 tot juni 2025, HALTE NIET BEDIEND. Neem bus 54 aan de vorige halte, VORST CENTRUM.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"54\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"5719\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Apr 2, 2024 to June 2025, works. STOP NOT SERVED. To go to BERVOETS, take bus 50 or T-bus(stop: r. Abbesses)\", \"fr\": \"Du 2/4/2024 \u00e0 juin 2025, travaux. ARRET NON DESSERVI. Pour rejoindre BERVOETS,bus 50 ou T-bus (arr\u00eat: r. des Abbesses)\", \"nl\": \"Van 2/4/2024 tot juni 2025, werken. HALTE NIET BEDIEND. Voor BERVOETS, neem bus 50 of de T-bus (halte: Abdissenstraat)\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"54\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"5161\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Apr 2, 2024-June 2025, works. Bus 54 diverted btw FOREST NATIONAL and FOREST CENTRE. Info: stib-mivb.brussels\", \"fr\": \"Du 2/4/2024 \u00e0 juin 2025, travaux. Bus 54 d\u00e9vi\u00e9 entre FOREST NATIONAL et FOREST CENTRE. Info: stib.brussels.\", \"nl\": \"2/4/2024-juni 2025, werken. Bus 54 omgeleid tussen VORST NATIONAAL en VORST CENTRUM. Info: mivb.brussels\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"54\"}]",
+        "priority": 5,
+        "points": "[{\"id\": \"2934A\"}, {\"id\": \"2950\"}, {\"id\": \"2411B\"}, {\"id\": \"2937B\"}, {\"id\": \"2936\"}, {\"id\": \"2935\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"On May 5 until 8PM, flea market. STOP NOT SERVED. Stop of bus 54: rue Defacqzstraat 133.\", \"fr\": \"Le 19/5 jusqu'\u00e0 20h, brocante. ARRET NON DESSERVI. Arr\u00eat du bus 54: rue Defacqz 133.\", \"nl\": \"Op 19/5 tot 20u, rommelmarkt. HALTE NIET BEDIEND. Halte van bus 54: Defacqzstraat 133.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"54\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"2931\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. Bus 56 diverted between VERGER and VAN PRAET via avenue des Croix de Guerre\", \"fr\": \"Travaux. Bus 56 d\u00e9vi\u00e9 entre VERGER et VAN PRAET via avenue des Croix de Guerre\", \"nl\": \"Werken. Bus 56 omgeleid tussen BOOMGAARD en VAN PRAET via Oorlogskruisenlaan\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"56\"}]",
+        "priority": 5,
+        "points": "[{\"id\": \"2823B\"}, {\"id\": \"2766\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Until Summer of 2024, works. Bus 56 diverted. Take bus 56 at ANTOON VAN OSS.\", \"fr\": \"Jusqu'\u00e0 l'\u00e9t\u00e9 2024, travaux. Bus 56 d\u00e9vi\u00e9. Prenez le bus 56 \u00e0 ANTOON VAN OSS.\", \"nl\": \"Tot zomer 2024, werken. Bus 56 omgeleid. Neem bus 56 aan ANTOON VAN OSS.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"56\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"1827\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. STOP NOT SERVED. Take bus 47 56 at the usual stop of trams 3 7 direction CHURCHILL / VANDERKINDERE.\", \"fr\": \"Travaux. ARRET NON DESSERVI. Prenez le bus 47 56 \u00e0 l'arr\u00eat habituel des trams 3 7 vers CHURCHILL/VANDERKINDERE.\", \"nl\": \"Werken. HALTE NIET BEDIEND. Neem bus 47 56 aan de gebruikelijke halte van tram 3 7 naar CHURCHILL/VANDERKINDERE.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"56\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"6368C\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. As of Apr 15, bus 56 diverted from AMBIORIX to MAELBEEK. Connection metro at MAELBEEK / MAALBEEK.\", \"fr\": \"Travaux. D\u00e8s le 15/4, bus 56 d\u00e9vi\u00e9 depuis AMBIORIX vers MAELBEEK. Correspondance m\u00e9tro \u00e0 MAELBEEK.\", \"nl\": \"Werken. Vanaf 15/4, bus 56 omgeleid vanaf AMBIORIX naar MAALBEEK. Aansluiting metro aan MAALBEEK.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"56\"}]",
+        "priority": 6,
+        "points": "[{\"id\": \"2092\"}, {\"id\": \"6461\"}, {\"id\": \"5740\"}, {\"id\": \"2100\"}, {\"id\": \"2067\"}, {\"id\": \"6191\"}, {\"id\": \"9291\"}, {\"id\": \"2097\"}, {\"id\": \"2096\"}, {\"id\": \"2094\"}, {\"id\": \"1007\"}, {\"id\": \"2920\"}, {\"id\": \"3414\"}, {\"id\": \"2105\"}, {\"id\": \"2102\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. As of March 18, bus 56 operates normally between HOP. MILITAIRE / MILITAIR HOSP. and ANTOON VAN OSS.\", \"fr\": \"Travaux. D\u00e8s le 18/3, bus 56 circule \u00e0 nouveau normalement entre HOPITAL MILITAIRE et ANTOON VAN OSS.\", \"nl\": \"Werken. Vanaf 18/3 rijdt B56 opnieuw langs zijn gebruikelijke reisweg tss MILITAIR HOSPITAAL en ANTOON VAN OSS.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"56\"}]",
+        "priority": 5,
+        "points": "[{\"id\": \"2365\"}, {\"id\": \"2827\"}, {\"id\": \"1989\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. STOP NOT SERVED. Temporary stop: avenue des Croix de Guerre 78\", \"fr\": \"Jusqu'\u00e0 l'\u00e9t\u00e9 2024, travaux. Arr\u00eat des bus 47 et 56 : avenue des Croix de Guerre 78.\", \"nl\": \"Tot zomer 2024, werken. Halte van bus 47 en 56: Oorlogskruisenlaan 78.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"56\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"2377\"}, {\"id\": \"2299\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Until Summer of 2024, works. Stop not served. Take bus 47 or 57 at ANTOON VAN OSS (stop of bus 56 to BUDA).\", \"fr\": \"Jsq \u00e9t\u00e9 2024, travaux. Arr\u00eat non desservi. Prenez le bus 47 ou 57 \u00e0 ANTOON VAN OSS (arr\u00eat du bus 56 vers BUDA).\", \"nl\": \"Tot zomer 2024, werken. Halte niet bediend. Neem bus 47 of 57 aan ANTOON VAN OSS (halte van bus 56 naar BUDA).\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"56\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"1837\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Until Summer of 2024, works. Bus 56 diverted. Stop of bus 56: avenue des Croix de l'Yser / IJzerkruisenlaan 36.\", \"fr\": \"Jusqu'\u00e0 l'\u00e9t\u00e9 2024, travaux. Bus 56 d\u00e9vi\u00e9. Arr\u00eat du bus 56 : avenue des Croix de l'Yser 36.\", \"nl\": \"Tot zomer 2024, werken. Bus 56 omgeleid. Halte van bus 56: IJzerkruisenlaan 36.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"56\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"2093\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. As of Apr 15, STOP NOT SERVED. Take bus 56 at AMBIORIX (stop of bus 64 to Bordet Station).\", \"fr\": \"Travaux. D\u00e8s le 15/4, ARRET NON DESSERVI. Prenez le bus 56 \u00e0 AMBIORIX (arr\u00eat du bus 64 vers Bordet Station).\", \"nl\": \"Werken. Vanaf 15/4, HALTE NIET BEDIEND. Neem bus 56 aan AMBIORIX (halte van bus 64 naar Bordet Station).\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"56\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"1474B\"}, {\"id\": \"2083\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Until Summer 2024,works. B56 diverted btw P. BENOIT and VAN PRAET. As of Mar 18, bus 56 serves the stop MERCATOR.\", \"fr\": \"Jsq \u00e9t\u00e9 2024, travaux. Bus 56 d\u00e9vi\u00e9 entre P. BENOIT et VAN PRAET. D\u00e8s le 18/3, bus 56 dessert \u00e0 nouveau MERCATOR.\", \"nl\": \"Tot zomer 2024, werken. Bus 56 omgeleid tss P. BENOIT en VAN PRAET. Vanaf 18/3 bedient bus 56 opnieuw MERCATOR.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"56\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"2379\"}, {\"id\": \"1991\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Until Summer of 2024, works. As of Mar 18, stop served normally by bus 57.\", \"fr\": \"Jusqu'\u00e0 l'\u00e9t\u00e9 2024, travaux. D\u00e8s le 18/3, arr\u00eat \u00e0 nouveau desservi par les bus 57.\", \"nl\": \"Tot zomer 2024, werken. Vanaf 18/3, halte opnieuw bediend door bus 57.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"57\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"2352\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Until Summer of 2024, works. Stop not served. Take bus 47 or 56 at ANTOON VAN OSS. For HOP MILITAIRE , walk.\", \"fr\": \"Jsq \u00e9t\u00e9 2024, travaux. Arr\u00eat non desservi. Bus 47 ou 56 \u00e0 ANTOON VAN OSS. Pour HOPITAL MILITAIRE, \u00e0 pied.\", \"nl\": \"Tot zomer 2024, werken. Halte niet bediend. Neem bus 47 of 56 aan ANTOON VAN OSS. Voor MILITAIR HOSPITAAL, ga te voet.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"57\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"1838\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Dec 4, works. STOP NOT SERVED. Take bus 14 and 57 under the CCN building, at the terminus of bus 61.\", \"fr\": \"D\u00e8s le 4/12, travaux. ARRET NON DESSERVI. Prenez le bus 14 et 57 sous le b\u00e2timent CCN, au terminus du bus 61.\", \"nl\": \"Vanaf 4/12, werken. HALTE NIET BEDIEND. Neem bus 14 en 57 onder het CCN-gebouw, aan eindhalte bus 61.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"57\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"1082\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Until Summer of 2024, works. Stop not served. Stop of bus 57: chauss\u00e9e de Vilvorde, in front of number 150.\", \"fr\": \"Jusqu'\u00e0 l'\u00e9t\u00e9 2024, travaux. Arr\u00eat non desservi. Arr\u00eat du bus 57: ch\u00e9e de Vilvorde, en face du num\u00e9ro 150.\", \"nl\": \"Tot zomer 2024, werken. Halte niet bediend. Halte van bus 57: Vilvoordsesteenweg, tegenover nummer 150.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"57\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"3063\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Until Summer of 2024, works. Stop not served. Stop of bus 57: MARLY.\", \"fr\": \"Jsq \u00e9t\u00e9 2024, travaux. Arr\u00eat non desservi. Arr\u00eat du bus 57 : MARLY.\", \"nl\": \"Tot zomer 2024, werken. Halte niet bediend. Halte van bus 57: MARLY.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"57\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"2360\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Dec 4, works. STOP NOT SERVED. Take bus 58 at the stop WTC of bus 14 direction UZ-VUB.\", \"fr\": \"D\u00e8s le 4/12, travaux. ARRET NON DESSERVI. Prenez le bus 58 \u00e0 l'arr\u00eat WTC du bus 14 direction UZ-VUB.\", \"nl\": \"Vanaf 4/12, werken. HALTE NIET BEDIEND. Neem bus 58 aan de halte WTC van bus 14 richting UZ-VUB.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"58\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"3400\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Oct 22, works. The stop is moved : Rue du Pavillon, 86. (Moved 20m forwards).\", \"fr\": \"A partir du 22/10, travaux. Arr\u00eat d\u00e9plac\u00e9 : rue du Pavillon, 86. (Avanc\u00e9 de 20m).\", \"nl\": \"Vanaf 22/10, werken. De halte is verplaatst : Palvijoenstraat, 86. (20m vooruitgebracht).\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"58\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"5741\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Dec 4, works. STOP NOT SERVED. Stop of bus 58 and 88 : rue du Progr\u00e8s, after crossing rue des Charbonniers.\", \"fr\": \"D\u00e8s le 4/12, travaux. ARRET NON DESSERVI. Arr\u00eat des bus 58 et 88 : rue du Progr\u00e8s, apr\u00e8s rue des Charbonniers.\", \"nl\": \"Vanaf 4/12, werken. HALTE NIET BEDIEND. Halte bus 58 en 88 : Vooruitgangstraat, na Koolbrandersstraat.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"58\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"1083\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. As of Apr 15, STOP NOT SERVED. Take bus 60 at the stop of bus 27 to LUXEMBOURG / LUXEMBURG.\", \"fr\": \"Travaux. D\u00e8s le 15/4, ARRET NON DESSERVI. Prenez le bus 60 \u00e0 l'arr\u00eat du bus 27 vers LUXEMBOURG.\", \"nl\": \"Werken. Vanaf 15/4, HALTE NIET BEDIEND. Neem bus 60 aan de halte van bus 27 naar LUXEMBURG.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"60\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"1416\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. As of Apr 15, bus 60 diverted. Take bus 60 at the previous stop, at the St-Cyr house.\", \"fr\": \"Travaux. D\u00e8s le 15/4,bus 60 d\u00e9vi\u00e9. Prenez le bus 60 \u00e0 l'arr\u00eat pr\u00e9c\u00e9dent, devant la maison Saint-Cyr.\", \"nl\": \"Werken. Vanaf 15/4, bus 60 omgeleid. Neem bus 60 aan de vorige halte, voor het St-Cyr-huis.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"60\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"1273\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Mar 11, works. Bus 60 diverted between GROELSTVELD and DE WANSIJN via DIEWEG.\", \"fr\": \"D\u00e8s le 11/3, travaux. Bus 60 d\u00e9vi\u00e9 entre GROELSTVELD et DE WANSIJN via DIEWEG.\", \"nl\": \"Vanaf 11/3, werken. Bus 60 omgeleid tussen GROELSTVELD en DE WANSIJN via DIEWEG.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"60\"}]",
+        "priority": 5,
+        "points": "[{\"id\": \"2702\"}, {\"id\": \"2701\"}, {\"id\": \"1929\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. As of Apr 15, bus 60 diverted between JOURDAN and AMBIORIX via MAELBEEK. Connection metro at MAELBEEK.\", \"fr\": \"Travaux. D\u00e8s le 15/4, bus 60 d\u00e9vi\u00e9 entre JOURDAN et AMBIORIX via MAELBEEK. Correspondance m\u00e9tro \u00e0 MAELBEEK.\", \"nl\": \"Werken. Vanaf 15/4, bus 60 omgeleid tussen JOURDAN en AMBIORIX via MAALBEEK. Aansluiting metro aan MAALBEEK.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"60\"}]",
+        "priority": 6,
+        "points": "[{\"id\": \"1884\"}, {\"id\": \"1883\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. As of Apr 15, bus 60 diverted between JOURDAN and AMBIORIX via MAELBEEK. Connection metro at MAELBEEK.\", \"fr\": \"Travaux. D\u00e8s le 15/4, bus 60 d\u00e9vi\u00e9 entre JOURDAN et AMBIORIX via MAELBEEK. Correspondance m\u00e9tro \u00e0 MAELBEEK.\", \"nl\": \"Werken. Vanaf 15/4, bus 60 omgeleid tussen JOURDAN en AMBIORIX via MAALBEEK. Aansluiting metro aan MAALBEEK.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"60\"}]",
+        "priority": 6,
+        "points": "[{\"id\": \"6453\"}, {\"id\": \"2133\"}, {\"id\": \"2132\"}, {\"id\": \"2131\"}, {\"id\": \"1250\"}, {\"id\": \"4857B\"}, {\"id\": \"4804B\"}, {\"id\": \"6956B\"}, {\"id\": \"1976\"}, {\"id\": \"1653\"}, {\"id\": \"2134\"}, {\"id\": \"1739\"}, {\"id\": \"6406\"}, {\"id\": \"2847\"}, {\"id\": \"1977\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Mar 5 at 9AM, works. STOP NOT SERVED. Temporary stop: avenue Jean & Pierre Carsoellaan 4.\", \"fr\": \"D\u00e8s le 5/3 \u00e0 9h, travaux. ARRET NON DESSERVI. Arr\u00eat provisoire: avenue Jean et Pierre Carsoel 4.\", \"nl\": \"Vanaf 5/3 om 9u, werken. HALTE NIET BEDIEND. Tijdelijke halte: Jean en Pierre Carsoellaan 4.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"60\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"6931B\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. As of April 7th, stop served only by bus 66. Take bus 29, 63 or 65 at the stop of bus 71 to DELTA.\", \"fr\": \"Travaux. D\u00e8s le 7/4, arr\u00eat uniquement desservi par bus 66. Bus 29, 63 ou 65 \u00e0 l'arr\u00eat du bus 71 vers DELTA.\", \"nl\": \"Werken. Vanaf 7/4, halte enkel bediend door bus 66. Neem bus 29, 63 of 65 aan de halte van bus 71 naar DELTA.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"65\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"6445\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Apr 14 at 7AM, works. STOP NOT SERVED. Take bus 66 at the drop off stop.\", \"fr\": \"D\u00e8s le 14/4 \u00e0 7h, travaux. ARRET NON DESSERVI. Prenez le bus 66 \u00e0 l'arr\u00eat de d\u00e9barquement.\", \"nl\": \"Vanaf 14/4 om 7u, werken. HALTE NIET BEDIEND. Neem bus 66 aan de afstaphalte.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"66\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"3284\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Jan 8-Jun 28, works. Stop not served. Stop of tram 7: av. Croix du Feu in front of av. Pagodes.\", \"fr\": \"8/1-28/6, travaux. Arr\u00eat non desservi. Arr\u00eat du tram 7: avenue des Croix du Feu, \u00e0 hauteur de l'avenue des Pagodes.\", \"nl\": \"8/1-28/6, werken. Halte niet bediend. Halte van tram 7: Vuurkruisenlaan, ter hoogte van de Pagodenlaan.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"7\"}]",
+        "priority": 5,
+        "points": "[{\"id\": \"5771\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Jan 8-Jun 28, works. Stop not served. T-bus to HEEMBEEK and DE WAND at the stop of bus 56 to BUDA.\", \"fr\": \"8/1-28/6, travaux. Arr\u00eat non desservi. T-bus vers HEEMBEEK et DE WAND \u00e0 l'arr\u00eat du bus 56 vers BUDA.\", \"nl\": \"8/1-28/6, werken. Halte niet bediend. T-bus naar HEEMBEEK en DE WAND aan de halte van bus 56 naar BUDA.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"7\"}]",
+        "priority": 5,
+        "points": "[{\"id\": \"5770F\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Jan 7, 9PM-Jun 28,works. Stop not served. Stop T-bus to DOCKS BRUXSEL: av. Croix du Feu, crossing av. Pagodes.\", \"fr\": \"7/1, 21h-28/6, travaux. Arr\u00eat non desservi.Arr\u00eat du T-bus vers DOCKS BRUXSEL: av. Croix du Feu, carr. av. Pagodes.\", \"nl\": \"7/1, 21u-28/6, werken. Halte niet bediend.Halte van de T-bus naar DOCKS BRUXSEL: Vuurkruisenln, kruispt Pagodenln.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"7\"}]",
+        "priority": 5,
+        "points": "[{\"id\": \"5706\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Jan 8 to Jun 28, works. After CHURCHILL, tram 7 continues on line 3 direction ESPLANADE.\", \"fr\": \"Du 8/1 au 28/6, travaux. Apr\u00e8s CHURCHILL, tram 7 continue sur la ligne 3 direction ESPLANADE.\", \"nl\": \"Van 8/1 tot en met 28/6, werken. Na CHURCHILL rijdt tram 7 verder op lijn 3 richting ESPLANADE.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"7\"}]",
+        "priority": 6,
+        "points": "[{\"id\": \"5307H\"}, {\"id\": \"5317G\"}, {\"id\": \"5305G\"}, {\"id\": \"5220F\"}, {\"id\": \"5200F\"}, {\"id\": \"5266F\"}, {\"id\": \"3481\"}, {\"id\": \"0821\"}, {\"id\": \"0901\"}, {\"id\": \"2246F\"}, {\"id\": \"0801\"}, {\"id\": \"5306G\"}, {\"id\": \"5308F\"}, {\"id\": \"5210\"}, {\"id\": \"5211\"}, {\"id\": \"5758F\"}, {\"id\": \"5311\"}, {\"id\": \"5212\"}, {\"id\": \"5213\"}, {\"id\": \"5312\"}, {\"id\": \"1049F\"}, {\"id\": \"6457F\"}, {\"id\": \"5303\"}, {\"id\": \"5205\"}, {\"id\": \"5208\"}, {\"id\": \"9969F\"}, {\"id\": \"0811\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Jan 8-Jun 28, works. Tram 7 replaced by T-bus between DOCKS BRUXSEL and HEEMBEEK. Info: stib-mivb.brussels\", \"fr\": \"8/1-28/6, travaux. Tram 7 remplac\u00e9 par des T-bus entre DOCKS BRUXSEL et HEEMBEEK. Info: stib. brussels.\", \"nl\": \"8/1-28/6, werken. Tram 7 vervangen door T-bus tussen DOCKS BRUXSEL en HEEMBEEK. info: mivb. brussels.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"7\"}]",
+        "priority": 6,
+        "points": "[{\"id\": \"5261\"}, {\"id\": \"5267\"}, {\"id\": \"5264F\"}, {\"id\": \"5256F\"}, {\"id\": \"1048F\"}, {\"id\": \"5355F\"}, {\"id\": \"5222F\"}, {\"id\": \"3480\"}, {\"id\": \"6456F\"}, {\"id\": \"5258\"}, {\"id\": \"0806\"}, {\"id\": \"5357\"}, {\"id\": \"0906\"}, {\"id\": \"5359\"}, {\"id\": \"0826\"}, {\"id\": \"5253\"}, {\"id\": \"5352\"}, {\"id\": \"5254\"}, {\"id\": \"5356\"}, {\"id\": \"5265F\"}, {\"id\": \"5221F\"}, {\"id\": \"5354H\"}, {\"id\": \"5255F\"}, {\"id\": \"5350G\"}, {\"id\": \"9963F\"}, {\"id\": \"0816\"}, {\"id\": \"2243F\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Jan 8-Jun 28, works. Tram 7 interrupted btw HEEMBEEK and DOCKS BXL. Stop T-bus to DOCKS BXL: next to this stop.\", \"fr\": \"8/1-28/6, travaux. T7 interrompu de HEEMBEEK \u00e0 DOCKS BXL. Arr\u00eat du T-bus vers DOCKS BXL: \u00e0 c\u00f4t\u00e9 de cet arr\u00eat.\", \"nl\": \"8/1-28/6, werken. T7 onderbroken tss HEEMBEEK en DOCKS BXL. Halte T-bus naar DOCKS BXL: naast deze halte.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"7\"}]",
+        "priority": 5,
+        "points": "[{\"id\": \"5705\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Jan 8-Jun 28, works. Tram 7 interrupted btw HEEMBEEK and DOCKS BXL. Stop of the T-bus to DOCKS BXL: av. Araucaria\", \"fr\": \"8/1-28/6, travaux. T7 interrompu de HEEMBEEK \u00e0 DOCKS BRUXSEL. Arr\u00eat du T-bus vers DOCKS BRUXSEL: av. Araucaria\", \"nl\": \"8/1-28/6, werken. T7 onderbroken tss HEEMBEEK en DOCKS BRUXSEL. Halte T-bus naar DOCKS BRUXSEL: Araucarialaan.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"7\"}]",
+        "priority": 5,
+        "points": "[{\"id\": \"5704F\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Mar 18, works. STOP NOT SERVED. Temporary stop: avenue de la Couronne / Kroonlaan 439-443.\", \"fr\": \"D\u00e8s le 18/3, travaux. ARRET NON DESSERVI. Arr\u00eat provisoire: avenue de la Couronne 439-443.\", \"nl\": \"Vanaf 18/3, werken. HALTE NIET BEDIEND. Tijdelijke halte: Kroonlaan 439-443.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"72\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"3558\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. From Apr 2 until June 2025, STOP NOT SERVED. Take bus 74 at the previous stop, FOREST CENTRE.\", \"fr\": \"Travaux. Du 2/4 \u00e0 juin 2025, ARRET NON DESSERVI. Prenez le bus 74 \u00e0 l'arr\u00eat pr\u00e9c\u00e9dent, FOREST CENTRE.\", \"nl\": \"Werken. Vanaf 2/4 tot juni 2025, HALTE NIET BEDIEND. Neem bus 74 aan de vorige halte, VORST CENTRUM.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"74\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"5719\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Apr 2, 2024 to June 2025, works. STOP NOT SERVED. Stop of bus 74: FOREST NATIONAL (av. du Globelaan 8).\", \"fr\": \"Du 2/4/2024 \u00e0 juin 2025, travaux. ARRET NON DESSERVI. Arr\u00eat des bus 74: FOREST NATIONAL. (avenue du Globe 8).\", \"nl\": \"Van 2/4/2024 tot juni 2025, werken. HALTE NIET BEDIEND. Halte van bus 74: VORST NATIONAAL (Globelaan 8)\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"74\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"2939B\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Subsidence. Bus 74 limited to DECROLY. Take bus 74 at DECROLY.\", \"fr\": \"Effondrement. Bus 74 limit\u00e9 \u00e0 DECROLY. Prenez le bus 74 \u00e0 DECROLY.\", \"nl\": \"Wegverzakking. Bus 74 beperkt tot DECROLY. Neem bus 74 aan DECROLY.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"74\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"2417\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Apr 2, 2024 to June 2025, works. STOP NOT SERVED. Stop of bus 74: av. du Globelaan 43.\", \"fr\": \"Du 2/4/2024 \u00e0 juin 2025, travaux. ARRET NON DESSERVI. Arr\u00eat du bus 74: avenue du Globe 43.\", \"nl\": \"Van 2/4/2024 tot juni 2025, werken. HALTE NIET BEDIEND. Halte van bus 74: Globelaan 43.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"74\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"2732\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Apr 2, 2024 to June 2025, works. STOP NOT SERVED. Stop of bus 74: FOREST NATIONAL (av. du Globelaan 43)\", \"fr\": \"Du 2/4/2024 \u00e0 juin 2025, travaux. ARRET NON DESSERVI. Arr\u00eat du bus 74: FOREST NATIONAL (avenue du Globe 43).\", \"nl\": \"Van 2/4/2024 tot juni 2025, werken. HALTE NIET BEDIEND. Halte van bus 74: VORST NATIONAAL (Globelaan 43)\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"74\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"2952B\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. As of Apr 15, bus 79 diverted from MICHEL-ANGE to MAELBEEK. Stop SCHUMAN moved rue Franklin.\", \"fr\": \"Travaux. D\u00e8s le 15/4, bus 79 d\u00e9vi\u00e9 depuis MICHEL-ANGE vers MAELBEEK. Arr\u00eat SCHUMAN d\u00e9plac\u00e9 rue Franklin.\", \"nl\": \"Werken. Vanaf 15/4, bus 79 omgeleid vanaf MICHELANGELO naar MAALBEEK. Halte SCHUMAN verplaatst Franklinstr.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"79\"}]",
+        "priority": 6,
+        "points": "[{\"id\": \"6450\"}, {\"id\": \"6055\"}, {\"id\": \"9853\"}, {\"id\": \"1462\"}, {\"id\": \"2043\"}, {\"id\": \"2042\"}, {\"id\": \"2041\"}, {\"id\": \"3902\"}, {\"id\": \"3903\"}, {\"id\": \"3904\"}, {\"id\": \"2028\"}, {\"id\": \"3905\"}, {\"id\": \"1533\"}, {\"id\": \"1531\"}, {\"id\": \"1464\"}, {\"id\": \"1463\"}, {\"id\": \"1320\"}, {\"id\": \"3920\"}, {\"id\": \"3911\"}, {\"id\": \"1339\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Afterwork. Every Thursday after 4PM, stop moved to rue de Tr\u00e8ves, in front of the stop in the other direction\", \"fr\": \"Afterwork. Tous les jeudis apr\u00e8s 16h, arr\u00eat d\u00e9plac\u00e9 rue de Tr\u00e8ves, en face de l'arr\u00eat dans l'autre sens.\", \"nl\": \"Afterwork.Elke donderdag na 16u, halte verplaatst naar de Trierstraat, tegenover de halte in de andere richting.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"80\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"1233\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"On May 5 until 8PM, flea market. Tram 81 interrupted. Take the tram at the stop of tram 92 to FORT-JACO.\", \"fr\": \"Le 19/5 jusqu'\u00e0 20h, brocante. Tram 81 interrompu. Prenez le tram \u00e0 l'arr\u00eat du tram 92 vers FORT-JACO.\", \"nl\": \"Op 19/5 tot 20u, rommelmarkt. Tram 81 onderbroken. Neem de tram aan de halte van tram 92 naar FORT-JACO.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"81\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"6425F\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"May 5 until 8PM, flea market. T81 interrupted between JANSON and FLAGEY. Connection T-bus at LEVURE / GIST.\", \"fr\": \"19/5 jsq 20h, brocante. Tram 81 interrompu entre JANSON et FLAGEY. Correspondance T-bus \u00e0 LEVURE.\", \"nl\": \"19/5 tot 20u, rommel- markt. T81 onderbroken tussen JANSON en FLAGEY. Aansluiting T-bus aan GIST.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"81\"}]",
+        "priority": 5,
+        "points": "[{\"id\": \"6153\"}, {\"id\": \"2286G\"}, {\"id\": \"6157F\"}, {\"id\": \"6009\"}, {\"id\": \"6156F\"}, {\"id\": \"6158H\"}, {\"id\": \"6155F\"}, {\"id\": \"6462F\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"On May 5 until 8PM, flea market. STOP NOT SERVED. Take the T-bus at JANSON: chauss\u00e9e de Charleroisesteenweg 180.\", \"fr\": \"Le 19/5 jusqu'\u00e0 20h, brocante. ARRET NON DESSERVI. Prenez le T-bus \u00e0 JANSON: chauss\u00e9e de Charleroi 180.\", \"nl\": \"Op 19/5 tot 20u, rommelmarkt. HALTE NIET BEDIEND. Neem de T-bus aan JANSON: Charleroisesteenweg 180.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"81\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"2960F\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"On May 5 until 8PM, flea market. STOP NOT SERVED. Take the tram at JANSON, at the stop of tram 92 to FORT-JACO.\", \"fr\": \"Le 19/5 jusqu'\u00e0 20h, brocante. ARRET NON DESSERVI. Prenez le tram \u00e0 JANSON, \u00e0 l'arr\u00eat du tram 92 vers FORT-JACO.\", \"nl\": \"Op 19/5 tot 20u, rommelmarkt. HALTE NIET BEDIEND. Neem de tram aan JANSON, aan halte tram 92 naar FORT-JACO.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"81\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"2931F\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"On May 5 until 8PM, flea market. Tram 81 interrupted. Stop of the T-bus: rue Lesbroussart- straat 71-73.\", \"fr\": \"Le 19/5 jusqu'\u00e0 20h, brocante. Tram 81 interrompu. Arr\u00eat du T-bus : rue Lesbroussart 71-73.\", \"nl\": \"Op 19/5 tot 20u, rommel- markt. Tram 81 onderbroken. Halte T-bus: Lesbroussart- straat 71-73.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"81\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"2380F\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"On May 5 until 8PM, flea market. STOP NOT SERVED. Stop the T-bus and B54: rue Lesbroussart, before avenue Louise.\", \"fr\": \"19/5 jsq 20h, brocante. ARRET NON DESSERVI. Arr\u00eat du T-bus et B54 : rue Lesbroussart, avant avenue Louise.\", \"nl\": \"Op 19/5 tot 20u, rommelmarkt. HALTE NIET BEDIEND. Halte T-bus en B54: Lesbroussartstraat, voor Louizalaan.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"81\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"2972F\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"On May 5 until 8PM, flea market. Tram 81 replaced by a T-bus between JANSON and LEVURE / GIST.\", \"fr\": \"Le 19/5 jusqu'\u00e0 20h, brocante. Tram 81 remplac\u00e9 par des T-bus entre JANSON et LEVURE.\", \"nl\": \"Op 19/5 tot 20u, rommelmarkt. Tram 81 vervangen door T-bus tussen JANSON en GIST.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"81\"}]",
+        "priority": 5,
+        "points": "[{\"id\": \"6099\"}, {\"id\": \"6077F\"}, {\"id\": \"6121F\"}, {\"id\": \"3611F\"}, {\"id\": \"2539F\"}, {\"id\": \"3612F\"}, {\"id\": \"3613F\"}, {\"id\": \"3371F\"}, {\"id\": \"6858G\"}, {\"id\": \"0631\"}, {\"id\": \"6705F\"}, {\"id\": \"2260F\"}, {\"id\": \"6799F\"}, {\"id\": \"6106\"}, {\"id\": \"6860G\"}, {\"id\": \"2259F\"}, {\"id\": \"6856\"}, {\"id\": \"2257G\"}, {\"id\": \"6857\"}, {\"id\": \"6109\"}, {\"id\": \"2331F\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"On May 5 until 8PM, flea market. STOP NOT SERVED. Stop T-bus and bus 54: crossing Lesbroussart- Louise, on tram tracks.\", \"fr\": \"19/5 jsq 20h, brocante. ARRET NON DESSERVI. Arr\u00eat T-bus et B54: carrefour Lesbroussart- Louise, sur les voies.\", \"nl\": \"19/5 tot 20u,rommelmarkt HALTE NIET BEDIEND. Halte T-bus en B54: kruispunt Lesbroussart- Louiza, op tramsporen.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"81\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"2971F\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. Until 2026, stop not served. Stop of the T-bus: Grote Baan 227 (stop of De Lijn to Anderlecht).\", \"fr\": \"Travaux. Jsq 2026, arr\u00eat non desservi. Arr\u00eat du T-bus: Grand'Route 227 (arr\u00eat des bus De Lijn vers Anderlecht).\", \"nl\": \"Werken. Tot 2026, halte niet bediend. Halte van de T-bus: Grote Baan 227 (halte van De Lijn naar Anderlecht).\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"82\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"5732F\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. Until 2026, tram 82 and 97 interrupted. Stop of the T-bus and of bus 50: ch. de Neerstalsestwg 236.\", \"fr\": \"Travaux. Jsq 2026, tram 82 et 97 interrompus. Arr\u00eat du T-bus et du bus 50: chauss\u00e9e de Neerstalle 236\", \"nl\": \"Werken. Tot 2026, tram 82 en 97 onderbroken. Halte van de T-bus en van bus 50: Neerstalsesteenweg 236\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"82\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"5164F\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Until 2026, works. T-bus 82/97 diverted. Stop T-bus 82/97: bd 2e Arm\u00e9e Britannique / Britse Tweedelegerlaan.\", \"fr\": \"Jsq 2026, travaux. T-bus 82/97 d\u00e9vi\u00e9. Arr\u00eat T-bus 82/97: bd 2e Arm\u00e9e Britannique, carrefour rue de la Station.\", \"nl\": \"Tot 2026, werken. T-bus 82/97 omgeleid. Halte T-bus 82/97: Britse Tweedelegerlaan, kruispunt Stationstraat.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"82\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"5719H\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Until 2026,works.Tram 82 replaced by T-bus btw FOREST CENTRE / VORST CENTRUM and DROGENBOS. More info: stib-mivb.be.\", \"fr\": \"Jusqu'en 2026, travaux. Tram 82 remplac\u00e9 par des T-bus entre FOREST CENTRE et DROGENBOS. Info: stib.brussels.\", \"nl\": \"Tot 2026, werken. Tram 82 wordt vervangen door T-bus tussen VORST CENTRUM en DROGENBOS. Info: mivb.brussels.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"82\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"5163F\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Jan 22, 6AM-end of June, works. Bus 86 diverted between GARE DE L'OUEST/ WESTSTATION and SUZAN DANIEL via ETANGS NOIRS.\", \"fr\": \"Du 22/1 \u00e0 6h jusqu'\u00e0 fin juin, travaux. Bus 86 d\u00e9vi\u00e9 entre GARE DE L'OUEST et SUZAN DANIEL via ETANGS NOIRS.\", \"nl\": \"Van 22/1 om 6u tot eind juni, werken. Bus 86 omgeleid tussen WESTSTATION-SUZAN DANIEL via ZWARTE VIJVERS.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"86\"}]",
+        "priority": 5,
+        "points": "[{\"id\": \"3238\"}, {\"id\": \"3234\"}, {\"id\": \"3253\"}, {\"id\": \"3252\"}, {\"id\": \"3282\"}, {\"id\": \"3281\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"As of Nov 16 at 6AM, works. Stop moved to av. Port / Havenln, in front of number 100 (moved backward of +/- 120m)\", \"fr\": \"D\u00e8s le 16/11 \u00e0 6h, travaux. Arr\u00eat d\u00e9plac\u00e9 avenue du Port, en face du num\u00e9ro 100 (recul\u00e9 de +/- 120m).\", \"nl\": \"Vanaf 16/11 om 6u,werken Halte verplaatst naar de Havenlaan, tegenover nr 100 (achteruitgebracht van +/- 120m)\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"86\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"2305\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From May 6, works. STOP NOT SERVED. Take bus 89 to NEERPEDE at the stop of bus 53 to WESTLAND SHOPPING.\", \"fr\": \"D\u00e8s le 6/5, travaux. ARRET NON DESSERVI. Bus 89 vers NEERPEDE \u00e0 l'arr\u00eat du bus 53 vers WESTLAND SHOPPING.\", \"nl\": \"Vanaf 6/5, werken. HALTE NIET BEDIEND. Neem bus 89 naar NEERPEDE aan de halte van bus 53 naar WESTLAND SHOPPING.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"89\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"1261\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From May 6, works. Bus 89 extended to NEERPEDE. Stop WESTLAND SHOPPING relocated.\", \"fr\": \"D\u00e8s le 6/5, travaux. Bus 89 prolong\u00e9 jusqu'\u00e0 NEERPEDE. Arr\u00eat WESTLAND SHOPPING d\u00e9plac\u00e9.\", \"nl\": \"Vanaf 6/5, werken. Bus 89 verlengd tot NEERPEDE. Halte WESTLAND SHOPPING verplaatst.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"89\"}]",
+        "priority": 5,
+        "points": "[{\"id\": \"2779\"}, {\"id\": \"2768\"}, {\"id\": \"3638\"}, {\"id\": \"1117\"}, {\"id\": \"1257\"}, {\"id\": \"2750\"}, {\"id\": \"2783\"}, {\"id\": \"2781\"}, {\"id\": \"1260\"}, {\"id\": \"3636\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. As of Apr 22 at 9.30AM, bus 89 diverted btw TRIANGLE and QUATRE- VENTS. For DUCHESSE, T82 at TRIANGLE.\", \"fr\": \"Travaux. D\u00e8s le 22/4 \u00e0 9h30, bus 89 d\u00e9vi\u00e9 entre TRIANGLE et QUATRE- VENTS. Pour DUCHESSE, tram 82 \u00e0 TRIANGLE.\", \"nl\": \"Werken. Vanaf 22/4 om 9. 30u, bus 89 omgeleid tussen DRIEHOEK en VIER WINDEN. Voor HERTOGIN, tram 82 aan DRIEHOEK.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"89\"}]",
+        "priority": 5,
+        "points": "[{\"id\": \"3347\"}, {\"id\": \"2301\"}, {\"id\": \"2595\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. As of Apr 22 at 9.30AM, bus 89 diverted btw TRIANGLE and QUATRE- VENTS. For DUCHESSE, T82 at TRIANGLE.\", \"fr\": \"Travaux. D\u00e8s le 22/4 \u00e0 9h30, bus 89 d\u00e9vi\u00e9 entre TRIANGLE et QUATRE- VENTS. Pour DUCHESSE, tram 82 \u00e0 TRIANGLE.\", \"nl\": \"Werken. Vanaf 22/4 om 9. 30u, bus 89 omgeleid tussen DRIEHOEK en VIER WINDEN. Voor HERTOGIN, tram 82 aan DRIEHOEK.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"89\"}]",
+        "priority": 5,
+        "points": "[{\"id\": \"1895\"}, {\"id\": \"3223B\"}, {\"id\": \"3222\"}, {\"id\": \"3221\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From May 6, works. STOP NOT SERVED. Take bus 89 at the stop of bus 53 to HOPITAL MILITAIRE / MILITAIR HOSPITAAL.\", \"fr\": \"D\u00e8s le 6/5, travaux. ARRET NON DESSERVI. Prenez le bus 89 \u00e0 l'arr\u00eat du bus 53 vers HOPITAL MILITAIRE.\", \"nl\": \"Vanaf 6/5, werken. HALTE NIET BEDIEND. Neem bus 89 aan de halte van bus 53 naar MILITAIR HOSPITAAL.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"89\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"1203\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Until 2026, works. As of Mar 11, tram 97 interrupted between WIELS and DIEWEG. Take tram 4 to go to GLOBE.\", \"fr\": \"Jsq 2026,travaux. D\u00e8s le 11/3, tram 97 interrompu entre WIELS et DIEWEG. Prenez le tram 4 pour rejoindre GLOBE.\", \"nl\": \"Tot 2026, werken. Vanaf 11/3, tram 97 onderbroken tussen WIELS en DIEWEG. Neem tram 4 om naar GLOBE te gaan.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"97\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"5916F\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Until 2026, works. As of Mar 11, tram 97 interrupted to DIEWEG. For GLOBE, tram 4 at CARR. STALLE via T-bus.\", \"fr\": \"Jsq 2026,travaux. D\u00e8s le 11/3, tram 97 interrompu jsq DIEWEG. Pour GLOBE, tram 4 \u00e0 CARREFOUR STALLE via T-bus.\", \"nl\": \"Tot 2026, werken. Vanaf 11/3,tram 97 onderbroken tot DIEWEG. Voor GLOBE, neem tram 4 aan KRUISPT STALLE via T-bus.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"97\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"5722F\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Until 2026, works. Stop not served. Stop of the T-bus: rue de la Soierie / Zijdeweverijstraat 4.\", \"fr\": \"Jusqu'en 2026, travaux. Arr\u00eat non desservi. Arr\u00eat du T-bus: rue de la Soierie 4.\", \"nl\": \"Tot 2026, werken. Halte niet bediend. Halte van de T-bus: Zijdeweverijstraat 4.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"97\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"5154F\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Until 2026, works. Tram 97 interrupted to WIELS. Take tram 82 to go to WIELS.\", \"fr\": \"Jusqu'en 2026, travaux. Tram 97 interrompu jusqu'\u00e0 WIELS. Pour rejoindre WIELS, prenez le tram 82.\", \"nl\": \"Tot 2026, werken. Tram 97 onderbroken tot WIELS. Neem tram 82 om naar WIELS te gaan.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"97\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"5151\"}, {\"id\": \"2668\"}, {\"id\": \"5155\"}, {\"id\": \"2667F\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Until 2026, works. As of Mar 11, tram 97 operated only btw LOUISE and WIELS. T-bus: av. Reine Marie-Henriette 1A\", \"fr\": \"Jsq 2026,travaux. D\u00e8s le 11/3, tram 97 circule uniquement entre LOUISE et WIELS. T-bus: av. Reine Marie-Henriette 1A\", \"nl\": \"Tot 2026, werken. Vanaf 11/3 rijdt tram 97 enkel tussen LOUIZA en WIELS. T-bus: Koningin Maria-Hendrikaln 1A\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"97\"}]",
+        "priority": 5,
+        "points": "[{\"id\": \"5115F\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Until 2026, works. As of Mar 11, tram 97 interrupted between WIELS and DIEWEG. Take tram 4 to go to GLOBE.\", \"fr\": \"Jsq 2026,travaux. D\u00e8s le 11/3, tram 97 interrompu entre WIELS et DIEWEG. Prenez le tram 4 pour rejoindre GLOBE.\", \"nl\": \"Tot 2026, werken. Vanaf 11/3, tram 97 onderbroken tussen WIELS en DIEWEG. Neem tram 4 om naar GLOBE te gaan.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"97\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"5917F\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Werken. 17/5, 21u-20/5, T-bus 19 diverted from GUILL. DE GREEF to DE WAND. HOP. BRUGMANN served by tram 51 93\", \"fr\": \"Travaux. 17/5, 21h-20/5, T-bus 19 d\u00e9vi\u00e9 depuis GUILL. DE GREEF vers DE WAND. HOP. BRUGMANN desservi par tram 51 93\", \"nl\": \"Werken. 17/5, 21u-20/5, T-bus 19 omgeleid vanaf GUILL. DE GREEF naar DE WAND. BRUGMANN-ZKH bediend door tram 51 93\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"T19\"}]",
+        "priority": 5,
+        "points": "[{\"id\": \"1767\"}, {\"id\": \"2515B\"}, {\"id\": \"6865\"}, {\"id\": \"6864\"}, {\"id\": \"1183\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"As of Oct 25, stop moved +/- 50m behind, side square Lain\u00e9square.\", \"fr\": \"D\u00e8s le 25/10, arr\u00eat recul\u00e9 de +/- 50m, c\u00f4t\u00e9 square Lain\u00e9\", \"nl\": \"Vanaf 25/10, werken. Halte achteruitgebracht van +/- 50m, kant Lain\u00e9square.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"T82\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"2023\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Until 2026, works. Stop of T-bus 82/97: ch. de Neerstalsesteenweg in front of 348.\", \"fr\": \"Jusqu'en 2026, travaux. Arr\u00eat du T-bus 82/97: chauss\u00e9e de Neerstalle, en face du num\u00e9ro 348.\", \"nl\": \"Tot 2026, werken. Halte van T-bus 82/97: Neerstalsesteenweg, tegenover nummer 348.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"T82\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"3242\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Apr 3 at 6AM, works. STOP NOT SERVED. Bus 38 at GOSSART (avenue Winston Churchilllaan 187).\", \"fr\": \"D\u00e8s le 3/4 \u00e0 6h, travaux. ARRET NON DESSERVI. Bus 38 \u00e0 GOSSART (avenue Winston Churchill 187).\", \"nl\": \"Vanaf 3/4 om 6u, werken. HALTE NIET BEDIEND. Bus 38 aan GOSSART (Winston Churchilllaan 187).\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"38\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"1972\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Apr 3 at 6AM, works. STOP NOT SERVED. Take bus 38 and 41 at the previous stop, HOUZEAU.\", \"fr\": \"D\u00e8s le 3/4 \u00e0 6h, travaux. ARRET NON DESSERVI. Prenez les bus 38 et 41 \u00e0 l'arr\u00eat pr\u00e9c\u00e9dent, HOUZEAU.\", \"nl\": \"Vanaf 3/4 om 6u, werken. HALTE NIET BEDIEND. Neem bus 38 en 41 aan de vorige halte, HOUZEAU.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"38\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"1970\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Apr 3 at 6AM, works. Bus 38 diverted between LONGCHAMP and HOUZEAU via rue Edith Cavellstraat.\", \"fr\": \"D\u00e8s le 3/4 \u00e0 6h, travaux. Bus 38 d\u00e9vi\u00e9 entre LONGCHAMP et HOUZEAU via rue Edith Cavell.\", \"nl\": \"Vanaf 3/4 om 6u, werken. Bus 38 omgeleid tussen LONGCHAMP en HOUZEAU via Edith Cavellstraat.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"38\"}]",
+        "priority": 5,
+        "points": "[{\"id\": \"1913\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. As of April 7th, bus 38 diverted. Take bus 38 at the next stop, ROYALE / KONING.\", \"fr\": \"Travaux. D\u00e8s le 7/4, bus 38 d\u00e9vi\u00e9. Prenez le bus 38 \u00e0 l'arr\u00eat suivant, ROYALE.\", \"nl\": \"Werken. Vanaf 7/4, bus 38 omgeleid. Neem bus 38 aan de volgende halte, KONING.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"38\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"3502\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Apr 3 at 6AM, works. STOP NOT SERVED. Bus 38 at GOSSART (avenue Winston Churchilllaan 202).\", \"fr\": \"D\u00e8s le 3/4 \u00e0 6h, travaux. ARRET NON DESSERVI. Bus 38 \u00e0 GOSSART (avenue Winston Churchill 202).\", \"nl\": \"Vanaf 3/4 om 6u, werken. HALTE NIET BEDIEND. Bus 38 aan GOSSART (Winston Churchilllaan 202).\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"38\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"1918\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Apr 3 at 6AM, works. Bus 38 diverted between LONGCHAMP and HOUZEAU via rue Edith Cavellstraat.\", \"fr\": \"D\u00e8s le 3/4 \u00e0 6h, travaux. Bus 38 d\u00e9vi\u00e9 entre LONGCHAMP et HOUZEAU via rue Edith Cavell.\", \"nl\": \"Vanaf 3/4 om 6u, werken. Bus 38 omgeleid tussen LONGCHAMP en HOUZEAU via Edith Cavellstraat.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"38\"}]",
+        "priority": 5,
+        "points": "[{\"id\": \"1916\"}, {\"id\": \"1915\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Apr 3 at 6AM, works. STOP NOT SERVED. Temporary stop: chauss\u00e9e de Waterloosesteenweg 803, stop De Fr\u00e9 of TEC.\", \"fr\": \"D\u00e8s 3/4 \u00e0 6h, travaux. ARRET NON DESSERVI. Arr\u00eat provisoire: ch. de Waterloo 803, arr\u00eat De Fr\u00e9 des TEC.\", \"nl\": \"Vanaf 3/4 om 6u, werken. HALTE NIET BEDIEND. Tijdelijke halte: Waterloosesteenweg 803, halte De Fr\u00e9 van TEC.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"41\"}]",
+        "priority": 5,
+        "points": "[{\"id\": \"2763\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Apr 3 at 6AM, works. STOP NOT SERVED. Temporary stop: chauss\u00e9e de Waterloosesteenweg 965, stop of TEC.\", \"fr\": \"D\u00e8s le 3/4 \u00e0 6h, travaux. ARRET NON DESSERVI. Arr\u00eat provisoire: chauss\u00e9e de Waterloo 965, arr\u00eat TEC.\", \"nl\": \"Vanaf 3/4 om 6u, werken. HALTE NIET BEDIEND. Tijdelijke halte: Waterloosesteenweg 965, halte van TEC.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"41\"}]",
+        "priority": 5,
+        "points": "[{\"id\": \"2714\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Apr 3 at 6AM, works. Bus 41 diverted between VERT CHASSEUR / GROENE JAGER and HOUZEAU via rue Edith Cavell.\", \"fr\": \"D\u00e8s le 3/4 \u00e0 6h, travaux. Bus 41 d\u00e9vi\u00e9 entre VERT CHASSEUR et HOUZEAU via rue Edith Cavell.\", \"nl\": \"Vanaf 3/4 om 6u, werken. Bus 41 omgeleid tussen GROENE JAGER en HOUZEAU via Edith Cavellstraat.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"41\"}]",
+        "priority": 5,
+        "points": "[{\"id\": \"5451\"}, {\"id\": \"4452\"}, {\"id\": \"4454\"}, {\"id\": \"2107\"}, {\"id\": \"2018\"}, {\"id\": \"1754\"}, {\"id\": \"1753\"}, {\"id\": \"2016\"}, {\"id\": \"1752\"}, {\"id\": \"2762\"}, {\"id\": \"2079\"}, {\"id\": \"4455\"}, {\"id\": \"4456\"}, {\"id\": \"6468\"}, {\"id\": \"5458\"}, {\"id\": \"4358\"}, {\"id\": \"5459\"}, {\"id\": \"6439\"}, {\"id\": \"4449\"}, {\"id\": \"1725\"}, {\"id\": \"4407\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Mar 4, works. Bus 43 and N11 diverted. Weekdays before 8PM: B43 at BRAVES. Otherwise: bus at GRIOTTES.\", \"fr\": \"D\u00e8s le 4/3, travaux. Bus 43 et N11 d\u00e9vi\u00e9s. En semaine avant 20h: B43 \u00e0 BRAVES. Autres moments: bus \u00e0 GRIOTTES.\", \"nl\": \"Vanaf 4/3, werken. Bus 43 en N11 omgeleid. Weekdagen voor 20u: B43 aan DAPPEREN. Anders: bus aan NOORDKRIEKEN.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"43\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"1963\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Enjoy your trip on our lines !\", \"fr\": \"Bon voyage sur nos lignes !\", \"nl\": \"Geniet van uw reis op onze lijnen !\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"44\"}]",
+        "priority": 9,
+        "points": "[{\"id\": \"9552\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. Until end of August, B46 not operated btw WTC-GLIBERT and PTE ANDERLECHT. For the center, bus 88 at WTC.\", \"fr\": \"Travaux. Jsq fin ao\u00fbt, B46 ne circule pas entre WTC-GLIBERT et PORTE D'ANDERLECHT. Pour le centre, bus 88 \u00e0 WTC.\", \"nl\": \"Werken. Tot einde augustus rijdt bus 46 niet tss WTC-GLIBERT en ANDERLECHTSEPT. Voor het centrum,neem B88 aan WTC\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"46\"}]",
+        "priority": 5,
+        "points": "[{\"id\": \"9025\"}, {\"id\": \"1896\"}, {\"id\": \"2209\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Until end of August, works. Bus 46 interrupted. Take bus 46 at ANNEESSENS (via bus 33).\", \"fr\": \"Jusque fin ao\u00fbt, travaux. Bus 46 interrompu. Prenez le bus 46 \u00e0 ANNEESSENS (via bus 33).\", \"nl\": \"Tot einde augustus, werken. Bus 46 onderbroken. Neem bus 46 aan ANNEESSENS (via bus 33).\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"46\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"1895\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Until end of August 2024, works. Stop not served. Walk to WTC-GLIBERT.\", \"fr\": \"Jusque fin ao\u00fbt 2024, travaux. Arr\u00eat non desservi. Continuez \u00e0 pied pour WTC-GLIBERT.\", \"nl\": \"Tot einde augustus 2024, werken. halte niet bediend. Ga te voet verder om naar WTC-GLIBERT te gaan.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"46\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"1894\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Until Summer of 2024, works. As of Mar 4, stop of bus 47: Military Area, stop of bus 57 to GARE DU NORD.\", \"fr\": \"Jsq \u00e9t\u00e9 2024, travaux. D\u00e8s le 4/3, arr\u00eat du bus 47 : Domaine Militaire, arr\u00eat du bus 57 vers GARE DU NORD.\", \"nl\": \"Tot zomer 2024, werken. Vanaf 4/3, halte van bus 47: Militair Domein, halte van bus 57 naar NOORDSTATION..\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"47\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"3068\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Until Summer of 2024, works. Stop not served. Take bus 47 or 57 at ANTOON VAN OSS (stop of bus 56 to BUDA).\", \"fr\": \"Jsq \u00e9t\u00e9 2024, travaux. Arr\u00eat non desservi. Prenez le bus 47 ou 57 \u00e0 ANTOON VAN OSS (arr\u00eat du bus 56 vers BUDA).\", \"nl\": \"Tot zomer 2024, werken. Halte niet bediend. Neem bus 47 of 57 aan ANTOON VAN OSS (halte van bus 56 naar BUDA).\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"47\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"1837\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Until Summer of 2024, works. Stop not served. Take bus 47 at the stop of bus 56 to BUDA.\", \"fr\": \"Jusqu'\u00e0 l'\u00e9t\u00e9 2024, travaux. Arr\u00eat non desservi. Prenez le bus 47 \u00e0 l'arr\u00eat du bus 56 vers BUDA.\", \"nl\": \"Tot zomer 2024, werken. Halte niet bediend. Neem bus 47 aan de halte van bus 56 naar BUDA.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"47\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"2358\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. STOP NOT SERVED. B47: at the stop CROIX DE GUERRE of B56 (av. des Croix de Guerre)\", \"fr\": \"Travaux. ARRET NON DESSERVI. B47 : \u00e0 l'arr\u00eat CROIX DE GUERRE du B56 (av. des Croix de Guerre)\", \"nl\": \"Werken. HALTE NIET BEDIEND. B47: aan de halte OORLOGSKRUISEN van B56 (Oorlogskruisenlaan)\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"47\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"2362B\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Oct 18 9.30AM, stop not served. Go to the previous stop : HELDENPLEIN.\", \"fr\": \"A partir du 18/10 9h30, arr\u00eat non desservi. Rejoignez l'arr\u00eat pr\u00e9c\u00e9dent : HELDENPLEIN.\", \"nl\": \"Vanaf 18/10 9u30, halte niet bediend. Ga naar de vorige halte HELDENPLEIN.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"47\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"9787\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Until Summer of 2024, works. Stop of bus 47: rue de Ransbeekstraat 201.\", \"fr\": \"Jusqu'\u00e0 l'\u00e9t\u00e9 2024, travaux. Arr\u00eat du bus 47: rue de Ransbeek 201.\", \"nl\": \"Tot zomer 2024, werken. Halte van bus 47: Ransbeekstraat 201.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"47\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"2360\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. Until 2026, tram 82 and 97 interrupted. Stop of the T-bus and of bus 50: ch. de Neerstalsestwg 236.\", \"fr\": \"Travaux. Jsq 2026, tram 82 et 97 interrompus. Arr\u00eat du T-bus et du bus 50: chauss\u00e9e de Neerstalle 236\", \"nl\": \"Werken. Tot 2026, tram 82 en 97 onderbroken. Halte van de T-bus en van bus 50: Neerstalsesteenweg 236\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"50\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"3604\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Until 2026, works. Bus 50 and T-bus diverted between FOREST CENTRE / VORST CENTRUM and BEMPT.\", \"fr\": \"Jusqu'en 2026, travaux. Bus 50 et T-bus d\u00e9vi\u00e9s entre FOREST CENTRE et BEMPT.\", \"nl\": \"Tot 2026, werken. Bus 50 en T-bus omgeleid tussen VORST CENTRUM en BEMPT.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"50\"}]",
+        "priority": 5,
+        "points": "[{\"id\": \"5915\"}, {\"id\": \"2548\"}, {\"id\": \"2546\"}, {\"id\": \"2544\"}, {\"id\": \"2555\"}, {\"id\": \"1015\"}, {\"id\": \"2553\"}, {\"id\": \"3211\"}, {\"id\": \"2539\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Until 2026, works. Bus 50 diverted. Stop bus 50: bd 2e Arm\u00e9e Britannique / Britse Tweedelegerlaan.\", \"fr\": \"Jsq 2026, travaux. Bus 50 d\u00e9vi\u00e9. Arr\u00eat bus 50: bd 2e Arm\u00e9e Britannique, carrefour rue de la Station.\", \"nl\": \"Tot 2026, werken. Bus 50 omgeleid. Halte bus 50: Britse Tweedelegerlaan, kruispunt Stationstraat.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"50\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"5719\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From May 18, 5AM, works. STOP NOT SERVED. Stop of bus 52: avenue du Parc / Parklaan 26, in front of number 26.\", \"fr\": \"D\u00e8s le 18/5, 5h, travaux. ARRET NON DESSERVI. Arr\u00eat du bus 52: avenue du Parc, en face du num\u00e9ro 26.\", \"nl\": \"Vanaf 18/5, 5u, werken. HALTE NIET BEDIEND. Halte van bus 52: Parklaan, tegenover nummer 26.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"52\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"2334B\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. As of Apr 15 at 6AM, STOP NOT SERVED. Take bus 53 at BEYSEGHEM / BEIZEGEM.\", \"fr\": \"Travaux. D\u00e8s le 15/4 \u00e0 6h, ARRET NON DESSERVI. Prenez le bus 53 \u00e0 BEYSEGHEM.\", \"nl\": \"Werken. Vanaf 15/4 om 6u, HALTE NIET BEDIEND. Neem bus 53 aan BEIZEGEM.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"53\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"2819\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. As of Apr 15 at 6AM, bus 53 diverted between BEYSEGHEM / BEIZEGEM and PETER BENOIT.\", \"fr\": \"Travaux. D\u00e8s le 15/4 \u00e0 6h, bus 53 d\u00e9vi\u00e9 entre BEYSEGHEM et PETER BENOIT.\", \"nl\": \"Werken. Vanaf 15/4 om 6u, bus 53 omgeleid tussen BEIZEGEM en PETER BENOIT.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"53\"}]",
+        "priority": 5,
+        "points": "[{\"id\": \"2813B\"}, {\"id\": \"2815B\"}, {\"id\": \"2566B\"}, {\"id\": \"2572\"}, {\"id\": \"2571\"}, {\"id\": \"2570\"}, {\"id\": \"3085\"}, {\"id\": \"2171\"}, {\"id\": \"2647\"}, {\"id\": \"2569\"}, {\"id\": \"2547\"}, {\"id\": \"2568\"}, {\"id\": \"2567\"}, {\"id\": \"4132B\"}, {\"id\": \"2565\"}, {\"id\": \"2564\"}, {\"id\": \"2809\"}, {\"id\": \"2573B\"}, {\"id\": \"2648\"}, {\"id\": \"2824\"}, {\"id\": \"3637\"}, {\"id\": \"1767\"}, {\"id\": \"2811\"}, {\"id\": \"1204\"}, {\"id\": \"2810\"}, {\"id\": \"2575\"}, {\"id\": \"2817\"}, {\"id\": \"2816\"}, {\"id\": \"2814\"}, {\"id\": \"3605\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. As of Apr 15 at 6AM, STOP NOT SERVED. Take bus 53 at BEYSEGHEM / BEIZEGEM.\", \"fr\": \"Travaux. D\u00e8s le 15/4 \u00e0 6h, ARRET NON DESSERVI. Prenez le bus 53 \u00e0 BEYSEGHEM.\", \"nl\": \"Werken. Vanaf 15/4 om 6u, HALTE NIET BEDIEND. Neem bus 53 aan BEIZEGEM.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"53\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"2852\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Until Summer of 2024, works. Stop not served. Stop of bus 53: place Peter Benoitplein 3\", \"fr\": \"Jusqu'\u00e0 l'\u00e9t\u00e9 2024, travaux. Arr\u00eat non desservi. Arr\u00eat du bus 53 : place Peter Benoit 3\", \"nl\": \"Tot zomer 2024, werken. Halte niet bediend. Halte van bus 53: Peter Benoitplein 3\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"53\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"2362B\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"On May 19 until 8PM, flea market. Bus 54 diverted between MA CAMPAGNE and BAILLI / BALJUW.\", \"fr\": \"Le 19/5 jusqu'\u00e0 20h, brocante. Bus 54 d\u00e9vi\u00e9 entre MA CAMPAGNE et BAILLI.\", \"nl\": \"Op 19/5 tot 20u, rommelmarkt. Bus 54 omgeleid tussen MA CAMPAGNE en BALJUW.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"54\"}]",
+        "priority": 5,
+        "points": "[{\"id\": \"3243\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Apr 2, 2024 to June 2025, works. STOP NOT SERVED. Take bus 54 at the next stop, FOREST NATIONAL.\", \"fr\": \"Du 2/4/2024 \u00e0 juin 2025, travaux. ARRET NON DESSERVI. Prenez le bus 54 \u00e0 l'arr\u00eat suivant, FOREST NATIONAL.\", \"nl\": \"Van 2/4/2024 tot juni 2025, werken. HALTE NIET BEDIEND. Neem bus 54 aan de volgende halte, VORST NATIONAAL.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"54\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"2952B\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"On May 19 until 8PM, flea market. Bus 54 diverted between BAILLI / BALJUW and MA CAMPAGNE.\", \"fr\": \"Le 19/5 jusqu'\u00e0 20h, brocante. Bus 54 d\u00e9vi\u00e9 entre BAILLI et MA CAMPAGNE.\", \"nl\": \"Op 19/5 tot 20u, rommelmarkt. Bus 54 omgeleid tussen BALJUW en MA CAMPAGNE.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"54\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"1734\"}, {\"id\": \"1780\"}, {\"id\": \"2929\"}, {\"id\": \"2928\"}, {\"id\": \"3518B\"}, {\"id\": \"3506\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Apr 2, 2024 to June 2025, works. STOP NOT SERVED. Stop of bus 54 and 74: avenue du Globelaan 8.\", \"fr\": \"Du 2/4/2024 \u00e0 juin 2025, travaux. ARRET NON DESSERVI. Arr\u00eat des bus 54 et 74: avenue du Globe 8.\", \"nl\": \"Van 2/4/2024 tot juni 2025, werken. HALTE NIET BEDIEND. Halte van bus 54 en 74: Globelaan 8.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"54\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"2616B\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"On May 19 until 8PM, flea market. Stop not served. Stop of bus 54: chauss\u00e9e de Waterloo / Waterloosesteenweg 394.\", \"fr\": \"Le 19/5 jusqu'\u00e0 20h, brocante. Arr\u00eat non desservi. Arr\u00eat du bus 54: chauss\u00e9e de Waterloo, 394.\", \"nl\": \"Op 19/5 tot 20u, rommelmarkt. Halte niet bediend. Halte van bus 54: Waterloosesteenweg 394.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"54\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"2932\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"On May 5 until 8PM, flea market. STOP NOT SERVED. Stop the T-bus and B54: rue Lesbroussart, before avenue Louise.\", \"fr\": \"19/5 jsq 20h, brocante. ARRET NON DESSERVI. Arr\u00eat du T-bus et B54 : rue Lesbroussart, avant avenue Louise.\", \"nl\": \"Op 19/5 tot 20u, rommelmarkt. HALTE NIET BEDIEND. Halte T-bus en B54: Lesbroussartstraat, voor Louizalaan.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"54\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"2972\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. As of Apr 15, bus 56 diverted. Take bus 56 at the previous stop, at the St-Cyr house.\", \"fr\": \"Travaux. D\u00e8s le 15/4, bus 56 d\u00e9vi\u00e9. Prenez le bus 56 \u00e0 l'arr\u00eat pr\u00e9c\u00e9dent, devant la maison Saint-Cyr.\", \"nl\": \"Werken. Vanaf 15/4, bus 56 omgeleid. Neem bus 56 aan de vorige halte, voor het St-Cyr-huis.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"56\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"1273\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"As of Nov 14, stop moved to avenue Van Praetlaan, after Van Praet bridge.\", \"fr\": \"D\u00e8s le 14/11, arr\u00eat d\u00e9plac\u00e9 avenue Van Praet, apr\u00e8s le pont Van Praet.\", \"nl\": \"Vanaf 14/11, halte verplaatst naar de Van Praetlaan, na het Van Praetbrug.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"56\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"6370\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Until Summer of 2024, works. As of March 18, buses 56 and 57 serve this stop normally.\", \"fr\": \"Jusqu'\u00e0 l'\u00e9t\u00e9 2024, travaux. D\u00e8s le 18/3, les bus 56 et 57 desservent \u00e0 nouveau cet arr\u00eat.\", \"nl\": \"Tot zomer 2024, werken. Vanaf 18/3 bedienen bus 56 en 57 opnieuw deze halte.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"56\"}]",
+        "priority": 5,
+        "points": "[{\"id\": \"1839\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Until Summer of 2024, works. Stop not served. Take bus 47 or 56 at ANTOON VAN OSS. For HOP MILITAIRE , walk.\", \"fr\": \"Jsq \u00e9t\u00e9 2024, travaux. Arr\u00eat non desservi. Bus 47 ou 56 \u00e0 ANTOON VAN OSS. Pour HOPITAL MILITAIRE, \u00e0 pied.\", \"nl\": \"Tot zomer 2024, werken. Halte niet bediend. Neem bus 47 of 56 aan ANTOON VAN OSS. Voor MILITAIR HOSPITAAL, ga te voet.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"56\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"1838\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Until Summer of 2024, works. As of Mar 18, stop served normally by bus 56.\", \"fr\": \"Jusqu'\u00e0 l'\u00e9t\u00e9 2024, travaux. D\u00e8s le 18/3, arr\u00eat \u00e0 nouveau desservi par les bus 56.\", \"nl\": \"Tot zomer 2024, werken. Vanaf 18/3, halte opnieuw bediend door bus 56.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"56\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"2352\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Until Summer of 2024, works. Stop not served. Take bus 57 at the stop of bus 56 to SCHUMAN.\", \"fr\": \"Jusqu'\u00e0 l'\u00e9t\u00e9 2024, travaux. Arr\u00eat non desservi. Prenez le bus 57 \u00e0 l'arr\u00eat du bus 56 vers SCHUMAN.\", \"nl\": \"Tot zomer 2024, werken. Halte niet bediend. Neem bus 57 aan de halte van bus 56 naar SCHUMAN.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"57\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"2317\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Until Summer of 2024, works. Stop not served. Take bus 57 at the stop of bus 56 to BUDA.\", \"fr\": \"Jusqu'\u00e0 l'\u00e9t\u00e9 2024, travaux. Arr\u00eat non desservi. Prenez le bus 57 \u00e0 l'arr\u00eat du bus 56 vers BUDA.\", \"nl\": \"Tot zomer 2024, werken. Halte niet bediend. Neem bus 57 aan de halte van bus 56 naar BUDA.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"57\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"2358\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Until Summer of 2024, works. Bus 57 diverted. Take bus 57 at ANTOON VAN OSS (stop of bus 56 to BUDA)\", \"fr\": \"Jusqu'\u00e0 l'\u00e9t\u00e9 2024, travaux. Bus 57 d\u00e9vi\u00e9. Prenez le bus 57 \u00e0 ANTOON VAN OSS (arr\u00eat du bus 56 vers BUDA).\", \"nl\": \"Tot zomer 2024, werken. Bus 57 omgeleid. Neem bus 57 aan ANTOON VAN OSS (halte van bus 56 naar BUDA).\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"57\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"1827\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. As of Apr 15, STOP NOT SERVED. Take bus 60 at PARC LEOPOLD (ch. Etterbeek, in front of number 166).\", \"fr\": \"Travaux. D\u00e8s le 15/4, ARRET NON DESSERVI. Bus 60 \u00e0 PARC LEOPOLD (chauss\u00e9e d'Etterbeek, en face du num\u00e9ro 166).\", \"nl\": \"Werken. Vanaf 15/4, HALTE NIET BEDIEND. Neem bus 60 aan LEOPOLDSPARK (Etterbeeksesteenweg, tegenover nummer 166)\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"60\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"1271B\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. As of Apr 15, STOP NOT SERVED. Take bus 60 at MAELBEEK / MAALBEEK.\", \"fr\": \"Travaux. D\u00e8s le 15/4, ARRET NON DESSERVI. Prenez le bus 60 \u00e0 MAELBEEK.\", \"nl\": \"Werken. Vanaf 15/4, HALTE NIET BEDIEND. Neem bus 60 aan MAALBEEK.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"60\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"1270B\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. As of Apr 15, bus 60 diverted between JOURDAN and AMBIORIX via MAELBEEK. Connection metro at MAELBEEK.\", \"fr\": \"Travaux. D\u00e8s le 15/4, bus 60 d\u00e9vi\u00e9 entre JOURDAN et AMBIORIX via MAELBEEK. Correspondance m\u00e9tro \u00e0 MAELBEEK.\", \"nl\": \"Werken. Vanaf 15/4, bus 60 omgeleid tussen JOURDAN en AMBIORIX via MAALBEEK. Aansluiting metro aan MAALBEEK.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"60\"}]",
+        "priority": 6,
+        "points": "[{\"id\": \"1986\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Risk of subsidence. Stop of bus 65, 66 and N04 moved to chauss\u00e9e de Haecht/Haachtsesteenweg, next to number 162\", \"fr\": \"Risque d'effondrement. Arr\u00eat des bus 65, 66 et N04 d\u00e9plac\u00e9 chauss\u00e9e de Haecht, \u00e0 hauteur du num\u00e9ro 162.\", \"nl\": \"Risico op instorting. Halte van bus 65, 66 en N04 verplaatst naar de Haachtsesteenweg, ter hoogte van nummer 162.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"66\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"6418\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Jan 8-Jun 28, works. Tram 7 replaced by T-bus between DOCKS BRUXSEL and HEEMBEEK. Info: stib-mivb.brussels\", \"fr\": \"8/1-28/6, travaux. Tram 7 remplac\u00e9 par des T-bus entre DOCKS BRUXSEL et HEEMBEEK. Info: stib. brussels.\", \"nl\": \"8/1-28/6, werken. Tram 7 vervangen door T-bus tussen DOCKS BRUXSEL en HEEMBEEK. info: mivb. brussels.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"7\"}]",
+        "priority": 5,
+        "points": "[{\"id\": \"2636F\"}, {\"id\": \"9056F\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Jan 7 at 9PM to Jun 28, works. Tram 7 does not serve this stop. Take tram 3 to go to VANDERKINDERE.\", \"fr\": \"Du 7/1 \u00e0 21h au 28/6, travaux. Tram 7 ne dessert pas cet arr\u00eat. Prenez le tram 3 pour rejoindre VANDERKINDERE.\", \"nl\": \"Van 7/1 om 21u tot en met 28/6, werken. Tram 7 bedient deze halte niet. Neem tram 3 om naar VANDERKINDERE te gaan.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"7\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"5219F\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Jan 8 to Jun 28, works. Tram 7 interrupted to HEEMBEEK. T-bus at the stop of bus 56 to BUDA.\", \"fr\": \"Du 8/1 au 28/6, travaux. Tram 7 interrompu jusqu'\u00e0 HEEMBEEK. T-bus \u00e0 l'arr\u00eat du bus 56 vers BUDA.\", \"nl\": \"8/1-28/6, werken. Tram 7 onderbroken tot HEEMBEEK. T-bus aan de halte van bus 56 naar BUDA.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"7\"}]",
+        "priority": 5,
+        "points": "[{\"id\": \"5759F\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Mar 18, works. STOP NOT SERVED. stop of bus 71: avenue de l'Universit\u00e9 / Hogeschoollaan 4-10.\", \"fr\": \"D\u00e8s le 18/3, travaux. ARRET NON DESSERVI. Arr\u00eat du bus 71: avenue de l'Universit\u00e9 4-10.\", \"nl\": \"Vanaf 18/3, werken. HALTE NIET BEDIEND. Halte van bus 71: Hogeschoollaan 4-10.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"71\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"3514\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Subsidence. Bus 74 limited to DECROLY. Walk from DECROLY to UCCLE-STALLE / UKKEL-STALLE.\", \"fr\": \"Effondrement. Bus 74 limit\u00e9 \u00e0 DECROLY. Continuez \u00e0 pied depuis DECROLY jusqu'\u00e0 UCCLE STALLE.\", \"nl\": \"Wegverzakking. Bus 74 beperkt tot DECROLY. Ga te voet van DECROLY tot UKKEL-STALLE.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"74\"}]",
+        "priority": 5,
+        "points": "[{\"id\": \"2631\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Subsidence. Bus 74 limited to DECROLY. Walk from DECROLY to UCCLE-STALLE / UKKEL-STALLE.\", \"fr\": \"Effondrement. Bus 74 limit\u00e9 \u00e0 DECROLY. Continuez \u00e0 pied depuis DECROLY jusqu'\u00e0 UCCLE STALLE.\", \"nl\": \"Wegverzakking. Bus 74 beperkt tot DECROLY. Ga te voet van DECROLY tot UKKEL-STALLE.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"74\"}]",
+        "priority": 5,
+        "points": "[{\"id\": \"3682\"}, {\"id\": \"3074\"}, {\"id\": \"5915\"}, {\"id\": \"2614\"}, {\"id\": \"2602\"}, {\"id\": \"2601\"}, {\"id\": \"2600\"}, {\"id\": \"2226\"}, {\"id\": \"2523\"}, {\"id\": \"2555\"}, {\"id\": \"1015\"}, {\"id\": \"2599\"}, {\"id\": \"2598\"}, {\"id\": \"2607\"}, {\"id\": \"2606\"}, {\"id\": \"2605\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Apr 2, 2024-June 2025, works. Bus 74 diverted between FOREST NATIONAL and FOREST CENTRE. Info: stib-mivb.brussels\", \"fr\": \"Du 2/4/2024 \u00e0 juin 2025, travaux. Bus 74 d\u00e9vi\u00e9 entre FOREST NATIONAL et FOREST CENTRE. Info: stib.brussels.\", \"nl\": \"2/4/2024-juni 2025, werken. Bus 74 omgeleid tussen VORST NATIONAAL en VORST CENTRUM. Info: mivb.brussels\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"74\"}]",
+        "priority": 5,
+        "points": "[{\"id\": \"2632\"}, {\"id\": \"2453\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Apr 2, 2024 to June 2025, works. STOP NOT SERVED. Stop of bus 54 and 74: avenue du Globelaan 8.\", \"fr\": \"Du 2/4/2024 \u00e0 juin 2025, travaux. ARRET NON DESSERVI. Arr\u00eat des bus 54 et 74: avenue du Globe 8.\", \"nl\": \"Van 2/4/2024 tot juni 2025, werken. HALTE NIET BEDIEND. Halte van bus 54 en 74: Globelaan 8.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"74\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"2616B\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Jan 18, works. STOP NOT SERVED. Temporary stop: Avenue de Roodebeeklaan 45.\", \"fr\": \"D\u00e8s le 18/1, travaux. ARRET NON DESSERVI. Arr\u00eat provisoire: Avenue de Roodebeek 45.\", \"nl\": \"Vanaf 18/1, werken. HALTE NIET BEDIEND. Tijdelijke halte: Roodebeeklaan 45.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"79\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"1404\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. As of Apr 15, STOP NOT SERVED. Stop of bus 79: rue Archim\u00e8de / Archimedesstraat 16.\", \"fr\": \"Travaux. D\u00e8s le 15/4, ARRET NON DESSERVI. Arr\u00eat du bus 79: rue Archim\u00e8de 16.\", \"nl\": \"Werken. Vanaf 15/4, HALTE NIET BEDIEND. Halte van bus 79: Archimedesstraat 16.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"79\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"1474B\"}, {\"id\": \"2083\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"On May 5 until 8PM, flea market. STOP NOT SERVED. Stop of the T-bus: chauss\u00e9e de Charleroisesteenweg 180.\", \"fr\": \"Le 19/5 jusqu'\u00e0 20h, brocante. ARRET NON DESSERVI. Arr\u00eat du T-bus : chauss\u00e9e de Charleroi 180.\", \"nl\": \"Op 19/5 tot 20u, rommelmarkt. HALTE NIET BEDIEND. Halte van de T-bus: Charleroisesteenweg 180.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"81\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"6427F\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"On May 5 until 8PM, flea market. T81 interrupted. Stop of T81: avenue des Eperons d'Or, before place Flageyplein.\", \"fr\": \"19/5 jsq 20h, brocante. Tram 81 interrompu. Arr\u00eat du T81 : avenue des Eperons d'Or, avant carrefour place Flagey.\", \"nl\": \"Op 19/5 tot 20u, rommelmarkt. Tram 81 onderbroken. Halte van T81: Gulden-Sporenlaan, voor Flageyplein.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"81\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"3508F\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"On May 5 until 8PM, flea market. Tram 81 interrupted. Stop of the T-bus: rue Lesbroussart- straat 72-74.\", \"fr\": \"Le 19/5 jusqu'\u00e0 20h, brocante. Tram 81 interrompu. Arr\u00eat du T-bus : rue Lesbroussart 72-74.\", \"nl\": \"Op 19/5 tot 20u, rommel- markt. T81 onderbroken. Halte T-bus: Lesbroussartstraat 72-74.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"81\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"6120\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"On May 5 until 8PM, flea market. T81 interrupted. Stop of T-bus: place E. Flageyplein, stop of bus 71 to DE BROUCKERE.\", \"fr\": \"19/5 jsq 20h, brocante. Tram 81 interrompu. Arr\u00eat du T-bus : place Eug\u00e8ne Flagey, arr\u00eat du bus 71 DE BROUCKERE.\", \"nl\": \"Op 19/5 tot 20u, rommel- markt. T81 onderbroken. Halte van T-bus: E. Flagey- plein, halte bus 71 naar DE BROUCKERE.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"81\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"3572F\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. Until 2026, stop not served. Walk to DROGENBOS.\", \"fr\": \"Travaux. Jusqu'en 2026, arr\u00eat non desservi. Pour rejoindre DROGENBOS, continuez \u00e0 pied.\", \"nl\": \"Werken. Tot 2026, halte niet bediend. Ga te voet verder om naar DROGENBOS te gaan.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"82\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"5729\"}, {\"id\": \"5725\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works. Until 2026, stop not served. T-bus 82 to DROGENBOS at the previous stop, CARREFOUR STALLE.\", \"fr\": \"Travaux. Jusqu'en 2026, arr\u00eat non desservi. T-bus 82 vers DROGENBOS \u00e0 l'arr\u00eat pr\u00e9c\u00e9dent, CARREFOUR STALLE.\", \"nl\": \"Werken. Tot 2026, halte niet bediend. T-bus 82 naar DROGENBOS aan de vorige halte, KRUISPUNT STALLE.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"82\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"5724\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Until 2026, works. Stop not served. Take tram 82 at FOREST CENTRE / VORST CENTRUM (stop to Drogenbos).\", \"fr\": \"Jusqu'en 2026, travaux. Arr\u00eat non desservi. Prenez le tram 82 \u00e0 FOREST CENTRE (arr\u00eat vers Drogenbos).\", \"nl\": \"Tot 2026, werken. Halte niet bediend. Neem tram 82 aan VORST CENTRUM (halte naar Drogenbos).\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"82\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"5152G\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Jan 22, 6AM-end of June, works. Bus 86 diverted. Bus 86 at stop MERCHTEM of bus 20 to GARE DU NORD / NOORDSTATION.\", \"fr\": \"Du 22/1 \u00e0 6h jusqu'\u00e0 fin juin, travaux. Bus 86 d\u00e9vi\u00e9. Bus 86 \u00e0 l'arr\u00eat MERCHTEM du bus 20 vers GARE DU NORD.\", \"nl\": \"Van 22/1 om 6u tot eind juni, werken. Bus 86 omgeleid. B86 aan halte MERCHTEM van bus 20 naar NOORDSTATION.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"86\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"6755\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Jan 22 at 6AM to end of June, works. Bus 86 diverted. Stop of bus 86: rue A. Vandenpeereboomstraat 44\", \"fr\": \"Du 22/1 \u00e0 6h jusqu'\u00e0 fin juin, travaux. Bus 86 d\u00e9vi\u00e9. Arr\u00eat du bus 86: rue  A. Vandenpeereboom 44.\", \"nl\": \"Van 22/1 om 6u tot eind juni, werken. Bus 86 omgeleid. Halte van bus 86: A. Vandenpeereboomstraat 44\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"86\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"4595\"}, {\"id\": \"1242\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Mar 3 at 7AM, works. STOP NOT SERVED. Take bus 86 at the next stop DUCHESSE BRABANT / HERTOGIN BRABANT.\", \"fr\": \"D\u00e8s le 3/3 \u00e0 7h, travaux. ARRET NON DESSERVI. Prenez le bus 86 \u00e0 l'arr\u00eat suivant, DUCHESSE BRABANT.\", \"nl\": \"Vanaf 3/3 om 7u, werken. HALTE NIET BEDIEND. Neem bus 86 aan de volgende halte HERTOGIN BRABANT.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"86\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"6706\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Jan 22, 6AM-end of June, works. B86 diverted. Stop of B86:ch.De Gand/ Gentsestwg, in front of number 219 (Stop B13).\", \"fr\": \"Du 22/1 \u00e0 6h jusqu'\u00e0 fin juin, travaux. Bus 86 d\u00e9vi\u00e9. Arr\u00eat du B86: ch. de Gand, en face du num\u00e9ro 219 (arr\u00eat B13).\", \"nl\": \"Van 22/1 om 6u tot eind juni, werken. Bus 86 omgeleid. Halte van B86: Gentsesteenweg,tegenover nr. 219 (halte bus 13).\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"86\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"6754\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"As of Nov 16 at 6AM, works. Stop moved to av. Port / Havenln, in front of number 100 (moved backward of +/- 120m)\", \"fr\": \"D\u00e8s le 16/11 \u00e0 6h, travaux. Arr\u00eat d\u00e9plac\u00e9 avenue du Port, en face du num\u00e9ro 100 (recul\u00e9 de +/- 120m).\", \"nl\": \"Vanaf 16/11 om 6u,werken Halte verplaatst naar de Havenlaan, tegenover nr 100 (achteruitgebracht van +/- 120m)\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"88\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"2305\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Dec 4, works. STOP NOT SERVED. Stop of bus 88: rue du Progr\u00e8s / Vooruitgangstraat 64.\", \"fr\": \"D\u00e8s le 4/12, travaux. ARRET NON DESSERVI. Arr\u00eat du bus 88: rue du Progr\u00e8s 64.\", \"nl\": \"Vanaf 4/12, werken. HALTE NIET BEDIEND. Halte van bus 88: Vooruitgangstraat 64.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"88\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"3400\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Dec 4, works. STOP NOT SERVED. Stop of bus 58 and 88 : rue du Progr\u00e8s, after crossing rue des Charbonniers.\", \"fr\": \"D\u00e8s le 4/12, travaux. ARRET NON DESSERVI. Arr\u00eat des bus 58 et 88 : rue du Progr\u00e8s, apr\u00e8s rue des Charbonniers.\", \"nl\": \"Vanaf 4/12, werken. HALTE NIET BEDIEND. Halte bus 58 en 88 : Vooruitgangstraat, na Koolbrandersstraat.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"88\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"1083\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Until end of August, works. Bus 89 diverted. For the city center, take metro 1 or 5 at STE-CATHERINE.\", \"fr\": \"Jusque fin ao\u00fbt, travaux. Bus 89 d\u00e9vi\u00e9. Pour le centre-ville, prenez le m\u00e9tro 1 ou 5 \u00e0 SAINTE-CATHERINE.\", \"nl\": \"Tot einde augustus, werken. Bus 89 omgeleid. Om naar het stadscentrum te gaan, neem M 1 5 aan SINT-KATELIJNE.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"89\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"3261\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Until end of August, works. Bus 89 diverted btw PTE DE NINOVE and BOURSE, and interrupted bt BOURSE and CENTRAL ST\", \"fr\": \"Jsq fin ao\u00fbt, travaux. Bus 89 d\u00e9vi\u00e9 entre PORTE DE NINOVE et BOURSE, et interrompu entre BOURSE et GARE CENTRALE.\", \"nl\": \"Tot einde augustus, werken. Bus 89 omgeleid tss NINOOFSEPOORT en BEURS, en onderbroken tss BEURS en CENTR ST\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"89\"}]",
+        "priority": 5,
+        "points": "[{\"id\": \"2754\"}, {\"id\": \"2776\"}, {\"id\": \"2748B\"}, {\"id\": \"4595\"}, {\"id\": \"1178\"}, {\"id\": \"2784\"}, {\"id\": \"2782\"}, {\"id\": \"6648\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Until end of August 2024, works. Stop not served. Take bus 29 or 71 at DE BROUCKERE to go to CENTRAL STATION.\", \"fr\": \"Jsq fin ao\u00fbt 2024, travaux. Arr\u00eat non desservi. Prenez le bus 29 ou 71 \u00e0 DE BROUCKERE pour GARE CENTRALE.\", \"nl\": \"Tot einde augustus 2024, werken. halte niet bediend. Neem bus 29 of 71 aan DE BROUCKERE om naar CENTR. ST. te gaan\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"89\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"1894\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Mar 5 at 9AM, works. STOP NOT SERVED. Temporary stop: avenue Jean & Pierre Carsoellaan 4.\", \"fr\": \"D\u00e8s le 5/3 \u00e0 9h, travaux. ARRET NON DESSERVI. Arr\u00eat provisoire: avenue Jean et Pierre Carsoel 4.\", \"nl\": \"Vanaf 5/3 om 9u, werken. HALTE NIET BEDIEND. Tijdelijke halte: Jean en Pierre Carsoellaan 4.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"92\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"6931H\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Mar 18, works. STOP NOT SERVED. stop of bus 95: chauss\u00e9e de Boondael / Boondaalsesteenweg, before roundabout.\", \"fr\": \"D\u00e8s le 18/3, travaux. ARRET NON DESSERVI. Arr\u00eat du bus 95: chauss\u00e9e de Boondael, avant le rond-point.\", \"nl\": \"Vanaf 18/3, werken. HALTE NIET BEDIEND. Halte van bus 95: Boondaalsesteenweg, voor rondpunt.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"95\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"3514\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Afterwork. Every Thursday after 4PM, stop moved to rue de Tr\u00e8ves, in front of the stop in the other direction\", \"fr\": \"Afterwork. Tous les jeudis apr\u00e8s 16h, arr\u00eat d\u00e9plac\u00e9 rue de Tr\u00e8ves, en face de l'arr\u00eat dans l'autre sens.\", \"nl\": \"Afterwork.Elke donderdag na 16u, halte verplaatst naar de Trierstraat, tegenover de halte in de andere richting.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"95\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"1233\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Mar 25 until Jun 30, works. STOP NOT SERVED. Stop of bus 95: bd. Gen. Jacqueslaan 235.\", \"fr\": \"Du 25/3 au 30/6, travaux. ARRET NON DESSERVI. Arr\u00eat du bus 95: boulevard G\u00e9n\u00e9ral Jacques, 235.\", \"nl\": \"Van 25/3 tot en met 30/6, werken. HALTE NIET BEDIEND. Halte van bus 95:  Generaal Jacqueslaan 235.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"95\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"4363\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"From Mar 18, works. STOP NOT SERVED. Temporary stop: avenue de la Couronne / Kroonlaan 439-443.\", \"fr\": \"D\u00e8s le 18/3, travaux. ARRET NON DESSERVI. Arr\u00eat provisoire: avenue de la Couronne 439-443.\", \"nl\": \"Vanaf 18/3, werken. HALTE NIET BEDIEND. Tijdelijke halte: Kroonlaan 439-443.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"95\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"3558\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Until 2026, works. Tram 97 interrupted. T-bus to CARREFOUR / KRUISPUNT STALLE at the stop of bus 54 to TRONE/TROON\", \"fr\": \"Jusqu'en 2026, travaux. Tram 97 interrompu. T-bus vers CARREFOUR STALLE \u00e0 l'arr\u00eat du bus 54 vers TRONE.\", \"nl\": \"Tot 2026, werken. Tram 97 onderbroken. T-bus naar KRUISPUNT STALLE aan de halte van bus 54 naar TROON.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"97\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"5121F\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Until 2026, works. As of Mar 11, tram 97 interrupted btw WIELS and DIEWEG. Take T92 at MARLOW to go to DIEWEG\", \"fr\": \"Jsq 2026,travaux. D\u00e8s le 11/3, tram 97 interrompu entre WIELS et DIEWEG. Prenez le T92 \u00e0 MARLOW pour aller \u00e0 DIEWEG\", \"nl\": \"Tot 2026, werken. Vanaf 11/3,tram 97 onderbroken tss WIELS en DIEWEG. Neem tram 92 aan MARLOW om naar DIEWEG te gaan\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"97\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"1985G\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Until 2026, works. As of Mar 11, tram 97 operated only btw LOUISE and WIELS.T-bus to CARREFOUR STALLE at ROCHEFORT.\", \"fr\": \"Jsq 2026,travaux. D\u00e8s le 11/3, tram 97 circule uniquement entre LOUISE et WIELS.T-bus vers CARR STALLE \u00e0 ROCHEFORT.\", \"nl\": \"Tot 2026, werken. Vanaf 11/3 rijdt tram 97 enkel tussen LOUIZA en WIELS. T-bus naar KRUISPUNT STALLE aan ROCHEFORT.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"97\"}]",
+        "priority": 5,
+        "points": "[{\"id\": \"6078\"}, {\"id\": \"6428F\"}, {\"id\": \"5018F\"}, {\"id\": \"5016F\"}, {\"id\": \"2404F\"}, {\"id\": \"6314\"}, {\"id\": \"2336G\"}, {\"id\": \"6162\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Until 2026, works. As of Mar 11, tram 97 interrupted between WIELS and DIEWEG. Take tram 4 to go to GLOBE.\", \"fr\": \"Jsq 2026,travaux. D\u00e8s le 11/3, tram 97 interrompu entre WIELS et DIEWEG. Prenez le tram 4 pour rejoindre GLOBE.\", \"nl\": \"Tot 2026, werken. Vanaf 11/3, tram 97 onderbroken tussen WIELS en DIEWEG. Neem tram 4 om naar GLOBE te gaan.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"97\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"5723G\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Until 2026, works. As of Mar 11, T97 operated only btw LOUISE and WIELS. T82 at WIELS or T-bus at PIERRE DECOSTER\", \"fr\": \"Jsq 2026, travaux. D\u00e8s le 11/3, T97  uniquement entre LOUISE et WIELS. Tram 82 \u00e0 WIELS ou T-bus \u00e0 PIERRE DECOSTER.\", \"nl\": \"Tot 2026, werken. Vanaf 11/3 rijdt T97 enkel tss LOUIZA en WIELS.Neem T82 aan WIELS of de T-bus aan PIERRE DECOSTER.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"97\"}]",
+        "priority": 5,
+        "points": "[{\"id\": \"5116\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Until 2026, works. As of Mar 11, tram 97 interrupted to DIEWEG. For GLOBE, tram 4 at CARR. STALLE via T-bus\", \"fr\": \"Jsq 2026,travaux. D\u00e8s le 11/3, tram 97 interrompu jsq DIEWEG. Pour GLOBE, tram 4 \u00e0 CARREFOUR STALLE via T-bus.\", \"nl\": \"Tot 2026, werken. Vanaf 11/3,T97 onderbroken tot DIEWEG. Voor GLOBE, neem T4 aan KRUISPUNT STALLE via T-bus.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"97\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"5163F\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Until 2026, works. T97 interrupted to WIELS. Stop of the T-bus to ROCHEFORT: r. Soierie / Zijdeweverijstraat 9\", \"fr\": \"Jusqu'en 2026, travaux. Tram 97 interrompu jusqu'\u00e0 WIELS. Arr\u00eat du T-bus vers ROCHEFORT: rue de la Soierie 9.\", \"nl\": \"Tot 2026, werken. Tram 97 onderbroken tot WIELS. Halte van de T-bus naar ROCHEFORT: Zijdeweverijstraat 9.\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"97\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"5156F\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Until 2026, works. As of Mar 11, tram 97 interrupted btw WIELS and DIEWEG. Take tram 92 to go to DIEWEG\", \"fr\": \"Jsq 2026,travaux. D\u00e8s le 11/3, tram 97 interrompu entre WIELS et DIEWEG. Prenez le tram 92 pour rejoindre DIEWEG\", \"nl\": \"Tot 2026, werken. Vanaf 11/3,tram 97 onderbroken tss WIELS en DIEWEG. Neem tram 92 om naar DIEWEG te gaan\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"97\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"2765\"}, {\"id\": \"2764G\"}]"
+    },
+    {
+        "content": "[{\"text\": [{\"en\": \"Works.From May 17 at 9PM until May 20, STOP NOT SERVED. T-bus to SIMONIS at CIM. / KERKH. JETTE, via tram 51 or 93.\", \"fr\": \"Travaux. Du 17/5 \u00e0 21h au 20/5, ARRET NON DESSERVI. T-bus vers SIMONIS \u00e0 CIM. DE JETTE, via tram 51 ou 93.\", \"nl\": \"Werken. Van 17/5 om 21u tot 20/5, HALTE NIET BEDIEND. T-bus naar SIMONIS aan KERKHOF VAN JETTE, via tram 51 of 93\"}], \"type\": \"Description\"}]",
+        "type": "LongText",
+        "lines": "[{\"id\": \"T19\"}]",
+        "priority": 4,
+        "points": "[{\"id\": \"2802\"}]"
+    }
+]

--- a/storage/app/samples/2026-03-22-travellers-information-rt-production.json
+++ b/storage/app/samples/2026-03-22-travellers-information-rt-production.json
@@ -1,0 +1,1722 @@
+{
+    "results": [
+        {
+            "content": "[{\"text\":[{\"en\":\"Works. 22 Dec 2025-end of 2026, stop not served. For MONTGOMERY, temporary B96 from MORIS to TRINITE and T81\",\"fr\":\"Travaux. 22/12/25-fin 2026,arrêt non desservi. Pour MONTGOMERY, bus temporaire 96 de MORIS à TRINITE, et T81. \",\"nl\":\"Werken. 22/12/25-eind 2026,halte niet bediend. Voor MONTGOMERY, tijdel. bus 96 van MORIS tot DRIEVULDIGHEID en T81. \"}],\"type\":\"Description\"}]",
+            "type": "LongText",
+            "lines": "[{\"id\":\"81\"}]",
+            "priority": 4,
+            "points": "[{\"id\":\"6077F\"}]"
+        },
+        {
+            "content": "[{\"text\":[{\"en\":\"Works. Until 2027, bus 74 diverted from VICTOR ALLARD to VAN HAELEN. UCCLE-STALLE / UKKEL- STALLE not served.\",\"fr\":\"Travaux. Jusqu’en 2027, bus 74 dévié depuis VICTOR ALLARD vers VAN HAELEN. UCCLE-STALLE non desservi.\",\"nl\":\"Werken. Tot 2027, bus 74 omgeleid vanaf VICTOR ALLARD naar VAN HAELEN. UKKEL-STALLE niet bediend\"}],\"type\":\"Description\"}]",
+            "type": "LongText",
+            "lines": "[{\"id\":\"74\"}]",
+            "priority": 5,
+            "points": "[{\"id\":\"2415\"},{\"id\":\"2414\"},{\"id\":\"2631\"}]"
+        },
+        {
+            "content": "[{\"text\":[{\"en\":\"Works. 4 Aug to December 2026, T51 interrupted. T51 at MARGUERITE DURAS via M2-6 at RIBAUCOURT (600m)to YSER, then walk\",\"fr\":\"Travaux. 4/8 à décembre 2026, T51 interrompu. T51 à MARGUERITE DURAS via M2-6 à RIBAUCOURT jsq YSER, puis à pied.\",\"nl\":\"Werken. 4/8 tot december 2026, T51 onderbroken. T51 aan MARGUERITE DURAS via M2-6 aan RIBAUCOURT tot IJZER, dan te voet.\"}],\"type\":\"Description\"}]",
+            "type": "LongText",
+            "lines": "[{\"id\":\"51\"}]",
+            "priority": 4,
+            "points": "[{\"id\":\"5011F\"}]"
+        },
+        {
+            "content": "[{\"text\":[{\"en\":\"Until 2027, works. Tram 97 interrupted. To go to GLOBE, tram 4 at CARREFOUR STALLE / KRUISPUNT STALLE.\",\"fr\":\"Jusqu’en 2027, travaux. Tram 97 interrompu. Pour rejoindre GLOBE, tram 4 à CARREFOUR STALLE.\",\"nl\":\"Tot 2027, werken. Tram 97 onderbroken. Om naar GLOBE te gaan, neem tram 4 aan KRUISPUNT STALLE.\"}],\"type\":\"Description\"}]",
+            "type": "LongText",
+            "lines": "[]",
+            "priority": 4,
+            "points": "[{\"id\":\"5722F\"},{\"id\":\"5163F\"}]"
+        },
+        {
+            "content": "[{\"text\":[{\"en\":\"Works. Until 2027, stop not served. Take bus 74 to DROGENBOS at CARREFOUR STALLE (stop of bus 75 to BON AIR).\",\"fr\":\"Travaux. Jsq 2027, arrêt non desservi. Prenez le bus 74 vers DROGENBOS à CARR. STALLE (arrêt B75 vers BON AIR).\",\"nl\":\"Werken. Tot 2027, halte niet bediend. Neem bus 74 naar DROGENBOS aan KRUISPUNT STALLE (halte B75 naar GOEDE LUCHT).\"}],\"type\":\"Description\"}]",
+            "type": "LongText",
+            "lines": "[{\"id\":\"82\"}]",
+            "priority": 4,
+            "points": "[{\"id\":\"5724\"}]"
+        },
+        {
+            "content": "[{\"text\":[{\"en\":\"Works. From 19 Jan to end of 2026, bus 53 diverted. Take the bus at the next stop, EMILE DELVA (300m).\",\"fr\":\"Travaux. Du 19/1 à fin 2026, bus 53 dévié. Prenez le bus à l'arrêt suivant, EMILE DELVA (300m).\",\"nl\":\"Werken. Van 19/1 tot eind 2026, bus 53 omgeleid. Neem de bus aan de volgende halte, EMILE DELVA (300m). \"}],\"type\":\"Description\"}]",
+            "type": "LongText",
+            "lines": "[{\"id\":\"53\"}]",
+            "priority": 4,
+            "points": "[{\"id\":\"3085\"}]"
+        },
+        {
+            "content": "[{\"text\":[{\"en\":\"Works. From 4 Aug 2025 to May 2026, bus 54 diverted. Stop of bus 54 between rue du Bailli and rue Lesbroussart.\",\"fr\":\"Travaux. Du 4/8/2025 à mai 2026, bus 54 dévié. Arrêt du bus 54entre rue du Bailli et rue Lesbroussart.\",\"nl\":\"Werken. Van 4/8/2025 tot mei 2026, bus 54 omgeleid. Halte van bus 54 tussen Baljuwstraat en Lesbroussartstraat.\"}],\"type\":\"Description\"}]",
+            "type": "LongText",
+            "lines": "[{\"id\":\"54\"}]",
+            "priority": 4,
+            "points": "[{\"id\":\"2971\"}]"
+        },
+        {
+            "content": "[{\"text\":[{\"en\":\"Works. 19 Jan to summer 2026, bus 41 diverted. Bus 41 at FUTAIE (via bus 41 to HELDEN/HEROS) or KEYM (600m). \",\"fr\":\"Travaux. Du 19/1 à l'été 2026, bus 41 dévié. Prenez le bus à FUTAIE (via bus 41 vers HEROS) ou à KEYM (600 mètres).\",\"nl\":\"Werken. 19/1 tot zomer 2026, bus 41 omgeleid. Neem de bus aan FUTAIE (via bus 41 naar HELDEN) of KEYM (600 meter).\"}],\"type\":\"Description\"}]",
+            "type": "LongText",
+            "lines": "[{\"id\":\"41\"}]",
+            "priority": 4,
+            "points": "[{\"id\":\"2115\"}]"
+        },
+        {
+            "content": "[{\"text\":[{\"en\":\"Works. From 9 Oct, stop relocated. Temporary stop: Stapelhuisstraat/rue de l'Entrepot 5A.\",\"fr\":\"Travaux. Dès le 9/10, arrêt déplacé. Arrêt provisoire: rue de l'Entrepot 5A.\",\"nl\":\"Werken. Vanaf 9/10, halte verplaatst. Tijdelijke halte: Stapelhuisstraat 5A.\"}],\"type\":\"Description\"}]",
+            "type": "LongText",
+            "lines": "[{\"id\":\"88\"},{\"id\":\"46\"},{\"id\":\"N18\"},{\"id\":\"86\"}]",
+            "priority": 4,
+            "points": "[{\"id\":\"2370\"}]"
+        },
+        {
+            "content": "[{\"text\":[{\"en\":\"Until 2027, works. T97 temporarily withdrawn. For ST-DENIS, T82 or B50 at WIELS. For CARREFOUR STALLE, B74 at CHARROI.\",\"fr\":\"Jsq 2027, travaux. T97 temporairement supprimé. Pour ST-DENIS, T82 ou B50 à WIELS. Pour CARR STALLE, B74 à CHARROI.\",\"nl\":\"Tot 2027, werken. T97 tijdelijk geschrapt. Voor ST-DENIJS, T82 of B50 aan WIELS. Voor KRPT STALLE, B74 aan GERIJ.\"}],\"type\":\"Description\"}]",
+            "type": "LongText",
+            "lines": "[]",
+            "priority": 4,
+            "points": "[{\"id\":\"5116\"}]"
+        },
+        {
+            "content": "[{\"text\":[{\"en\":\"Works. From 17 May 2025 to mid 2027, terminus not served. Take bus 69 at the stop of bus 59 to BORDET STATION.\",\"fr\":\"Travaux. Du 17/5/25 à mi-2027, terminus non desservi. Prenez le bus 69 à l'arrêt du bus 59 vers BORDET STATION.\",\"nl\":\"Werken. Van 17/5/25 tot midden 2027, eindpunt niet bediend. Neem bus 69 aan de halte van bus 59 naar BORDET STATION.\"}],\"type\":\"Description\"}]",
+            "type": "LongText",
+            "lines": "[{\"id\":\"69\"}]",
+            "priority": 4,
+            "points": "[{\"id\":\"3107\"}]"
+        },
+        {
+            "content": "[{\"text\":[{\"en\":\"Until 2027, works. T82 interrupted. For DROGENBOS, take bus 74 at CARR. STALLE (stop of bus 75 to BON AIR)\",\"fr\":\"Jusqu’en 2027, travaux. T82 interrompu. Pour DROGENBOS, B74 à CARREFOUR STALLE (arrêt du bus 75 vers BON AIR)\",\"nl\":\"Tot 2027, werken. T82 onderbroken. Voor DROGENBOS, B74 aan KRUISPUNT STALLE (halte bus 75 naar GOEDE LUCHT)\"}],\"type\":\"Description\"}]",
+            "type": "LongText",
+            "lines": "[{\"id\":\"82\"}]",
+            "priority": 4,
+            "points": "[{\"id\":\"5722F\"},{\"id\":\"5163F\"}]"
+        },
+        {
+            "content": "[{\"text\":[{\"en\":\"B48 52 96 N12: works. As of 17 June: stop moved to chée de Waterloosestwg 157 (B48 52 N12) / 210 (B96).\",\"fr\":\"B48 52 96 N12: travaux. Dès le 17/6, arrêt déplacé chée de Waterloo 157 pour B48 52 et N12, (numéro 210 pour le B96)\",\"nl\":\"B48 52 96 N12: werken. Vanaf 17/6: halte verplaatst: Waterloosestwg nrs. 157 (B48 52 N12) / 210 (B96)\"}],\"type\":\"Description\"}]",
+            "type": "LongText",
+            "lines": "[{\"id\":\"N12\"},{\"id\":\"48\"},{\"id\":\"52\"},{\"id\":\"96\"}]",
+            "priority": 4,
+            "points": "[{\"id\":\"2334B\"}]"
+        },
+        {
+            "content": "[{\"text\":[{\"en\":\"Works. 26 Jan-end 2026, stop not served. Take tram 81 at the stop of tram 82 to GARE DE BERCHEM/STATION BERCHEM.\",\"fr\":\"Travaux. 26/1-fin 2026, tram 81 interrompu. Prenez le tram 81 à l'arrêt du tram 82 vers GARE DE BERCHEM.\",\"nl\":\"Werken. 26/1-eind 2026, tram 81 onderbroken. Neem tram 81 aan de halte van tram 82 naar STATION BERCHEM.\"}],\"type\":\"Description\"}]",
+            "type": "LongText",
+            "lines": "[{\"id\":\"81\"}]",
+            "priority": 4,
+            "points": "[{\"id\":\"6175\"}]"
+        },
+        {
+            "content": "[{\"text\":[{\"en\":\"Works. Until 2027, terminus not served. Take bus 74 at the next stop, VICTOR ALLARD.\",\"fr\":\"Travaux. Jusqu'en 2027, terminus non desservi. Prenez le bus 74 à l’arrêt suivant, VICTOR ALLARD.\",\"nl\":\"Werken. Tot 2027, eindpunt niet bediend. Neem bus 74 aan de volgende halte, VICTOR ALLARD.\"}],\"type\":\"Description\"}]",
+            "type": "LongText",
+            "lines": "[{\"id\":\"74\"}]",
+            "priority": 4,
+            "points": "[{\"id\":\"2417\"}]"
+        },
+        {
+            "content": "[{\"text\":[{\"en\":\"Works. As of 5 Jan, bus 74 diverted between BERVOETS and CHARROI / GERIJ via UNION and WIELS.\",\"fr\":\"Travaux. Dès le 5/1, bus 74 dévié entre BERVOETS et CHARROI via UNION et WIELS.\",\"nl\":\"Werken. Vanaf 5/1, bus 74 omgeleid tussen BERVOETS en GERIJ via BERVOETS en WIELS.\"}],\"type\":\"Description\"}]",
+            "type": "LongText",
+            "lines": "[{\"id\":\"74\"}]",
+            "priority": 5,
+            "points": "[{\"id\":\"2616B\"},{\"id\":\"7472\"},{\"id\":\"7474\"},{\"id\":\"7465\"},{\"id\":\"2452\"},{\"id\":\"2939B\"},{\"id\":\"3405\"},{\"id\":\"5916\"},{\"id\":\"1457\"},{\"id\":\"3415\"},{\"id\":\"2632\"},{\"id\":\"1452\"},{\"id\":\"2453\"}]"
+        },
+        {
+            "content": "[{\"text\":[{\"en\":\"Works. As of 29 Jan, stop ROCHEFORT moved. Stop of temporary bus 96: avenue Wielemans- Ceuppenslaan 185.\",\"fr\":\"Travaux. Dès le 29/1, arrêt ROCHEFORT déplacé. Arrêt du bus temporaire 96: avenue Wielemans- Ceuppens 185.\",\"nl\":\"Werken.Vanaf 29/1, halte ROCHEFORT verplaatst. Halte van tijdelijke bus 96: Wielemans- Ceuppenslaan 185.\"}],\"type\":\"Description\"}]",
+            "type": "LongText",
+            "lines": "[{\"id\":\"96\"}]",
+            "priority": 4,
+            "points": "[{\"id\":\"1730\"}]"
+        },
+        {
+            "content": "[{\"text\":[{\"fr\":\"Le dimanche 5h-15h, marché. Arrêt non desservi. Arrêt provis: bd. du Souverain, peu avant rue Nisard.\",\"nl\":\"Op zondag 5u-15u, markt. Halte niet bediend. Tijd. halte: Vorstlaan, net voor Nisardstraat.\"}],\"type\":\"Description\"}]",
+            "type": "LongText",
+            "lines": "[{\"id\":\"17\"},{\"id\":\"95\"}]",
+            "priority": 6,
+            "points": "[{\"id\":\"4351\"}]"
+        },
+        {
+            "content": "[{\"text\":[{\"en\":\"Until 2027, works. Tram 97 temporarily withdrawn. To continue to LOUISE / LOUIZA, take tram 92.\",\"fr\":\"Jusqu’en 2027, travaux. Tram 97 temporairement supprimé. Pour continuer vers LOUISE, prenez le tram 92.\",\"nl\":\"Tot 2027, werken. Tram 97 tijdelijk geschrapt. Om naar LOUIZA te gaan, neem tram 92.\"}],\"type\":\"Description\"}]",
+            "type": "LongText",
+            "lines": "[]",
+            "priority": 6,
+            "points": "[{\"id\":\"6427F\"},{\"id\":\"5068F\"},{\"id\":\"5066F\"},{\"id\":\"6430F\"}]"
+        },
+        {
+            "content": "[{\"text\":[{\"en\":\"Works. 16 Mar, 7am-27 Mar, 5pm,bus 50 diverted between ST-DENIS / ST- DENIJS and BERVOETS. All stops are served.\",\"fr\":\"Travaux. Du 16/3 à 7h au 27/3 à 17h, bus 50 dévié entre SAINT-DENIS et BERVOETS. Tous les arrêts sont desservis.\",\"nl\":\"Werken. Van 16/3 om 7u tot 27/3 om 17u, bus 50 omgeleid tussen SINT- DENIJS en BERVOETS. Alle haltes worden bediend.\"}],\"type\":\"Description\"}]",
+            "type": "LongText",
+            "lines": "[{\"id\":\"50\"}]",
+            "priority": 5,
+            "points": "[{\"id\":\"3604\"},{\"id\":\"3603\"},{\"id\":\"2661\"},{\"id\":\"2662B\"},{\"id\":\"2659\"}]"
+        },
+        {
+            "content": "[{\"text\":[{\"en\":\"Until 2027, works. Tram 97 does not serve this stop. Take tram 92 to go to DIEWEG.\",\"fr\":\"Jusqu'en 2027, travaux. tram 97 ne dessert pas cet arrêt. Prenez le tram 92 pour rejoindre DIEWEG.\",\"nl\":\"Tot 2027, werken. Tram 97 bedient deze halte niet. Neem tram 92 om naar DIEWEG te gaan.\"}],\"type\":\"Description\"}]",
+            "type": "LongText",
+            "lines": "[]",
+            "priority": 5,
+            "points": "[{\"id\":\"2765\"},{\"id\":\"2764G\"}]"
+        },
+        {
+            "content": "[{\"text\":[{\"en\":\"Works. From 6 Jan, bus 53 83 diverted. Stop of bus 83: avenue de Versailleslaan 224.\",\"fr\":\"Travaux. Dès le 6/1, bus 53 83 déviés. Arrêt du bus 83: avenue de Versailles 224.\",\"nl\":\"Werken. Vanaf 6/1, bus 53 83 omgeleid. Halte van bus 83: Versailleslaan 224.\"}],\"type\":\"Description\"}]",
+            "type": "LongText",
+            "lines": "[{\"id\":\"83\"}]",
+            "priority": 4,
+            "points": "[{\"id\":\"2853\"}]"
+        },
+        {
+            "content": "[{\"text\":[{\"en\":\"Until 2027, works. Stop not served. For DROGENBOS, take bus 74 at stop B75 to BON AIR. For GLOBE, tram 4.\",\"fr\":\"Jsq 2027, travaux. Arrêt non desservi. Pour DROGENBOS, B74 à l’arrêt B75 vers BON AIR. Pour GLOBE, tram 4.\",\"nl\":\"Tot 2027, werken. Halte niet bediend. Voor DROGENBOS, B74 aan halte B75 naar GOEDE LUCHT. Voor GLOBE, tram 4.\"}],\"type\":\"Description\"}]",
+            "type": "LongText",
+            "lines": "[{\"id\":\"82\"}]",
+            "priority": 4,
+            "points": "[{\"id\":\"5723G\"}]"
+        },
+        {
+            "content": "[{\"text\":[{\"en\":\"Works. 17 May 2025-mid 2027, bus 59 diverted btw ANATOLE FRANCE and HUART-HAMOIR, via HELMET.\",\"fr\":\"Travaux. Du 17/5/25 à mi-2027, bus 59 dévié entre ANATOLE FRANCE et HUART-HAMOIR, via HELMET.\",\"nl\":\"Werken. 17/5/25-midden 2027, bus 59 omgeleid ts ANATOLE FRANCE en HUART- HAMOIR, via HELMET.\"}],\"type\":\"Description\"}]",
+            "type": "LongText",
+            "lines": "[{\"id\":\"59\"}]",
+            "priority": 5,
+            "points": "[{\"id\":\"3104\"},{\"id\":\"3103\"},{\"id\":\"3102\"},{\"id\":\"3101\"},{\"id\":\"3098\"}]"
+        },
+        {
+            "content": "[{\"text\":[{\"en\":\"Match. 22 Mar, 3.30pm- 1am, B46 diverted btw NEERPEDE and ST-GUIDON. B75 diverted btw RENE HENRY and VAN BEETHOVEN.\",\"fr\":\"Match. 22/3, 15h30-1h, B46 dévié entre NEERPEDE et SAINT-GUIDON. B75 dévié entre RENE HENRY et VAN BEETHOVEN.\",\"nl\":\"Match. 22/3, 15.30u-1u, B46 omgeleid tss NEERPEDE en ST-GUIDO. B75 omgeleid tussen RENE HENRY en VAN BEETHOVEN.\"}],\"type\":\"Description\"}]",
+            "type": "LongText",
+            "lines": "[{\"id\":\"46\"},{\"id\":\"75\"}]",
+            "priority": 5,
+            "points": "[{\"id\":\"1487\"}]"
+        },
+        {
+            "content": "[{\"text\":[{\"en\":\"Works. 21 May 2025-mid 2027, stop not served. Tram 55 at TILLEUL or VERBOEKHOVEN (via bus 59 69).\",\"fr\":\"Travaux.21/5/25-mi-2027, arrêt non desservi. Tram 55 à TILLEUL ou à VERBOEKHOVEN (via bus 59 69).\",\"nl\":\"Werken. 21/5/25-midden 2027,halte niet bediend. Tram 55 aan LINDE of aan VERBOEKHOVEN (via bus 59 69).\"}],\"type\":\"Description\"}]",
+            "type": "LongText",
+            "lines": "[{\"id\":\"55\"}]",
+            "priority": 4,
+            "points": "[{\"id\":\"5361F\"}]"
+        },
+        {
+            "content": "[{\"text\":[{\"en\":\"Until 2027, works. As of 9 June 2025, tram 97 temporarily withdrawn. For ST-DENIS, take bus 74 to CLEMENCE EVERARD.\",\"fr\":\"Jusqu’en 2027, travaux. Tram 97 temporairement supprimé. Pour SAINT- DENIS, prenez le bus 74 vers CLEMENCE EVERARD.\",\"nl\":\"Tot 2027, werken. Tram 97 tijdelijk geschrapt. Voor SINT-DENIJS, neem bus 74 naar CLEMENCE EVERARD.\"}],\"type\":\"Description\"}]",
+            "type": "LongText",
+            "lines": "[]",
+            "priority": 4,
+            "points": "[{\"id\":\"5952F\"},{\"id\":\"5953F\"}]"
+        },
+        {
+            "content": "[{\"text\":[{\"en\":\"Works. Until 29 March, stop MORIS not served. Take the temporary bus 96 at MA CAMPAGNE.\",\"fr\":\"Travaux. Jusqu'au 29/3, arrêt MORIS non desservi. Prenez le bus temporaire 96 à MA CAMPAGNE.\",\"nl\":\"Werken. Tot en met 29/3, halte MORIS niet bediend. Neem de tijdelijke bus 96 aan MA CAMPAGNE.\"}],\"type\":\"Description\"}]",
+            "type": "LongText",
+            "lines": "[{\"id\":\"96\"}]",
+            "priority": 4,
+            "points": "[{\"id\":\"2485\"},{\"id\":\"2481\"}]"
+        },
+        {
+            "content": "[{\"text\":[{\"en\":\"Works. From 19 Jan to summer 2026, bus 41 diverted between FUTAIE and KEYM. More info on stib-mivb.be and in app.\",\"fr\":\"Travaux. Du 19/1 à l'été 2026, bus 41 dévié entre FUTAIE et KEYM. Plus d'infos sur stib. brussels et app.\",\"nl\":\"Werken. Van 19/1 tot zomer 2026, bus  41 omgeleid tussen FUTAIE en KEYM. Meer info op mivb.brussels en in app.\"}],\"type\":\"Description\"}]",
+            "type": "LongText",
+            "lines": "[{\"id\":\"41\"}]",
+            "priority": 5,
+            "points": "[{\"id\":\"4076\"},{\"id\":\"6440\"},{\"id\":\"2074\"},{\"id\":\"1547\"},{\"id\":\"1943\"},{\"id\":\"2721\"},{\"id\":\"1970\"},{\"id\":\"1969\"},{\"id\":\"5416\"},{\"id\":\"1968\"},{\"id\":\"2715\"},{\"id\":\"1658\"},{\"id\":\"2714\"}]"
+        },
+        {
+            "content": "[{\"text\":[{\"en\":\"Until 2027, works. Tram 82 limited to NEERSTALLE. For DROGENBOS, take B74 at ST-DENIS (as of 22 Dec).\",\"fr\":\"Jsq 2027, travaux. Tram 82 limité à NEERSTALLE. Pour DROGENBOS, prenez le bus 74 à SAINT-DENIS (dès le 22/12).\",\"nl\":\"Tot 2027,werken. Tram 82 beperkt tot NEERSTALLE. Voor DROGENBOS, neem bus 74 aan SINT-DENIJS (vanaf 22/12).\"}],\"type\":\"Description\"}]",
+            "type": "LongText",
+            "lines": "[{\"id\":\"82\"}]",
+            "priority": 5,
+            "points": "[{\"id\":\"3257F\"},{\"id\":\"2539F\"},{\"id\":\"4022\"},{\"id\":\"2548F\"},{\"id\":\"6005\"},{\"id\":\"6004\"},{\"id\":\"3263F\"},{\"id\":\"3253F\"},{\"id\":\"6648F\"},{\"id\":\"6659F\"},{\"id\":\"5718\"},{\"id\":\"0631\"},{\"id\":\"4005F\"},{\"id\":\"4006G\"},{\"id\":\"1308G\"},{\"id\":\"4007G\"},{\"id\":\"4262F\"},{\"id\":\"2544F\"},{\"id\":\"4002G\"},{\"id\":\"4003G\"},{\"id\":\"6657\"},{\"id\":\"6650G\"}]"
+        },
+        {
+            "content": "[{\"text\":[{\"en\":\"Works. 26 Jan-end 2026, T81 replaced by temporary bus 96 to WIELS. Until May 2026, B54 stop: av. Louise 184\",\"fr\":\"Travaux. 26/1-fin 2026, T81 remplacé par bus temporaire 96 jusqu'à WIELS. Jsq mai 2026, arrêt B54: av.Louise 184\",\"nl\":\"Werken. 26/1-eind 2026, T81 vervangen door tijdelijke bus 96 tot WIELS. Tot mei 2026, halte B54: Louizaln 184.\"}],\"type\":\"Description\"}]",
+            "type": "LongText",
+            "lines": "[{\"id\":\"81\"}]",
+            "priority": 7,
+            "points": "[{\"id\":\"2972F\"}]"
+        },
+        {
+            "content": "[{\"text\":[{\"en\":\"Works. 17 May 25-mid 2027, stop not served. For BORDET STATION, take bus 59 at CHAUMONTEL (via rue du Tilleul)\",\"fr\":\"Travaux. 17/5/25-mi- 2027,arrêt non desservi. Pour BORDET STATION, bus 59 à CHAUMONTEL (via rue du Tilleul)\",\"nl\":\"Werken. 17/5/25-midden 2027,halte niet bediend. Voor BORDET STATION, bus 59 aan CHAUMONTEL (via Lindestraat).\"}],\"type\":\"Description\"}]",
+            "type": "LongText",
+            "lines": "[{\"id\":\"55\"}]",
+            "priority": 4,
+            "points": "[{\"id\":\"5868\"}]"
+        },
+        {
+            "content": "[{\"text\":[{\"en\":\"Until 2027, works. Tram 97 temporarily withdrawn. For JANSON, temporary bus 96, for LOUISE, T92 at JANSON.\",\"fr\":\"Jsq 2027, travaux. Tram 97 temporairement supprimé. Pour JANSON, bus temporaire 96, pour LOUISE, T92 à JANSON.\",\"nl\":\"Tot 2027, werken. Tram 97 tijdelijk geschrapt. Voor JANSON, tijdelijke bus 96, voor LOUIZA, T92 aan JANSON.\"}],\"type\":\"Description\"}]",
+            "type": "LongText",
+            "lines": "[]",
+            "priority": 4,
+            "points": "[{\"id\":\"2462F\"},{\"id\":\"2463F\"}]"
+        },
+        {
+            "content": "[{\"text\":[{\"en\":\"Works. From 17 May 2025 to mid 2027, stop not served. For DA VINCI, take bus 65, 69 or 80 at this stop.\",\"fr\":\"Travaux. Du 17/5/25 à mi-2027, tram 55 interrompu. Pour DA VINCI, prenez le bus 65, 69 ou 80 à cet arrêt.\",\"nl\":\"Werken. Van 17/5/25 tot midden 2027, halte niet bediend. Voor DA VINCI, neem bus 65, 69 of 80 aan deze halte.\"}],\"type\":\"Description\"}]",
+            "type": "LongText",
+            "lines": "[{\"id\":\"55\"}]",
+            "priority": 4,
+            "points": "[{\"id\":\"5362F\"}]"
+        },
+        {
+            "content": "[{\"text\":[{\"en\":\"Works. From 21 Mar until 22 Mar at 6.30pm, bus 79 diverted btw DIAMANT and CARENE. Stop CARENE bus 79: av. Léon Grosjean 79\",\"fr\":\"Travaux. Du 21/3 au 22/3 à 18h30, bus 79 dévié entre DIAMANT et CARENE. Arrêt CARENE bus 79: av. Léon Grosjean 79.\",\"nl\":\"Werken. Van 21/3 tot 22/3 om 18.30u, bus 79 omgeleid tss DIAMANT en CARINA. Halte CARINA bus 79: Léon Grosjeanlaan 79\"}],\"type\":\"Description\"}]",
+            "type": "LongText",
+            "lines": "[{\"id\":\"79\"}]",
+            "priority": 4,
+            "points": "[{\"id\":\"3904\"}]"
+        },
+        {
+            "content": "[{\"text\":[{\"en\":\"Works. From 4 Aug 2025 to May 2026, bus 54 diverted. Stop of bus 54: avenue Louise / Louizalaan 184.\",\"fr\":\"Travaux. Du 4/8/2025 à mai 2026, bus 54 dévié. Arrêt du bus 54: avenue Louise 184.\",\"nl\":\"Werken. Van 4/8/2025 tot mei 2026, bus 54 omgeleid. Halte van bus 54: Louizalaan 184.\"}],\"type\":\"Description\"}]",
+            "type": "LongText",
+            "lines": "[{\"id\":\"54\"}]",
+            "priority": 4,
+            "points": "[{\"id\":\"2479\"},{\"id\":\"1993\"},{\"id\":\"2972\"}]"
+        },
+        {
+            "content": "[{\"text\":[{\"en\":\"Works. From 6 Jan, bus 53 83 diverted. Stop of bus 83: avenue de Versailleslaan, in front of number 224.\",\"fr\":\"Travaux. Dès le 6/1, bus 53 83 déviés. Arrêt du bus 83: avenue de Versailles, face au numéro 224.\",\"nl\":\"Werken. Vanaf 6/1, bus 53 83 omgeleid. Halte van bus 83: Versailleslaan, tegenover nummer 224.\"}],\"type\":\"Description\"}]",
+            "type": "LongText",
+            "lines": "[{\"id\":\"83\"}]",
+            "priority": 4,
+            "points": "[{\"id\":\"2817\"}]"
+        },
+        {
+            "content": "[{\"text\":[{\"en\":\"Works. 22 Jan-mid-June, bus 48 52 diverted. For ANNEESSENS, tram 4 or 10 at PORTE DE HAL. Bus 52 at MADELEINE.\",\"fr\":\"Travaux. Du 22/1 à mi- juin, bus 48 52 déviés. Pour ANNEESSENS, tram 4 10 à PORTE DE HAL. Bus 52 à MADELEINE.\",\"nl\":\"Werken.22/1-midden juni, bus 48 52 omgeleid. Voor ANNEESSENS, tram 4 of 10 aan HALLEPOORT. Bus 52 aan MAGDALENA.\"}],\"type\":\"Description\"}]",
+            "type": "LongText",
+            "lines": "[{\"id\":\"48\"},{\"id\":\"52\"}]",
+            "priority": 4,
+            "points": "[{\"id\":\"1127\"}]"
+        },
+        {
+            "content": "[{\"text\":[{\"en\":\"End of the works ch. Bruxelles. As of 22 Dec, stop of bus 50: chaussée de Neerstalle 116. BUS 54 at ST-DENIS.\",\"fr\":\"Fin des travaux chée de Bruxelles. Dès le 22/12, arrêt du bus 50 : chée de Neerstalle 116. Bus 54 à SAINT-DENIS.\",\"nl\":\"Einde van de werken Brusselsesteenweg. Vanaf 22/12, halte van bus 50: Neerstalsesteenweg 116. Bus 54 aan SINT-DENIJS.\"}],\"type\":\"Description\"}]",
+            "type": "LongText",
+            "lines": "[{\"id\":\"50\"},{\"id\":\"54\"}]",
+            "priority": 4,
+            "points": "[{\"id\":\"3603\"},{\"id\":\"3193\"}]"
+        },
+        {
+            "content": "[{\"text\":[{\"en\":\"As of 3 Dec at 10am, stop of bus 86 moved pl. Duchesse de Brabant / Hertogin van Brabantpl. 32 on a trial basis.\",\"fr\":\"Dès le 3/12 à 10h, arrêt du bus 86 déplacé place de la Duchesse de Brabant 32, à titre d'essai.\",\"nl\":\"Vanaf 3/12 om 10u, halte van bus 86 verplaatst Hertogin van Brabantplein 32, bij wijze van proef.\"}],\"type\":\"Description\"}]",
+            "type": "LongText",
+            "lines": "[{\"id\":\"86\"}]",
+            "priority": 4,
+            "points": "[{\"id\":\"4594\"}]"
+        },
+        {
+            "content": "[{\"text\":[{\"en\":\"Works. 19 Jan-end of 2026, B53 diverted. B53 at LEOPOLD I (450m) or KERKH. VAN JETTE/CIM. DE JETTE (via T51).\",\"fr\":\"Travaux. 19/1 à fin 2026, bus 53 dévié. Bus 53 à LEOPOLD I (450m) ou à CIMETIERE DE JETTE (via tram 51).\",\"nl\":\"Werken. 19/1 tot eind 2026, bus 53 omgeleid. Bus 53 aan LEOPOLD I (450m) of aan KERKHOF VAN JETTE (via T51).\"}],\"type\":\"Description\"}]",
+            "type": "LongText",
+            "lines": "[{\"id\":\"53\"}]",
+            "priority": 4,
+            "points": "[{\"id\":\"2575\"}]"
+        },
+        {
+            "content": "[{\"text\":[{\"en\":\"Works. 17 May 2025-mid 2027, bus 59 diverted btw BORDET STN and ST- VINCENT, and btw ANATOLE FRANCE and HUART-HAMOIR.\",\"fr\":\"Travaux.17/5/25-mi-2027, B59 dévié entre BORDET STAT. et ST-VINCENT, et entre ANATOLE FRANCE et HUART-HAMOIR.\",\"nl\":\"Werken. 17/5/25-midden 2027, B59 omgeleid tss BORDET STAT. en ST- VINCENTIUS,en ts ANATOLE FRANCE en HUART-HAMOIR.\"}],\"type\":\"Description\"}]",
+            "type": "LongText",
+            "lines": "[{\"id\":\"59\"}]",
+            "priority": 5,
+            "points": "[{\"id\":\"5298\"}]"
+        },
+        {
+            "content": "[{\"text\":[{\"en\":\"Works. 26 Jan-end 2026, tram 81 replaced by temporary bus 96 to WIELS. Stop of bus 96: rue de l’Aqueduc 53.\",\"fr\":\"Travaux. 26/1-fin 2026, tram 81 remplacé par bus temporaire 96 jusqu’à WIELS. Arrêt du bus 96: rue de l’Aqueduc 53.\",\"nl\":\"Werken. 26/1-eind 2026, tram 81 vervangen door tijdelijke bus 96 tot WIELS. Halte van bus 96: Aquaductstraat 53.\"}],\"type\":\"Description\"}]",
+            "type": "LongText",
+            "lines": "[{\"id\":\"81\"}]",
+            "priority": 4,
+            "points": "[{\"id\":\"6425F\"},{\"id\":\"2931F\"}]"
+        },
+        {
+            "content": "[{\"text\":[{\"en\":\"Works. From 22 Jan until mid-June,bus 52 diverted btw PORTE DE HAL and MADELEINE. Info: stib- mivb.be or app.\",\"fr\":\"Travaux. Du 22/1 à mi- juin, bus 52 dévié entre PORTE DE HAL et MADELEINE. Info : stib. brussels ou app.\",\"nl\":\"Werken. Van 22/1 tot midden juni, bus 52 omgeleid tss HALLEPOORT en MAGDALENA. Info: mivb.brussels of app.\"}],\"type\":\"Description\"}]",
+            "type": "LongText",
+            "lines": "[{\"id\":\"52\"}]",
+            "priority": 5,
+            "points": "[{\"id\":\"2735\"},{\"id\":\"2333\"},{\"id\":\"2465\"},{\"id\":\"2463\"},{\"id\":\"2462\"},{\"id\":\"1085\"},{\"id\":\"2736\"}]"
+        },
+        {
+            "content": "[{\"text\":[{\"en\":\"Works. From 31 Mar 2025 to mid-2026, tram 62 limited at BOURGET. Take tram 62 at BOURGET (walk 350 meters - 3 min).\",\"fr\":\"Travaux. Du 31/3/2025 à mi-2026, tram 62 limité à BOURGET. Prenez le tram 62 à BOURGET (350 mètres – 3 min à pied).\",\"nl\":\"Werken. Van 31/3/2025 tot midden 2026, tram 62 beperkt aan BOURGET. Neem tram 62 aan BOURGET (350m - 3min te voet).\"}],\"type\":\"Description\"}]",
+            "type": "LongText",
+            "lines": "[{\"id\":\"62\"}]",
+            "priority": 4,
+            "points": "[{\"id\":\"3335F\"}]"
+        },
+        {
+            "content": "[{\"text\":[{\"en\":\"Works. From 9 Mar to +/- 27 Mar, stop ENNEPETAL served. Temporary stop: Ensorlaan 6.\",\"fr\":\"Travaux. Du 9/3 au +/- 27/3, arrêt ENNEPETAL déplacé. Arrêt provisoire ENNEPETAL: Ensorlaan 6.\",\"nl\":\"Werken. Van 9/3 tot +/- 27/3, halte ENNEPETAL verplaatst. Tijdelijke halte : Ensorlaan 6.\"}],\"type\":\"Description\"}]",
+            "type": "LongText",
+            "lines": "[{\"id\":\"47\"}]",
+            "priority": 4,
+            "points": "[{\"id\":\"9631\"}]"
+        },
+        {
+            "content": "[{\"text\":[{\"en\":\"Works. 26 Jan-end 2026, stop not served. Tram 81 at WIELS via temporary bus 96 from BARRIERE (ch. Waterloo 208).\",\"fr\":\"Travaux. 26/1-fin 2026, arrêt non desservi.T81 à WIELS,via bus temporaire 96 depuis BARRIERE (chée de Waterloo 208).\",\"nl\":\"Werken. 26/1-eind 2026, halte niet bediend. T81 aan WIELS,via tijdelijke bus 96 vanaf BAREEL (Waterloosestwg 208). \"}],\"type\":\"Description\"}]",
+            "type": "LongText",
+            "lines": "[{\"id\":\"81\"}]",
+            "priority": 4,
+            "points": "[{\"id\":\"6165\"}]"
+        },
+        {
+            "content": "[{\"text\":[{\"fr\":\"Le dimanche 5h-15h, marché. Arrêt non desservi. Bus 17-95 à l'arrêt suivant, Les Trois Tilleuls.\",\"nl\":\"Op zondag 5u-15u, markt. Halte niet bediend. Bus 17-95 aan de volgende halte, Drie Linden.\"}],\"type\":\"Description\"}]",
+            "type": "LongText",
+            "lines": "[{\"id\":\"17\"},{\"id\":\"95\"}]",
+            "priority": 6,
+            "points": "[{\"id\":\"4348\"}]"
+        },
+        {
+            "content": "[{\"text\":[{\"en\":\"Works. 26 Jan-end 2026, T81 diverted from AV. DU ROI to WIELS and replaced by temp. bus 96 btw WIELS and TRINITE. \",\"fr\":\"Travaux. 26/1-fin 2026, T81 dévié d'AV. DU ROI vers WIELS et remplacé par bus temporaire 96 entre WIELS et TRINITE. \",\"nl\":\"Werken. 26/1-eind 2026, T81 omgeleid van KONINGSLAAN naar WIELS, vervangen door B96 tss WIELS en DRIEVULDIGHEID.\"}],\"type\":\"Description\"}]",
+            "type": "LongText",
+            "lines": "[{\"id\":\"81\"}]",
+            "priority": 5,
+            "points": "[{\"id\":\"2539F\"},{\"id\":\"3611F\"},{\"id\":\"3612F\"},{\"id\":\"3613F\"},{\"id\":\"3371F\"},{\"id\":\"6858G\"},{\"id\":\"0631\"},{\"id\":\"6705F\"},{\"id\":\"2260F\"},{\"id\":\"6799F\"},{\"id\":\"6860G\"},{\"id\":\"2259F\"},{\"id\":\"6856\"},{\"id\":\"2257G\"},{\"id\":\"6857\"}]"
+        },
+        {
+            "content": "[{\"text\":[{\"en\":\"Works. Until end 2026, stop not served. T81 at WIELS (as of 26 Jan), bus 96: ch. Waterloo 208\",\"fr\":\"Travaux. Jsq fin 2026, arrêt non desservi. T81 à WIELS (dès le 26/1), bus 96: ch. Waterloo 208\",\"nl\":\"Werken. Tot eind 2026, halte niet bediend. T81 aan WIELS (vanaf 26/1), bus 96: Waterloosestwg 208\"}],\"type\":\"Description\"}]",
+            "type": "LongText",
+            "lines": "[{\"id\":\"81\"}]",
+            "priority": 4,
+            "points": "[{\"id\":\"6078\"}]"
+        },
+        {
+            "content": "[{\"text\":[{\"en\":\"Works. From 21 Mar until 22 Mar at 6.30pm, bus 21 diverted btw RTL HOUSE and DIAMANT via place Meiserplein.\",\"fr\":\"Travaux. Du 21/3 au 22/3 à 18h30, bus 21 dévié entre RTL HOUSE et DIAMANT via place Meiser.\",\"nl\":\"Werken. Van 21/3 tot 22/3 om 18.30u, bus 21 omgeleid tussen RTL HOUSE en DIAMANT via Meiserplein.\"}],\"type\":\"Description\"}]",
+            "type": "LongText",
+            "lines": "[{\"id\":\"21\"}]",
+            "priority": 5,
+            "points": "[{\"id\":\"3425\"},{\"id\":\"3458\"},{\"id\":\"3468\"},{\"id\":\"4500B\"},{\"id\":\"3214\"},{\"id\":\"3466\"},{\"id\":\"2695\"},{\"id\":\"3361\"},{\"id\":\"2924\"}]"
+        },
+        {
+            "content": "[{\"text\":[{\"en\":\"Works. Until end of April, B88 diverted btw GUILL. DE GREEF / CROCQ; B14 btw STATION/GARE DE JETTE / CROCQ.\",\"fr\":\"Travaux. Jusqu'à fin avril, bus 88 dévié entre GUILLAUME DE GREEF et CROCQ., bus 14 entre GARE DE JETTE et CROCQ.\",\"nl\":\"Werken. Tot eind april, bus 88 omgeleid tussen GUILLAUME DE GREEF en CROCQ, B14 tussen STATION JETTE en CROCQ.\"}],\"type\":\"Description\"}]",
+            "type": "LongText",
+            "lines": "[{\"id\":\"14\"}]",
+            "priority": 5,
+            "points": "[{\"id\":\"1767\"},{\"id\":\"1766\"},{\"id\":\"2515B\"},{\"id\":\"1212\"},{\"id\":\"1056\"},{\"id\":\"3245\"},{\"id\":\"1671\"},{\"id\":\"5076B\"},{\"id\":\"1082\"}]"
+        },
+        {
+            "content": "[{\"text\":[{\"fr\":\"Le dimanche 5h-15h, marché. Arrêt non desservi. Arrêt provis: bd. du Souverain, peu avant rue du Major Brück\",\"nl\":\"Op zondag 5u-15u, markt. Halte niet bediend. Tijd. halte: Vorstlaan, net voor Majoor Brückstraat.\"}],\"type\":\"Description\"}]",
+            "type": "LongText",
+            "lines": "[{\"id\":\"17\"}]",
+            "priority": 6,
+            "points": "[{\"id\":\"4349\"}]"
+        },
+        {
+            "content": "[{\"text\":[{\"en\":\"Works. From 4 Aug 2025 to May 2026, bus 54 diverted. Stop of bus 54: JANSON (rue Defacqzstraat 131).\",\"fr\":\"Travaux. Du 4/8/2025 à mai 2026, bus 54 dévié. Arrêt du bus 54 : JANSON (rue Defacqz 131).\",\"nl\":\"Werken. Van 4/8/2025 tot mei 2026, bus 54 omgeleid. Halte van bus 54: JANSON (Defacqzstraat 131).\"}],\"type\":\"Description\"}]",
+            "type": "LongText",
+            "lines": "[{\"id\":\"54\"}]",
+            "priority": 4,
+            "points": "[{\"id\":\"2931\"}]"
+        },
+        {
+            "content": "[{\"text\":[{\"en\":\"Match. 22 Mar, 3.30pm- 1am, STOP NOT SERVED. Bus 46 at the stop VAN BEETHOVEN of tram 81 to MONTGOMERY.\",\"fr\":\"Match. 22/3, 15h30-1h, ARRET NON DESSERVI. Bus 46 à l'arrêt VAN BEETHOVEN du tram 81 vers MONTGOMERY.\",\"nl\":\"Match. 22/3, 15.30u-1u, HALTE NIET BEDIEND. Bus 46 aan de halte VAN BEETHOVEN van tram 81 naar MONTGOMERY.\"}],\"type\":\"Description\"}]",
+            "type": "LongText",
+            "lines": "[{\"id\":\"46\"}]",
+            "priority": 4,
+            "points": "[{\"id\":\"3755\"}]"
+        },
+        {
+            "content": "[{\"text\":[{\"en\":\"Works. As of 23 Mar for +/- 3 weeks, bus 53 and 56 diverted btw PETER BENOIT and HOP.MILITAIRE / MILITAIR HOSPITAAL.\",\"fr\":\"Travaux.Dès le 23/3 pour +/- 3 semaines, bus 53 et 56 déviés entre PETER BENOIT et HOPITAL MILITAIRE.\",\"nl\":\"Werken. Vanaf 23/3 voor +/- 3 weken, bus 53 en 56 omgeleid tussen PETER BENOIT en MILITAIR HOSPITAAL.\"}],\"type\":\"Description\"}]",
+            "type": "LongText",
+            "lines": "[{\"id\":\"56\"},{\"id\":\"53\"}]",
+            "priority": 5,
+            "points": "[{\"id\":\"1989\"}]"
+        },
+        {
+            "content": "[{\"text\":[{\"en\":\"Until 2027, works. Tram 97 temporarily withdrawn. For BARRIERE or MORIS, bus 96 (av. Wielemans-Ceuppens 99)\",\"fr\":\"Jsq 2027, travaux. Tram 97 temporairement supprimé. Pour BARRIERE et MORIS, bus 96 (av. Wielemans-Ceuppens 99)\",\"nl\":\"Tot 2027, werken. Tram 97 tijdelijk geschrapt. Voor BAREEL of MORIS, bus 96 (W.-Ceuppenslaan 99)\"}],\"type\":\"Description\"}]",
+            "type": "LongText",
+            "lines": "[]",
+            "priority": 4,
+            "points": "[{\"id\":\"5158\"}]"
+        },
+        {
+            "content": "[{\"text\":[{\"en\":\"Works. Until 29 March, temporary bus 96 diverted from BARRIERE to MA CAMPAGNE. MORIS not served.\",\"fr\":\"Travaux. Jusqu'au 29/3, bus temporaire 96 dévié de BARRIERE à MA CAMPAGNE. MORIS non desservi.\",\"nl\":\"Werken. Tot en met 29/3, tijdelijke bus 96 omgeleid tss BAREEL en MA CAMPAGNE. MORIS niet bediend.\"}],\"type\":\"Description\"}]",
+            "type": "LongText",
+            "lines": "[{\"id\":\"96\"}]",
+            "priority": 6,
+            "points": "[{\"id\":\"2524\"},{\"id\":\"1730\"},{\"id\":\"1740\"},{\"id\":\"2333\"},{\"id\":\"5107B\"},{\"id\":\"1735\"}]"
+        },
+        {
+            "content": "[{\"text\":[{\"en\":\"Works. As of 5 Jan, bus 50 diverted. To continue to GARE DU MIDI / ZUIDSTATION, take bus 49.\",\"fr\":\"Travaux. Dès le 5/1, bus 50 dévié. Pour continuer vers GARE DU MIDI, prenez le bus 49.\",\"nl\":\"Werken. Vanaf 5/1, bus 50 omgeleid. Om verder naar ZUIDSTATION te reizen, neem bus 49.\"}],\"type\":\"Description\"}]",
+            "type": "LongText",
+            "lines": "[{\"id\":\"50\"}]",
+            "priority": 4,
+            "points": "[{\"id\":\"2524\"}]"
+        },
+        {
+            "content": "[{\"text\":[{\"en\":\"Until 2027, works. Tram 97 does not serve this stop. Take tram 92 at MARLOW to go to DIEWEG.\",\"fr\":\"Jusqu'en 2027, travaux. tram 97 ne dessert pas cet arrêt. Prenez le tram 92 à MARLOW pour rejoindre DIEWEG.\",\"nl\":\"Tot 2027, werken. Tram 97 bedient deze halte niet. Neem tram 92 aan MARLOW om naar DIEWEG te gaan.\"}],\"type\":\"Description\"}]",
+            "type": "LongText",
+            "lines": "[]",
+            "priority": 4,
+            "points": "[{\"id\":\"1985G\"}]"
+        },
+        {
+            "content": "[{\"text\":[{\"en\":\"Works.4 Aug to Dec 2026, T51 interrupted. T51 at MARGUERITE DURAS (via M2-6 btw ELISABETH-YSER) or GARE DU MIDI (via M6)\",\"fr\":\"Travaux. 4/8 à décembre 2026, T51 interrompu. T51 à MARGUERITE DURAS (via M2-6 ELISABETH- YSER) ou GARE DU MIDI.\",\"nl\":\"Werken.4/8 tot december 2026, T51 onderbroken. T51 aan MARGUERITE DURAS (via M2-6 tss.ELISABETH- IJZER)of ZUIDSTATION.\"}],\"type\":\"Description\"}]",
+            "type": "LongText",
+            "lines": "[{\"id\":\"51\"}]",
+            "priority": 4,
+            "points": "[{\"id\":\"5009G\"}]"
+        },
+        {
+            "content": "[{\"text\":[{\"en\":\"Until 2027, works. Tram 97 temporarily withdrawn. For ST-DENIS / ST-DENIJS, take bus 74 at WAGON / WAGEN.\",\"fr\":\"Jusqu’en 2027, travaux. Tram 97 temporairement supprimé. Pour SAINT- DENIS, prenez le bus 74 à WAGON.\",\"nl\":\"Tot 2027, werken. Tram 97 tijdelijk geschrapt. Voor SINT-DENIJS, neem bus 74 aan WAGEN.\"}],\"type\":\"Description\"}]",
+            "type": "LongText",
+            "lines": "[]",
+            "priority": 4,
+            "points": "[{\"id\":\"2708G\"},{\"id\":\"2709F\"},{\"id\":\"2710G\"},{\"id\":\"1984G\"}]"
+        },
+        {
+            "content": "[{\"text\":[{\"en\":\"Works. From 26 Jan, bus 65 diverted. Temporary stop: Steenweg Buda 40- 42.\",\"fr\":\"Travaux. Dès le 26/1, bus 65 dévié. Arrêt provisoire: Steenweg Buda 40-42.\",\"nl\":\"Werken. Vanaf 26/1, bus 65 omgeleid. Tijdelijke halte: Steenweg Buda 40- 42.\"}],\"type\":\"Description\"}]",
+            "type": "LongText",
+            "lines": "[{\"id\":\"65\"}]",
+            "priority": 4,
+            "points": "[{\"id\":\"9703\"}]"
+        },
+        {
+            "content": "[{\"text\":[{\"en\":\"Works. Stop of tram 10 moved backwards of +/- 100m, avenue de Tyraslaan\",\"fr\":\"Travaux. Arrêt du tram 10 reculé de +/- 100m, avenue de Tyras.\",\"nl\":\"Werken. Halte van tram 10 achteruitgebracht van +/- 100m, de Tyraslaan\"}],\"type\":\"Description\"}]",
+            "type": "LongText",
+            "lines": "[{\"id\":\"10\"}]",
+            "priority": 4,
+            "points": "[{\"id\":\"5795F\"}]"
+        },
+        {
+            "content": "[{\"text\":[{\"en\":\"Works. As of 18 Aug, stop moved rue du Noyer / Notelaarsstraat, in front of number 254.\",\"fr\":\"Travaux. Dès le 18/8, arrêt déplacé rue du Noyer, en face du numéro 254.\",\"nl\":\"Werken. Vanaf 18/8, halte verplaatst Notelaarsstraat, tegenover nummer 254.\"}],\"type\":\"Description\"}]",
+            "type": "LongText",
+            "lines": "[{\"id\":\"61\"}]",
+            "priority": 4,
+            "points": "[{\"id\":\"6023\"}]"
+        },
+        {
+            "content": "[{\"text\":[{\"en\":\"Match. 22 Mar, 3.30pm- 1am, bus 75 diverted between RENE HENRY and VAN BEETHOVEN via avenue Marius Renard.\",\"fr\":\"Match. 22/3, 15h30-1h, bus 75 dévié entre RENE HENRY et VAN BEETHOVEN via avenue Marius Renard.\",\"nl\":\"Match. 22/3, 15.30u-1u, bus 75 omgeleid tussen RENE HENRY en VAN BEETHOVEN via Marius Renardlaan.\"}],\"type\":\"Description\"}]",
+            "type": "LongText",
+            "lines": "[{\"id\":\"75\"}]",
+            "priority": 6,
+            "points": "[{\"id\":\"1204\"},{\"id\":\"1489\"},{\"id\":\"1488\"},{\"id\":\"1487\"},{\"id\":\"1486B\"}]"
+        },
+        {
+            "content": "[{\"text\":[{\"en\":\"Works. Until 2027, bus 74 diverted from VICTOR ALLARD to VAN HAELEN. UCCLE-STALLE / UKKEL- STALLE not served.\",\"fr\":\"Travaux. Jusqu’en 2027, bus 74 dévié depuis VICTOR ALLARD vers VAN HAELEN. UCCLE-STALLE non desservi.\",\"nl\":\"Werken. Tot 2027, bus 74 omgeleid vanaf VICTOR ALLARD naar VAN HAELEN. UKKEL-STALLE niet bediend\"}],\"type\":\"Description\"}]",
+            "type": "LongText",
+            "lines": "[{\"id\":\"74\"}]",
+            "priority": 5,
+            "points": "[{\"id\":\"2952B\"},{\"id\":\"3682\"},{\"id\":\"3074\"},{\"id\":\"2614\"},{\"id\":\"2602\"},{\"id\":\"2601\"},{\"id\":\"5719\"},{\"id\":\"2226\"},{\"id\":\"2523\"},{\"id\":\"2600\"},{\"id\":\"2732\"},{\"id\":\"1015\"},{\"id\":\"2225\"},{\"id\":\"2555\"},{\"id\":\"2599\"},{\"id\":\"2598\"},{\"id\":\"2607\"},{\"id\":\"2606\"},{\"id\":\"2605\"}]"
+        },
+        {
+            "content": "[{\"text\":[{\"en\":\"Works. As of 29 Jan, stop ROCHEFORT moved. Stop of bus 52 and N12: bd Guillaume Van Haelen, in front of number 198.\",\"fr\":\"Travaux. Dès le 29/1, arrêt ROCHEFORT déplacé. Arrêt des bus 52 et N12: boulevard Guillaume Van Haelen, face au 198.\",\"nl\":\"Werken.Vanaf 29/1, halte ROCHEFORT verplaatst. Halte bus 52 N12: Guill. Van Haelenlaan, tegenover nummer 198.\"}],\"type\":\"Description\"}]",
+            "type": "LongText",
+            "lines": "[{\"id\":\"N12\"},{\"id\":\"52\"}]",
+            "priority": 4,
+            "points": "[{\"id\":\"1730\"}]"
+        },
+        {
+            "content": "[{\"text\":[{\"en\":\"Works. From 21 Mar until 22 Mar at 6.30pm, bus 21 diverted between DIAMANT and RTL HOUSE. Take bus 21 at DIAMANT.\",\"fr\":\"Travaux. Du 21/3 au 22/3 à 18h30, bus 21 dévié entre DIAMANT et RTL HOUSE. Prenez le bus 21 à DIAMANT.\",\"nl\":\"Werken. Van 21/3 tot 22/3 om 18.30u, bus 21 omgeleid tussen DIAMANT en RTL HOUSE. Neem bus 21 aan DIAMANT.\"}],\"type\":\"Description\"}]",
+            "type": "LongText",
+            "lines": "[{\"id\":\"21\"}]",
+            "priority": 4,
+            "points": "[{\"id\":\"3905\"}]"
+        },
+        {
+            "content": "[{\"text\":[{\"en\":\"Works. 16 Feb 26-2027, bus 74 diverted bt GRAND ROUTE and CARR. STALLE. B74 at CARR. STALLE (stop B75 to HEROS)\",\"fr\":\"Travaux. Du 16/2 à 2027, bus 74 dévié de GRAND ROUTE à CARR. STALLE. B74 à CARR. STALLE(arrêt bus 75 vers HEROS)\",\"nl\":\"Werken. 16/2/26-2027, bus 74 omgeleid ts GROTE BAAN en KRUISPT STALLE. B74 aan KRUISPT STALLE (halte B75 naar HELDEN)\"}],\"type\":\"Description\"}]",
+            "type": "LongText",
+            "lines": "[{\"id\":\"74\"}]",
+            "priority": 4,
+            "points": "[{\"id\":\"1452TMP\"},{\"id\":\"7465TMP\"}]"
+        },
+        {
+            "content": "[{\"text\":[{\"en\":\"Works. From 22 Jan until mid-June, bus 48 52 diverted. Stop of bus 48 and 52: PORTE DE HAL (bd du Midi 142).\",\"fr\":\"Travaux. Du 22/1 à mi- juin, bus 48 52 déviés. Arrêt des bus 48 et 52 : PORTE DE HAL (boulevard du Midi 142).\",\"nl\":\"Werken. Van 22/1 tot midden juni, bus 48 52 omgeleid. Halte van bus 48 en 52: HALLEPOORT (Zuidlaan 142).\"}],\"type\":\"Description\"}]",
+            "type": "LongText",
+            "lines": "[{\"id\":\"48\"},{\"id\":\"52\"}]",
+            "priority": 4,
+            "points": "[{\"id\":\"1126\"},{\"id\":\"1125\"}]"
+        },
+        {
+            "content": "[{\"text\":[{\"en\":\"Works. From 27 Feb, 6pm, until end of April, B14 88 diverted. Stops: CROCQ (their previous one).\",\"fr\":\"Travaux. Dès le 27/2, 18h, jusqu'à fin avril, B 14 88 dévié. Prenez votre bus à son arrêt précédent, CROCQ.\",\"nl\":\"Werken. Van 27/2, 18u, tot eind april, worden B 14 88 omgeleid. Neem je bus aan halte CROCQ (de vorige halte).\"}],\"type\":\"Description\"}]",
+            "type": "LongText",
+            "lines": "[{\"id\":\"88\"},{\"id\":\"14\"}]",
+            "priority": 4,
+            "points": "[{\"id\":\"2803\"}]"
+        },
+        {
+            "content": "[{\"text\":[{\"en\":\"Works. As of Monday 4 Aug., 6am, bus 47 is diverted, for +/- 2 months. Take the bus at: (David) Teniersstr. 151.\",\"fr\":\"Travaux. Dès le lundi 4/8, 6h, bus 47 dévié pendant +/- 2 mois. Arrêt: (David) Teniersstraat 151-157.\",\"nl\":\"Werken. Vanaf maandag 4/8, 6u, wordt bus 47 omgeleid voor +/- 2 maand. Neem je bus aan: (D.)Teniersstraat 151.\"}],\"type\":\"Description\"}]",
+            "type": "LongText",
+            "lines": "[]",
+            "priority": 4,
+            "points": "[{\"id\":\"1485\"}]"
+        },
+        {
+            "content": "[{\"text\":[{\"en\":\"Works. 21 Mar-22 Mar, 6. 30pm, bus 79 diverted btw DIAMANT and CARENE. Take bus 79 at CARENE (av. Léon Grosjean 79)\",\"fr\":\"Travaux. 21/3-22/3, 18h30,bus 79 dévié entre DIAMANT et CARENE.Prenez le bus 79 à CARENE (av. Léon Grosjean 79).\",\"nl\":\"Werken. 21/3-22/3, 18. 30u, bus 79 omgeleid tss DIAMANT en CARINA. Neem bus 79 aan CARINA (Léon Grosjeanlaan 79)\"}],\"type\":\"Description\"}]",
+            "type": "LongText",
+            "lines": "[{\"id\":\"79\"}]",
+            "priority": 4,
+            "points": "[{\"id\":\"3905\"}]"
+        },
+        {
+            "content": "[{\"text\":[{\"en\":\"Works. As of 23 Mar, stop of bus 59 is relocated to rue Metsysstraat 41.\",\"fr\":\"Travaux, à partir du lundi 23/3, arrêt du B59 déplacé rue Metsys numéro 41.\",\"nl\":\"Werken. Vanaf maandag 23/3, halte van bus 59 verplaatst Metsysstraat 41.\"}],\"type\":\"Description\"}]",
+            "type": "LongText",
+            "lines": "[{\"id\":\"59\"}]",
+            "priority": 4,
+            "points": "[{\"id\":\"3167\"}]"
+        },
+        {
+            "content": "[{\"text\":[{\"en\":\"Works. As of 10 Jul (Thursday), B36 diverted. Stop moved to Val des Seigneurs / Herendal 4.\",\"fr\":\"Travaux. Dès le jeudi 10/7. B36 dévie, arrêt déplacé Val des Seigneurs numéro 4.\",\"nl\":\"Werken. Vanaf donderdag 10/7. B36 omgeleid; halte verplaatst naar Herendal 4. \"}],\"type\":\"Description\"}]",
+            "type": "LongText",
+            "lines": "[{\"id\":\"36\"}]",
+            "priority": 4,
+            "points": "[{\"id\":\"1302\"}]"
+        },
+        {
+            "content": "[{\"text\":[{\"en\":\"On Sunday 5AM-4PM, Market. STOP NOT SERVED. B80 at the stop LEMAN of B36 to Konkel, av. d'Auderghem\",\"fr\":\"Le dimanche 5h-16h, marché. ARRET NON DESSERVI. B80 à l'arrêt LEMAN du B36 vers Konkel, av. d'Auderghem\",\"nl\":\"Op zondag 5u-16u, markt. HALTE NIET BEDIEND. Bus 80 aan de halte LEMAN van bus 36 richting Konkel, Oudergemselaan\"}],\"type\":\"Description\"}]",
+            "type": "LongText",
+            "lines": "[{\"id\":\"80\"}]",
+            "priority": 5,
+            "points": "[{\"id\":\"3953\"}]"
+        },
+        {
+            "content": "[{\"text\":[{\"en\":\"Works. Stop of bus 38 moved to the Cantersteen, at the stop of bus 52 to FOREST / VORST (BERVOETS)\",\"fr\":\"Travaux. Arrêt du bus 38 déplacé Cantersteen, à l'arrêt du bus 52 vers FOREST (BERVOETS).\",\"nl\":\"Werken. Halte van bus 38 verplaatst naar de Kantersteen, aan de halte van bus 52 naar VORST (BERVOETS).\"}],\"type\":\"Description\"}]",
+            "type": "LongText",
+            "lines": "[{\"id\":\"38\"}]",
+            "priority": 4,
+            "points": "[{\"id\":\"6443\"}]"
+        },
+        {
+            "content": "[{\"text\":[{\"en\":\"Works. 22 Jan-mid-June, bus 48 diverted. For GRAND-PLACE or MANNEKEN- PIS, take bus 95. Walk to ANNEESSENS.\",\"fr\":\"Travaux. Du 22/1 à mi- juin, bus 48 dévié. Pour GRAND-PLACE ou MANNEKEN- PIS, prenez le bus 95. Pour ANNEESSENS, à pied.\",\"nl\":\"Werken.22/1-midden juni, bus 48 omgeleid. Voor GROTE MARKT of MANNEKEN- PIS, neem bus 95. Voor ANNEESSENS, ga te voet.\"}],\"type\":\"Description\"}]",
+            "type": "LongText",
+            "lines": "[{\"id\":\"48\"}]",
+            "priority": 4,
+            "points": "[{\"id\":\"1781\"},{\"id\":\"3630\"}]"
+        },
+        {
+            "content": "[{\"text\":[{\"en\":\"Works. 26 Jan-end 2026, tram 81 replaced by temporary bus 96 between TRINITE and WIELS. Info: stib-mivb.be or app.\",\"fr\":\"Travaux. 26/1-fin 2026, tram 81 remplacé par bus temporaire 96 entre TRINITE et WIELS. Info: stib.brussels ou app.\",\"nl\":\"Werken. 26/1-eind 2026, tram 81 vervangen door tijdelijke bus 96 tss DRIEVULDIGHEID en WIELS. Info: mivb.brussels, app\"}],\"type\":\"Description\"}]",
+            "type": "LongText",
+            "lines": "[{\"id\":\"81\"}]",
+            "priority": 6,
+            "points": "[{\"id\":\"6153\"},{\"id\":\"2286G\"},{\"id\":\"2380F\"},{\"id\":\"6157F\"},{\"id\":\"6009\"},{\"id\":\"6156F\"},{\"id\":\"6158H\"},{\"id\":\"6155F\"},{\"id\":\"6462F\"},{\"id\":\"3572F\"}]"
+        },
+        {
+            "content": "[{\"text\":[{\"en\":\"Works. As of 5 Jan, bus 50 diverted btw BERVOETS and WIELS, bus 74 diverted btw BERVOETS and CHARROI, via UNION.\",\"fr\":\"Travaux. Dès le 5/1, bus 50 dévié entre BERVOETS et WIELS, bus 74 dévié entre BERVOETS et CHARROI, via UNION.\",\"nl\":\"Werken. Vanaf 5/1, bus 50 omgeleid tss BERVOETS en WIELS, bus 74 omgeleid tussen BERVOETS en GERIJ, via UNION.\"}],\"type\":\"Description\"}]",
+            "type": "LongText",
+            "lines": "[{\"id\":\"50\"},{\"id\":\"74\"}]",
+            "priority": 5,
+            "points": "[{\"id\":\"1248\"},{\"id\":\"1085\"}]"
+        },
+        {
+            "content": "[{\"text\":[{\"en\":\"Works. 26 Jan-end of 2026, stop not served. Tram 81 at TRINITE via temporary bus 96 from BARRIERE (av. du Parc).\",\"fr\":\"Travaux. 26/1-fin 2026, arrêt non desservi. Tram 81 à TRINITE, via bus temporaire 96 depuis BARRIERE (av. du Parc).\",\"nl\":\"Werken. 26/1-eind 2026, halte niet bediend. Tram 81 aan DRIEVULDIGHEID, via tijdelijke bus 96 vanaf BAREEL (Parklaan).\"}],\"type\":\"Description\"}]",
+            "type": "LongText",
+            "lines": "[{\"id\":\"81\"}]",
+            "priority": 4,
+            "points": "[{\"id\":\"6121F\"}]"
+        },
+        {
+            "content": "[{\"text\":[{\"en\":\"Works. From 21 Mar to 22 Mar at 6.30pm, bus 21 diverted btw DIAMANT and RTL HOUSE. Stop of bus 21: chée de Louvain 770.\",\"fr\":\"Travaux. Du 21/3 au 22/3 à 18h30, bus 21 dévié entre DIAMANT et RTL HOUSE. Arrêt du bus 21: chaussée de Louvain 770.\",\"nl\":\"Werken. Van 21/3 tot 22/3 om 18.30u, bus 21 omgeleid tussen DIAMANT en RTL HOUSE. Halte van bus 21: Leuvensestwg 770\"}],\"type\":\"Description\"}]",
+            "type": "LongText",
+            "lines": "[{\"id\":\"21\"}]",
+            "priority": 4,
+            "points": "[{\"id\":\"3961\"},{\"id\":\"4558\"}]"
+        },
+        {
+            "content": "[{\"text\":[{\"en\":\"Passages of 04:26 - 04: 55 - 06:12 - 09:39 from stop of bus 59 to HOPITAL ETTERBEEK- IXELLES\",\"fr\":\"Passages de 04:26 - 04: 55 - 06:12 - 09:39 depuis l'arrêt du bus 59 direction HOP. ETTERBEEK-IXELLES.\",\"nl\":\"Doorkomsten van 04:26 - 04:55 - 06:12 - 09:39 vanaf halte bus 59 richting ZIEKH. ETTERBEEK-ELSENE.\"}],\"type\":\"Description\"}]",
+            "type": "LongText",
+            "lines": "[{\"id\":\"21\"}]",
+            "priority": 4,
+            "points": "[{\"id\":\"3214\"}]"
+        },
+        {
+            "content": "[{\"text\":[{\"en\":\"Works. As of 23 Mar for +/- 3 weeks,terminus VAL MARIA / MARIENDAAL of bus 83 moved Kruisberg, short after number 23.\",\"fr\":\"Travaux.Dès le 23/3 pour +/- 3 semaines, terminus VAL MARIA du bus 83 déplacé Kruisberg, peu après le numéro 23.\",\"nl\":\"Werken. Vanaf 23/3 voor +/- 3 weken, eindpunt MARIENDAAL van bus 83 verplaatst Kruisberg, kort na huisnummer 23.\"}],\"type\":\"Description\"}]",
+            "type": "LongText",
+            "lines": "[{\"id\":\"83\"}]",
+            "priority": 4,
+            "points": "[{\"id\":\"2822\"}]"
+        },
+        {
+            "content": "[{\"text\":[{\"en\":\"Works. As of 14/8, 6am. B46's stop is moved to rue de Laeken/Lakensestr 61-63 after crossing rue Hirond./Zwaluwenstr.\",\"fr\":\"Travaux. Dès 14/8, 6h, arrêt du B46 déplacé rue de Laeken 61-63 après le carrefour avec rue des Hirondelles.\",\"nl\":\"Werken. Vanaf 14/8, 6u, B46: halte verplaatst naar Lakensestr. 61-63, na kruispunt met Zwaluwenstr.\"}],\"type\":\"Description\"}]",
+            "type": "LongText",
+            "lines": "[{\"id\":\"46\"}]",
+            "priority": 4,
+            "points": "[{\"id\":\"3465\"}]"
+        },
+        {
+            "content": "[{\"text\":[{\"en\":\"Subsidence. Stop not served. Walk to HOPITAL ETTERBEEK-IXELLES / ZIEKENHUIS ETTERBEEK- ELSENE.\",\"fr\":\"Effondrement de voirie. Arrêt non desservi. Rejoignez HOPITAL ETTERBEEK-IXELLES à pied.\",\"nl\":\"Grondverzakking. Halte niet bediend. Ga te voet naar ZIEKENHUIS ETTERBEEK-ELSENE.\"}],\"type\":\"Description\"}]",
+            "type": "LongText",
+            "lines": "[{\"id\":\"59\"}]",
+            "priority": 4,
+            "points": "[{\"id\":\"3131\"}]"
+        },
+        {
+            "content": "[{\"text\":[{\"en\":\"Works. Until May 2026, bus 54 diverted.Stop bus 54: av. Ducpétiauxlaan 13. Temporary bus 96 at this stop.\",\"fr\":\"Travaux. Jsq mai 2026, bus 54 dévié. Arrêt du bus 54 : av. Ducpétiaux 13. Bus temporaire 96 à cet arrêt.\",\"nl\":\"Werken. Tot mei 2026, bus 54 omgeleid. Halte bus 54: Ducpétiauxlaan 13. Tijdelijke bus 96 aan deze halte.\"}],\"type\":\"Description\"}]",
+            "type": "LongText",
+            "lines": "[{\"id\":\"54\"}]",
+            "priority": 4,
+            "points": "[{\"id\":\"2932\"}]"
+        },
+        {
+            "content": "[{\"text\":[{\"en\":\"Works. 4 Aug to December 2026, T51 interrupted. Take tram 51 at BELGICA (walk or take bus 14 on the side lane).\",\"fr\":\"Travaux. 4/8 à décembre 2026, T51 interrompu. T51 à BELGICA (à pied ou via B14 depuis l'arrêt sur la bande latérale).\",\"nl\":\"Werken. 4/8 tot december 2026, T51 onderbroken. Neem tram 51 aan BELGICA (te voet/via B14 vanaf halte op zijstrook).\"}],\"type\":\"Description\"}]",
+            "type": "LongText",
+            "lines": "[{\"id\":\"51\"}]",
+            "priority": 4,
+            "points": "[{\"id\":\"5074F\"}]"
+        },
+        {
+            "content": "[{\"text\":[{\"en\":\"Until 2027, works. Tram 97 does not serve this stop. Take tram 92 at HEROS / HELDEN to go to DIEWEG.\",\"fr\":\"Jusqu'en 2027, travaux. tram 97 ne dessert pas cet arrêt. Prenez le tram 92 à HEROS pour rejoindre DIEWEG.\",\"nl\":\"Tot 2027, werken. Tram 97 bedient deze halte niet. Neem tram 92 aan HELDEN om naar DIEWEG te gaan.\"}],\"type\":\"Description\"}]",
+            "type": "LongText",
+            "lines": "[]",
+            "priority": 4,
+            "points": "[{\"id\":\"5916F\"},{\"id\":\"5917F\"}]"
+        },
+        {
+            "content": "[{\"text\":[{\"en\":\"Until 2027, works. Tram 97 temporarily withdrawn. For BARRIERE or JANSON, temporary bus 96 at WIELS via tram 82.\",\"fr\":\"Jsq 2027, travaux. T97 temporairement supprimé. Pour BARRIERE ou JANSON, bus temporaire 96 à WIELS via tram 82.\",\"nl\":\"Tot 2027, werken. Tram 97 tijdelijk geschrapt. Voor BAREEL of JANSON, tijdelijke bus 96 aan WIELS via tram 82.\"}],\"type\":\"Description\"}]",
+            "type": "LongText",
+            "lines": "[{\"id\":\"82\"}]",
+            "priority": 4,
+            "points": "[{\"id\":\"5156F\"},{\"id\":\"5164F\"},{\"id\":\"2663G\"}]"
+        },
+        {
+            "content": "[{\"text\":[{\"en\":\"Works. 16 Mar, 7am-27 Mar, 5pm,bus 50 diverted between BERVOETS and ST- DENIS / ST-DENIJS. All stops are served.\",\"fr\":\"Travaux. Du 16/3 à 7h au 27/3 à 17h, bus 50 dévié entre BERVOETS et SAINT- DENIS. Tous les arrêts sont desservis.\",\"nl\":\"Werken. Van 16/3 om 7u tot 27/3 om 17u, bus 50 omgeleid tussen BERVOETS en SINT-DENIJS. Alle haltes worden bediend.\"}],\"type\":\"Description\"}]",
+            "type": "LongText",
+            "lines": "[{\"id\":\"50\"}]",
+            "priority": 5,
+            "points": "[{\"id\":\"2548\"},{\"id\":\"2546\"},{\"id\":\"2544\"},{\"id\":\"2553\"},{\"id\":\"3211\"},{\"id\":\"2539\"}]"
+        },
+        {
+            "content": "[{\"text\":[{\"en\":\"Works. From 27 Februari 6pm until end of April, bus 88 diverted between CROCQ and GUILLAUME DE GREEF.\",\"fr\":\"Travaux.  Du 27 février, 18h, jusqu'à fin avril, bus 88 est dévié entre CROCQ et GUILLAUME DE GREEF.\",\"nl\":\"Werken. Van 27 februari, 18u, tot eind april, bus 88 wordt omgeleid tussen CROCQ en GUILLAUME DE GREEF.\"}],\"type\":\"Description\"}]",
+            "type": "LongText",
+            "lines": "[{\"id\":\"88\"}]",
+            "priority": 5,
+            "points": "[{\"id\":\"1744\"},{\"id\":\"1732\"},{\"id\":\"1743\"},{\"id\":\"4251\"},{\"id\":\"1334\"},{\"id\":\"1466\"},{\"id\":\"2163\"},{\"id\":\"2849\"}]"
+        },
+        {
+            "content": "[{\"text\":[{\"en\":\"Match. 22 Mar, 3.30pm- 1am, STOP NOT SERVED. Take bus 46 at SAINT- GUIDON / SINT-GUIDO.\",\"fr\":\"Match. 22/3, 15h30-1h, ARRET NON DESSERVI. Prenez le bus 46 à SAINT-GUIDON.\",\"nl\":\"Match. 22/3, 15.30u-1u, HALTE NIET BEDIEND. Neem bus 46 aan SINT-GUIDO.\"}],\"type\":\"Description\"}]",
+            "type": "LongText",
+            "lines": "[{\"id\":\"46\"}]",
+            "priority": 6,
+            "points": "[{\"id\":\"2518\"}]"
+        },
+        {
+            "content": "[{\"text\":[{\"en\":\"Works. From 4 Aug to December 2026, stop of bus 14 relocated. Take bus 14 on the side lane next to this stop. \",\"fr\":\"Travaux. Du 4/8 à décembre 2026, arrêt du bus 14 déplacé. Bus 14 sur la bande latérale à côté de cet arrêt. \",\"nl\":\"Werken. Van 4/8 tot december 2026, halte van bus 14 verplaatst. Neem bus 14 op de zijstrook naast deze halte.\"}],\"type\":\"Description\"}]",
+            "type": "LongText",
+            "lines": "[{\"id\":\"14\"}]",
+            "priority": 4,
+            "points": "[{\"id\":\"5074F\"}]"
+        },
+        {
+            "content": "[{\"text\":[{\"en\":\"Works. From 4 Aug to December 2026, tram 51 interrupted. For BELGICA, take bus 14 at SUZAN DANIEL (600m).\",\"fr\":\"Travaux. Du 4/8 à décembre 2026, tram 51 interrompu. Pour BELGICA, prenez le bus 14 à SUZAN DANIEL(600m).\",\"nl\":\"Werken. Van 4/8 tot december 2026, tram 51 onderbroken. Voor BELGICA, neem bus 14 aan SUZAN DANIEL (600m).\"}],\"type\":\"Description\"}]",
+            "type": "LongText",
+            "lines": "[{\"id\":\"51\"}]",
+            "priority": 4,
+            "points": "[{\"id\":\"5071\"}]"
+        },
+        {
+            "content": "[{\"text\":[{\"en\":\"Works. From 17 May 2025 to mid 2027, bus 69 extended from SCHAERBEEK GARE / SCHAARBEEK STATION to VERBOEKHOVEN.\",\"fr\":\"Travaux. Du 17/5/25 à mi-2027, bus 69 prolongé de SCHAERBEEK GARE à VERBOEKHOVEN. \",\"nl\":\"Werken. Van 17/5/25 tot midden 2027, bus 69 verlengd van SCHAARBEEK STATION tot VERBOEKHOVEN.\"}],\"type\":\"Description\"}]",
+            "type": "LongText",
+            "lines": "[{\"id\":\"69\"}]",
+            "priority": 5,
+            "points": "[{\"id\":\"9311\"},{\"id\":\"5361\"},{\"id\":\"3105\"},{\"id\":\"3104\"},{\"id\":\"3126B\"},{\"id\":\"5046\"},{\"id\":\"3103\"},{\"id\":\"3102\"},{\"id\":\"3101\"}]"
+        },
+        {
+            "content": "[{\"text\":[{\"en\":\"Works. As of 23 Mar for +/- 3 weeks, bus 56 diverted btw PETER BENOIT and HOP.MILITAIRE / MILITAIR HOSP.\",\"fr\":\"Travaux.Dès le 23/3 pour +/- 3 semaines, bus 56 dévié entre PETER BENOIT et HOPITAL MILITAIRE via rue de Ransbeek.\",\"nl\":\"Werken. Vanaf 23/3 voor +/- 3 weken, bus 56 omgeleid ts PETER BENOIT en MILITAIR HOSPITAAL via Ransbeekstraat.\"}],\"type\":\"Description\"}]",
+            "type": "LongText",
+            "lines": "[{\"id\":\"56\"}]",
+            "priority": 5,
+            "points": "[{\"id\":\"1086\"},{\"id\":\"2098\"},{\"id\":\"3451\"},{\"id\":\"1062\"},{\"id\":\"2095\"},{\"id\":\"2093\"},{\"id\":\"1006\"},{\"id\":\"2898\"},{\"id\":\"1577\"},{\"id\":\"2367\"},{\"id\":\"3412\"},{\"id\":\"1068\"},{\"id\":\"2101\"}]"
+        },
+        {
+            "content": "[{\"text\":[{\"en\":\"Works. From 16 Feb until 2027, bus 74 diverted btw GROTE BAAN and KRUISPUNT STALLE. Stop bus 74: Grote Baan 375.\",\"fr\":\"Travaux. Du 16/2 à 2027, bus 74 dévié entre GRAND’ROUTE et CARREFOUR STALLE. Arrêt du bus 74 : Grand’Route 375.\",\"nl\":\"Werken. Van 16/2 tot 2027, bus 74 omgeleid tss GROTE BAAN en KRUISPUNT STALLE. Halte bus 74: Grote Baan 375.\"}],\"type\":\"Description\"}]",
+            "type": "LongText",
+            "lines": "[{\"id\":\"74\"}]",
+            "priority": 4,
+            "points": "[{\"id\":\"1039\"},{\"id\":\"3405TMP\"},{\"id\":\"7474TMP\"}]"
+        },
+        {
+            "content": "[{\"text\":[{\"en\":\"Works. From 27 Oct 7am, for about 5 working days,  B53 88's stop is moved to rue Léopold I /Leopold I-straat  172.\",\"fr\":\"Travaux. A partir du lundi 27/10, 7h, pour +/- 5 jours ouvrables, arrêt du B53 88 déplacé rue Léopold I 172.\",\"nl\":\"Werken. Vanaf 27/10, 7u, gedurende +/- een werkweek, halte van B53 88 verplaatst naar Leopold I-straat 172.\"}],\"type\":\"Description\"}]",
+            "type": "LongText",
+            "lines": "[{\"id\":\"88\"},{\"id\":\"53\"}]",
+            "priority": 4,
+            "points": "[{\"id\":\"2171\"}]"
+        },
+        {
+            "content": "[{\"text\":[{\"en\":\"Works. From 7 Oct at 10am, stop relocated. Temporary stop: avenue Huart Hamoirlaan 146.\",\"fr\":\"Travaux. Dès le 7/10 à 10h, arrêt déplacé. Arrêt provisoire: avenue Huart Hamoir 146.\",\"nl\":\"Werken. Vanaf 7/10 om 10u, halte verplaatst. Tijdelijke halte: Huart Hamoirlaan 146.\"}],\"type\":\"Description\"}]",
+            "type": "LongText",
+            "lines": "[{\"id\":\"59\"}]",
+            "priority": 4,
+            "points": "[{\"id\":\"1888\"}]"
+        },
+        {
+            "content": "[{\"text\":[{\"en\":\"Works. 4 Aug to December 2026, T51 interrupted. For BELGICA, take M2-6 to ELISABETH, then M6 to ROI BAUDOUIN. \",\"fr\":\"Travaux. 4/8 à décembre 2026, T51 interrompu. Pour BELGICA, M2-6 jusque ELISABETH, puis le M6 vers ROI BAUDOUIN.\",\"nl\":\"Werken. 4/8 tot december 2026, T51 onderbroken. Voor BELGICA, neem M2-6 tot ELISABETH, dan M6 naar KONING BOUDEWIJN.\"}],\"type\":\"Description\"}]",
+            "type": "LongText",
+            "lines": "[{\"id\":\"51\"}]",
+            "priority": 4,
+            "points": "[{\"id\":\"6607\"}]"
+        },
+        {
+            "content": "[{\"text\":[{\"en\":\"Works. From 22 Jan until mid-June, bus 48 diverted. Walk to ANNEESSENS.\",\"fr\":\"Travaux. Du 22/1 à mi- juin, bus 48 dévié. Pour rejoindre ANNEESSENS, continuez à pied.\",\"nl\":\"Werken. Van 22/1 tot midden juni, bus 48 omgeleid. Ga te voet naar ANNEESSENS.\"}],\"type\":\"Description\"}]",
+            "type": "LongText",
+            "lines": "[{\"id\":\"48\"}]",
+            "priority": 4,
+            "points": "[{\"id\":\"2744\"},{\"id\":\"2737\"}]"
+        },
+        {
+            "content": "[{\"text\":[{\"en\":\"Works. From 17 May 2025 to mid 2027, stop not served. For DA VINCI, take bus 65, 69 or 80 at BORDET STATION.\",\"fr\":\"Travaux. Du 17/5/25 à mi-2027, arrêt non desservi. Pour DA VINCI, prenez le bus 65, 69 ou 80 à BORDET STATION.\",\"nl\":\"Werken. Van 17/5/25 tot midden 2027, halte niet bediend. Voor DA VINCI, neem bus 65, 69 of 80 aan BORDET STATION.\"}],\"type\":\"Description\"}]",
+            "type": "LongText",
+            "lines": "[{\"id\":\"55\"}]",
+            "priority": 4,
+            "points": "[{\"id\":\"2901\"}]"
+        },
+        {
+            "content": "[{\"text\":[{\"en\":\"Until 2027, works. As of 9 June, T97 temporarily withdrawn. For FOREST CENTRE, B50 at GARE DU MIDI. For DIEWEG, T92.\",\"fr\":\"Jsq 2027,travaux. Dès le 9/6, T97 temporairement supprimé. Pour SAINT- DENIS, B50 à GARE DU MIDI. Pour DIEWEG, T92.\",\"nl\":\"Tot 2027, werken. Vanaf 9/6, T97 tijdelijk geschrapt. Voor VORST CENTRUM, B50 aan ZUIDST. Voor DIEWEG, T92.\"}],\"type\":\"Description\"}]",
+            "type": "LongText",
+            "lines": "[]",
+            "priority": 4,
+            "points": "[{\"id\":\"5016F\"},{\"id\":\"6314\"}]"
+        },
+        {
+            "content": "[{\"text\":[{\"en\":\"Works. 4 Aug to December 2026, T51 interrupted. T51 at MARGUERITE DURAS via M2-6 at RIBAUCOURT to YSER, then walk 400m.\",\"fr\":\"Travaux. 4/8 à décembre 2026, T51 interrompu. T51 à MARGUERITE DURAS via M2-6 à RIBAUCOURT jusqu’à YSER, et à pied.\",\"nl\":\"Werken. 4/8 tot december 2026, T51 onderbroken. T51 aan MARGUERITE DURAS via M2-6 aan RIBAUCOURT tot IJZER, dan te voet.\"}],\"type\":\"Description\"}]",
+            "type": "LongText",
+            "lines": "[{\"id\":\"51\"}]",
+            "priority": 4,
+            "points": "[{\"id\":\"5015\"}]"
+        },
+        {
+            "content": "[{\"text\":[{\"en\":\"Works. Until end of April, bus 88 diverted. Bus 14 to UZ-VUB, bus 88 at CROCQ: avenue Ernest Masoinln, De Lijn stop.\",\"fr\":\"Travaux. Jusqu'à fin avril, B88 dévié. Prenez le B14 jusqu'à UZ-VUB, B88 à CROCQ: avenue Ernest Masoin, De Lijn.\",\"nl\":\"Werken. Tot eind april, bus 88 omgeleid. Neem bus 14 tot UZ-VUB, bus 88 aan CROCQ: Ernest Masoinln, De Lijn-halte.\"}],\"type\":\"Description\"}]",
+            "type": "LongText",
+            "lines": "[{\"id\":\"88\"}]",
+            "priority": 4,
+            "points": "[{\"id\":\"1036\"}]"
+        },
+        {
+            "content": "[{\"text\":[{\"en\":\"Works. Until 29 March, temporary bus 96 diverted btw MA CAMPAGNE and BARRIERE. MORIS not served.\",\"fr\":\"Travaux. Jusqu'au 29/3, bus temporaire 96 dévié de MA CAMPAGNE à BARRIERE. MORIS non desservi.\",\"nl\":\"Werken. Tot en met 29/3, tijdelijke bus 96 omgeleid tss MA CAMPAGNE en BAREEL. MORIS niet bediend.\"}],\"type\":\"Description\"}]",
+            "type": "LongText",
+            "lines": "[{\"id\":\"96\"}]",
+            "priority": 5,
+            "points": "[{\"id\":\"1997\"},{\"id\":\"2932\"},{\"id\":\"2689\"},{\"id\":\"2479\"},{\"id\":\"3440\"},{\"id\":\"3572\"},{\"id\":\"1702\"}]"
+        },
+        {
+            "content": "[{\"text\":[{\"en\":\"Works. Stop served only by bus 66. Take bus 29, 63 or 65 at the stop of bus 71 to DELTA.\",\"fr\":\"Travaux. Arrêt uniquement desservi par bus 66. Bus 29, 63 ou 65 à l'arrêt du bus 71 vers DELTA.\",\"nl\":\"Werken. Halte enkel bediend door bus 66. Neem bus 29, 63 of 65 aan de halte van bus 71 naar DELTA.\"}],\"type\":\"Description\"}]",
+            "type": "LongText",
+            "lines": "[{\"id\":\"66\"},{\"id\":\"29\"},{\"id\":\"63\"},{\"id\":\"65\"}]",
+            "priority": 4,
+            "points": "[{\"id\":\"6445\"}]"
+        },
+        {
+            "content": "[{\"text\":[{\"en\":\"Works. From 17 May 2025 to mid 2027, bus 59 diverted. To BORDET STATION, take bus 65, 69 or 80.\",\"fr\":\"Travaux. Du 17/5/25 à mi-2027, bus 59 dévié. Pour rejoindre BORDET STATION, prenez le bus 65, 69 ou 80. \",\"nl\":\"Werken. Van 17/5/25 tot midden 2027, bus 59 omgeleid. Om naar BORDET STATION te gaan, neem bus 65, 69 of 80.\"}],\"type\":\"Description\"}]",
+            "type": "LongText",
+            "lines": "[{\"id\":\"59\"}]",
+            "priority": 4,
+            "points": "[{\"id\":\"3176\"}]"
+        },
+        {
+            "content": "[{\"text\":[{\"en\":\"Subsidence. Bus 59 diverted between FLAGEY and HOPITAL ETTERBEEK- IXELLES / ZIEKENHUIS ETTERBEEK-ELSENE.\",\"fr\":\"Effondrement de voirie. Bus 59 dévié entre FLAGEY et HOPITAL ETTERBEEK-IXELLES.\",\"nl\":\"Grondverzakking. Bus 59 omgeleid tussen FLAGEY en ZIEKENHUIS ETTERBEEK- ELSENE.\"}],\"type\":\"Description\"}]",
+            "type": "LongText",
+            "lines": "[{\"id\":\"59\"}]",
+            "priority": 5,
+            "points": "[{\"id\":\"3121B\"},{\"id\":\"3080\"},{\"id\":\"3117\"},{\"id\":\"6465\"},{\"id\":\"3100\"},{\"id\":\"3120\"},{\"id\":\"3372\"},{\"id\":\"3921\"}]"
+        },
+        {
+            "content": "[{\"text\":[{\"en\":\"Works. From 17 May 2025 to mid 2027, bus 59 diverted. Take bus 59 at ST-VINCENT (via bus 64 or 69).\",\"fr\":\"Travaux. Du 17/5/25 à mi-2027, bus 59 dévié. Prenez le bus 59 à SAINT-VINCENT (via bus 64 ou 69). \",\"nl\":\"Werken. Van 17/5/25 tot midden 2027, bus 59 omgeleid. Neem bus 59 aan SINT-VINCENTIUS (via bus 64 of 69).\"}],\"type\":\"Description\"}]",
+            "type": "LongText",
+            "lines": "[{\"id\":\"59\"}]",
+            "priority": 4,
+            "points": "[{\"id\":\"3126B\"}]"
+        },
+        {
+            "content": "[{\"text\":[{\"en\":\"Match. 22 Mar, 3.30pm- 1am, bus 46 diverted between MEIR and NEERPEDE.\",\"fr\":\"Match. 22/3, 15h30-1h, bus 46 dévié entre MEIR et NEERPEDE. \",\"nl\":\"Match. 22/3, 15.30u-1u, bus 46 omgeleid tussen MEIR en NEERPEDE. \"}],\"type\":\"Description\"}]",
+            "type": "LongText",
+            "lines": "[{\"id\":\"46\"}]",
+            "priority": 6,
+            "points": "[{\"id\":\"2323\"}]"
+        },
+        {
+            "content": "[{\"text\":[{\"en\":\"Works. 22 Dec 25 - end 2026, stop not served. For MONTGOMERY, T81 at TRINITE via temporary bus 96. For LOUISE, T92\",\"fr\":\"Travaux. 22/12/25-2026, arrêt non desservi. Pour MONTGOMERY,T81 à TRINITE via bus temporaire 96. Pour LOUISE, T92.\",\"nl\":\"Werken. 22/12/25-2026, halte niet bediend. Voor MONTGOMERY, T81 aan DRIEVULDIGHEID via tijd. bus 96. Voor LOUIZA, T92\"}],\"type\":\"Description\"}]",
+            "type": "LongText",
+            "lines": "[{\"id\":\"81\"}]",
+            "priority": 4,
+            "points": "[{\"id\":\"6109\"}]"
+        },
+        {
+            "content": "[{\"text\":[{\"en\":\"Works. From 21 Oct to +/- 31 Oct, stop relocated. Take the bus 20 meters before this stop. \",\"fr\":\"Travaux. Du 21/10 au +/- 31/10, arrêt déplacé. Prenez le bus 20 mètres avant cet arrêt.\",\"nl\":\"Werken. Van 21/10 tot en met +/- 31/10, halte verplaatst. Neem de bus 20 meter voor deze halte.\"}],\"type\":\"Description\"}]",
+            "type": "LongText",
+            "lines": "[{\"id\":\"79\"}]",
+            "priority": 4,
+            "points": "[{\"id\":\"2037\"}]"
+        },
+        {
+            "content": "[{\"text\":[{\"en\":\"Works. 21 May 2025-mid 2027,tram 55 interrupted btw TILLEUL and DA VINCI. For BORDET STN, bus 59 at VERBOEKHOVEN.\",\"fr\":\"Travaux.21/5/25-mi-2027, tram 55 interrompu entre TILLEUL et DA VINCI. Pour BORDET STATION, bus 59 à VERBOEKHOVEN.\",\"nl\":\"Werken. 21/5/25-midden 2027,tram 55 onderbroken tss LINDE en DA VINCI. Voor BORDET STATION, bus 59 aan VERBOEKHOVEN.\"}],\"type\":\"Description\"}]",
+            "type": "LongText",
+            "lines": "[{\"id\":\"55\"}]",
+            "priority": 5,
+            "points": "[{\"id\":\"5765F\"},{\"id\":\"5762\"},{\"id\":\"2720F\"},{\"id\":\"2786F\"},{\"id\":\"0529\"},{\"id\":\"0536\"}]"
+        },
+        {
+            "content": "[{\"text\":[{\"en\":\"Works. From 19 Jan to end of 2026, bus 53 diverted between LEOPOLD I and EMILE DELVA. Info: stib-mivb.be or app\",\"fr\":\"Travaux. Du 19/1 à fin 2026, bus 53 dévié entre LEOPOLD I et EMILE DELVA. Info: stib. brussels ou app.\",\"nl\":\"Werken. Van 19/1 tot eind 2026, bus 53 omgeleid tussen LEOPOLD I en EMILE DELVA. Info: mivb.brussels of app.\"}],\"type\":\"Description\"}]",
+            "type": "LongText",
+            "lines": "[{\"id\":\"53\"}]",
+            "priority": 5,
+            "points": "[{\"id\":\"2566B\"},{\"id\":\"2572\"},{\"id\":\"2571\"},{\"id\":\"2570\"},{\"id\":\"1767\"},{\"id\":\"2569\"},{\"id\":\"1204\"},{\"id\":\"2568\"},{\"id\":\"1203\"},{\"id\":\"2567\"},{\"id\":\"2565\"},{\"id\":\"2564B\"},{\"id\":\"2573B\"},{\"id\":\"3605\"},{\"id\":\"3637\"}]"
+        },
+        {
+            "content": "[{\"text\":[{\"en\":\"Until 2027, works. T82 limited to NEERSTALLE, tram 97 withdrawn. For Drogenbos, bus 74 at ST- DENIS (as of 22 Dec).\",\"fr\":\"Jsq 2027, travaux. Tram 82 limité à NEERSTALLE, tram 97 supprimé. Pour Drogenbos, bus 74 à ST- DENIS (dès le 22/12).\",\"nl\":\"Tot 2027, werken. T82 beperkt tot NEERSTALLE, tram 97 geschrapt. Voor Drogenbos, bus 74 aan ST-DENIJS (vanaf 22/12).\"}],\"type\":\"Description\"}]",
+            "type": "LongText",
+            "lines": "[{\"id\":\"82\"}]",
+            "priority": 4,
+            "points": "[{\"id\":\"2603\"},{\"id\":\"5120\"},{\"id\":\"5123\"},{\"id\":\"2604F\"},{\"id\":\"5119\"}]"
+        },
+        {
+            "content": "[{\"text\":[{\"en\":\"Works. From 6 Jan, bus 53 83 diverted. Stop of bus 53: rue Beyseghemstraat, in front of number 107.\",\"fr\":\"Travaux. Dès le 6/1, bus 53 83 déviés. Arrêt du bus 53: rue de Beyseghem, face au numéro 107.\",\"nl\":\"Werken. Vanaf 6/1, bus 53 83 omgeleid. Halte van bus 53: Beyseghemstraat, tegenover nummer 107.\"}],\"type\":\"Description\"}]",
+            "type": "LongText",
+            "lines": "[{\"id\":\"53\"}]",
+            "priority": 4,
+            "points": "[{\"id\":\"2817\"}]"
+        },
+        {
+            "content": "[{\"text\":[{\"en\":\"Works. 23 Mar-25 Mar, 6pm, stop DE BROUCKERE of bus 89 to GARE CENTRALE moved rue de la Vierge Noire 21.\",\"fr\":\"Travaux. 23/3-25/3, 18h, arrêt DE BROUCKERE du bus 89 vers GARE CENTRALE déplacé rue de la Vierge Noire 21.\",\"nl\":\"Werken. 23/3-25/3, 18u, halte DE BROUCKERE van bus 89 naar CENTR. STAT. verplaatst Zwarte Lievevrouwstraat 21.\"}],\"type\":\"Description\"}]",
+            "type": "LongText",
+            "lines": "[{\"id\":\"89\"}]",
+            "priority": 4,
+            "points": "[{\"id\":\"1820\"}]"
+        },
+        {
+            "content": "[{\"text\":[{\"en\":\"Match. 22 Mar, 3.30pm- 1am, bus 46 diverted between MEIR and NEERPEDE via avenue Marius Renardlaan.\",\"fr\":\"Match. 22/3, 15h30-1h, bus 46 dévié entre MEIR et NEERPEDE via avenue Marius Renard.\",\"nl\":\"Match. 22/3, 15.30u-1u, bus 46 omgeleid tussen MEIR en NEERPEDE via Marius Renardlaan.\"}],\"type\":\"Description\"}]",
+            "type": "LongText",
+            "lines": "[{\"id\":\"46\"}]",
+            "priority": 6,
+            "points": "[{\"id\":\"3082\"},{\"id\":\"1024B\"},{\"id\":\"1282\"},{\"id\":\"2370\"},{\"id\":\"2218\"},{\"id\":\"1348\"},{\"id\":\"2217\"},{\"id\":\"2216\"},{\"id\":\"2403\"},{\"id\":\"2215\"},{\"id\":\"3469\"},{\"id\":\"1895\"},{\"id\":\"3369\"},{\"id\":\"3413\"},{\"id\":\"2213\"},{\"id\":\"3312\"},{\"id\":\"3378\"},{\"id\":\"3377\"},{\"id\":\"2209\"},{\"id\":\"2835\"}]"
+        },
+        {
+            "content": "[{\"text\":[{\"en\":\"Works. 19 Jan-end of 2026, B53 diverted. B53 at LEOPOLD I (450m) or KERKH. VAN JETTE/CIM. DE JETTE (via T51).\",\"fr\":\"Travaux. 19/1 à fin 2026, bus 53 dévié. Bus 53 à LEOPOLD I (450m) ou à CIMETIERE DE JETTE (via tram 51).\",\"nl\":\"Werken. 19/1 tot eind 2026, bus 53 omgeleid. Bus 53 aan LEOPOLD I (450m) of aan KERKHOF VAN JETTE (via T51).\"}],\"type\":\"Description\"}]",
+            "type": "LongText",
+            "lines": "[{\"id\":\"53\"}]",
+            "priority": 4,
+            "points": "[{\"id\":\"2504\"}]"
+        },
+        {
+            "content": "[{\"text\":[{\"en\":\"Match. 22 Mar, 3.30pm- 1am, STOP NOT SERVED. Take bus 46 at the stop NEERPEDE. \",\"fr\":\"Match. 22/3, 15h30-1h, ARRET NON DESSERVI. Prenez le bus 46 à l'arrêt NEERPEDE.\",\"nl\":\"Match. 22/3, 15.30u-1u, HALTE NIET BEDIEND. Neem bus 46 aan de halte NEERPEDE.\"}],\"type\":\"Description\"}]",
+            "type": "LongText",
+            "lines": "[{\"id\":\"46\"}]",
+            "priority": 4,
+            "points": "[{\"id\":\"3712\"},{\"id\":\"3713\"}]"
+        },
+        {
+            "content": "[{\"text\":[{\"en\":\"Works. 25 Mar, 6am-27 Mar, 5pm, stop DELACROIX to GARE CENTRALE moved backwards +/- 70m, rue de Birminghamstraat.\",\"fr\":\"Travaux. Du 25/3 à 6h au 27/3 à 17h, arrêt DELACROIX vers GARE CENTRALE reculé de +/- 70m, rue de Birmingham.\",\"nl\":\"Werken. 25/3, 6u-27/3, 17u, halte DELACROIX naar CENTRAAL STAT. achteruitgebracht van +/- 70m, Birminghamstr.\"}],\"type\":\"Description\"}]",
+            "type": "LongText",
+            "lines": "[{\"id\":\"89\"}]",
+            "priority": 4,
+            "points": "[{\"id\":\"1178\"}]"
+        },
+        {
+            "content": "[{\"text\":[{\"en\":\"Match. 22 Mar, 3.30pm- 1am, STOP NOT SERVED. Bus 46 at the stop FRANS HALS of tram 81 to MONTGOMERY.\",\"fr\":\"Match. 22/3, 15h30-1h, ARRET NON DESSERVI. Bus 46 à l'arrêt FRANS HALS du tram 81 vers MONTGOMERY.\",\"nl\":\"Match. 22/3, 15.30u-1u, HALTE NIET BEDIEND. Bus 46 aan de halte FRANS HALS van tram 81 naar MONTGOMERY.\"}],\"type\":\"Description\"}]",
+            "type": "LongText",
+            "lines": "[{\"id\":\"46\"}]",
+            "priority": 4,
+            "points": "[{\"id\":\"3756\"}]"
+        },
+        {
+            "content": "[{\"text\":[{\"en\":\"Works. The stop is moved : Rue du Pavillon, 86. (Moved 20m forwards).\",\"fr\":\"Travaux. Arrêt déplacé : rue du Pavillon, 86. (Avancé de 20m).\",\"nl\":\"Werken. De halte is verplaatst : Palvijoenstraat, 86. (20m vooruitgebracht).\"}],\"type\":\"Description\"}]",
+            "type": "LongText",
+            "lines": "[{\"id\":\"58\"}]",
+            "priority": 4,
+            "points": "[{\"id\":\"5741\"}]"
+        },
+        {
+            "content": "[{\"text\":[{\"en\":\"Works. 22 Dec 25 - end 2026, T81 interrupted. For LA CHASSE, temporary bus 96 at the stop of bus 52 to GARE CENTRALE\",\"fr\":\"Travaux. 22/12/25 - fin 2026,T81 interrompu.Pour LA CHASSE,bus temporaire 96 à l'arrêt du bus 52 vers GARE CENTRALE.\",\"nl\":\"Werken. 22/12/25-eind 2026, T81 onderbroken. Voor DE JACHT, tijdelijke B96 aan halte B52 naar CENTR STATION.\"}],\"type\":\"Description\"}]",
+            "type": "LongText",
+            "lines": "[{\"id\":\"81\"}]",
+            "priority": 4,
+            "points": "[{\"id\":\"2331F\"}]"
+        },
+        {
+            "content": "[{\"text\":[{\"en\":\"Works. As of 23 Mar for +/- 3 weeks, stop FERME NOS PILIFS not served. Take bus 56 at HOP. MILITAIRE/MILITAIR HOSP.\",\"fr\":\"Travaux.Dès le 23/3 pour +/- 3 semaines, arrêt FERME NOS PILIFS non desservi. Prenez le bus 56 à HOPITAL MILITAIRE.\",\"nl\":\"Werken. Vanaf 23/3 voor +/- 3 weken, halte FERME NOS PILIFS niet bediend. Neem bus 56 aan MILITAIR HOSPITAAL.\"}],\"type\":\"Description\"}]",
+            "type": "LongText",
+            "lines": "[{\"id\":\"56\"},{\"id\":\"53\"}]",
+            "priority": 4,
+            "points": "[{\"id\":\"2827\"}]"
+        },
+        {
+            "content": "[{\"text\":[{\"en\":\"Works. From 21 Mar until 22 Mar at 6.30pm, bus 21 diverted btw DIAMANT and RTL HOUSE. Stop of bus 21: chée de Louvain 770.\",\"fr\":\"Travaux. Du 21/3 au 22/3 à 18h30, bus 21 dévié entre DIAMANT et RTL HOUSE. Arrêt du bus 21: chaussée de Louvain 770.\",\"nl\":\"Werken. van 21/3 tot 22/3 om 18.30u, bus 21 omgeleid tussen DIAMANT en RTL HOUSE. Halte van bus 21: Leuvensestwg 770\"}],\"type\":\"Description\"}]",
+            "type": "LongText",
+            "lines": "[{\"id\":\"21\"}]",
+            "priority": 4,
+            "points": "[{\"id\":\"3957\"}]"
+        },
+        {
+            "content": "[{\"text\":[{\"en\":\"Match. 22 Mar, 3.30pm- 1am, STOP NOT SERVED. B46 at YSAYE of tram 81 to MARIUS RENARD, B75 at VAN BEETHOVEN.\",\"fr\":\"Match. 22/3, 15h30-1h, ARRET NON DESSERVI. B46 à l'arrêt YSAYE du tram 81 vers MARIUS RENARD, B75 à VAN BEETHOVEN.\",\"nl\":\"Match. 22/3, 15.30u-1u, HALTE NIET BEDIEND. B46 aan de halte YSAYE van T81 naar MARIUS RENARD, B75 aan VAN BEETHOVEN.\"}],\"type\":\"Description\"}]",
+            "type": "LongText",
+            "lines": "[{\"id\":\"46\"},{\"id\":\"75\"}]",
+            "priority": 4,
+            "points": "[{\"id\":\"2375\"}]"
+        },
+        {
+            "content": "[{\"text\":[{\"en\":\"Match. 22 Mar, 3.30pm- 1am, bus 75 diverted between VAN BEETHOVEN and RENE HENRY via av. Marius Renardlaan.\",\"fr\":\"Match. 22/3, 15h30-1h, bus 75 dévié entre VAN BEETHOVEN et RENE HENRY via avenue Marius Renard.\",\"nl\":\"Match. 22/3, 15.30u-1u, bus 75 omgeleid tussen VAN BEETHOVEN en RENE HENRY via Marius Renardlaan.\"}],\"type\":\"Description\"}]",
+            "type": "LongText",
+            "lines": "[{\"id\":\"75\"}]",
+            "priority": 6,
+            "points": "[{\"id\":\"5920C\"},{\"id\":\"5297B\"},{\"id\":\"1495\"},{\"id\":\"1594\"},{\"id\":\"1480\"},{\"id\":\"1479\"},{\"id\":\"1622\"},{\"id\":\"1478\"},{\"id\":\"1951\"},{\"id\":\"2610\"},{\"id\":\"1477B\"},{\"id\":\"1498\"},{\"id\":\"5953\"},{\"id\":\"5922\"}]"
+        },
+        {
+            "content": "[{\"text\":[{\"en\":\"Works. 26 Jan-end 2026, stop not served. For TRINITE, bus 48 btw AV. DU ROI and ROCHEFORT, and temporary bus 96.\",\"fr\":\"Travaux. 26/1-fin 2026, tram 81 interrompu. Pour TRINITE, B48 entre AV. DU ROI et ROCHEFORT, et bus temporaire 96. \",\"nl\":\"Werken. 26/1-eind 2026, tram 81 onderbroken.Voor DRIEVULDIGHEID, B48 tss KONINGSLN en ROCHEFORT, en tijdelijke bus 96. \"}],\"type\":\"Description\"}]",
+            "type": "LongText",
+            "lines": "[{\"id\":\"81\"}]",
+            "priority": 4,
+            "points": "[{\"id\":\"6099\"}]"
+        },
+        {
+            "content": "[{\"text\":[{\"en\":\"Works. From 21 Mar until 22 Mar at 6.30pm, bus 80 diverted between PADUWA and FEVRIER via place Meiserplein.\",\"fr\":\"Travaux. Du 21/3 au 22/3 à 18h30, bus 80 dévié entre PADUWA et FEVRIER via place Meiser.\",\"nl\":\"Werken. Van 21/3 tot 22/3 om 18.30u, bus 80 omgeleid tussen PADUWA en FEBRUARI via Meiserplein.\"}],\"type\":\"Description\"}]",
+            "type": "LongText",
+            "lines": "[{\"id\":\"80\"}]",
+            "priority": 5,
+            "points": "[{\"id\":\"3207\"},{\"id\":\"3210B\"},{\"id\":\"5362\"},{\"id\":\"5045\"},{\"id\":\"3401\"},{\"id\":\"3200\"},{\"id\":\"3898\"}]"
+        },
+        {
+            "content": "[{\"text\":[{\"en\":\"Works. Stop of tram 81: rue du Bailli / Baljuwstraat 42-54.\",\"fr\":\"Travaux. Arrêt du tram 81: rue du Bailli 42-54.\",\"nl\":\"Werken. Halte van tram 81: Baljuwstraat 42-54.\"}],\"type\":\"Description\"}]",
+            "type": "LongText",
+            "lines": "[{\"id\":\"81\"}]",
+            "priority": 7,
+            "points": "[{\"id\":\"2971F\"}]"
+        },
+        {
+            "content": "[{\"text\":[{\"en\":\"Works. Metro station CENTRAAL STATION not accessible to persons with reduced mobility until September 2026.\",\"fr\":\"Travaux. La station GARE CENTRALE n'est pas accessible aux personnes à mobilité réduite jusqu'en septembre 2026.\",\"nl\":\"Werken. CENTRAAL STATION is niet toegankelijk voor personen met beperkte mobiliteit tot september 2026.\"}],\"type\":\"Description\"}]",
+            "type": "LongText",
+            "lines": "[{\"id\":\"1\"},{\"id\":\"5\"}]",
+            "priority": 6,
+            "points": "[{\"id\":\"8211\"},{\"id\":\"8652\"},{\"id\":\"8231\"},{\"id\":\"8012\"},{\"id\":\"8111\"},{\"id\":\"8672\"},{\"id\":\"8732\"},{\"id\":\"8733\"},{\"id\":\"8071\"},{\"id\":\"8292\"},{\"id\":\"8091\"},{\"id\":\"8031\"},{\"id\":\"8251\"},{\"id\":\"8131\"},{\"id\":\"8692\"},{\"id\":\"8051\"},{\"id\":\"8151\"},{\"id\":\"8272\"},{\"id\":\"8702\"},{\"id\":\"8101\"},{\"id\":\"8662\"},{\"id\":\"8201\"},{\"id\":\"8022\"},{\"id\":\"8121\"},{\"id\":\"8682\"},{\"id\":\"8221\"},{\"id\":\"8722\"},{\"id\":\"8642\"},{\"id\":\"8742\"},{\"id\":\"8061\"},{\"id\":\"8081\"},{\"id\":\"8141\"},{\"id\":\"8021\"},{\"id\":\"8241\"},{\"id\":\"8161\"},{\"id\":\"8282\"},{\"id\":\"8041\"},{\"id\":\"8261\"},{\"id\":\"8712\"}]"
+        },
+        {
+            "content": "[{\"text\":[{\"fr\":\"Bon voyage sur nos lignes.\",\"nl\":\"Goede reis op onze lijnen.\"}],\"type\":\"Description\"}]",
+            "type": "LongText",
+            "lines": "[{\"id\":\"50\"}]",
+            "priority": 9,
+            "points": "[{\"id\":\"9657\"}]"
+        },
+        {
+            "content": "[{\"text\":[{\"en\":\"Works. From 16 Feb until 2027, bus 74 diverted between GROTE BAAN and KRUISPUNT STALLE via DROGENBOS-SHOPPING.\",\"fr\":\"Travaux. Du 16/2 à 2027, bus 74 dévié entre GRAND’ROUTE et CARREFOUR STALLE via DROGENBOS- SHOPPING.\",\"nl\":\"Werken. Van 16/2 tot 2027, bus 74 omgeleid tussen GROTE BAAN en KRUISPUNT STALLE via DROGENBOS-SHOPPING.\"}],\"type\":\"Description\"}]",
+            "type": "LongText",
+            "lines": "[{\"id\":\"74\"}]",
+            "priority": 5,
+            "points": "[{\"id\":\"7472\"},{\"id\":\"3415\"}]"
+        },
+        {
+            "content": "[{\"text\":[{\"en\":\"Until 2027, works. T82 limited to NEERSTALLE, tram 97 withdrawn. For DROGENBOS, bus 74 at this stop (as of 22 Dec)\",\"fr\":\"Jsq 2027,travaux. Tram 82 limité à NEERSTALLE, tram 97 supprimé.Pour DROGENBOS, bus 74 à cet arrêt (dès le 22/12)\",\"nl\":\"Tot 2027,werken. Tram 82 beperkt tot NEERSTALLE, tram 97 geschrapt. Voor DROGENBOS, bus 74 aan deze halte (vanaf 22/12)\"}],\"type\":\"Description\"}]",
+            "type": "LongText",
+            "lines": "[{\"id\":\"82\"}]",
+            "priority": 4,
+            "points": "[{\"id\":\"5153F\"}]"
+        },
+        {
+            "content": "[{\"text\":[{\"en\":\"Works. Until end 2026, stop not served. Stop of temporary bus 96: ch. Waterloo 346, tram 81 at WIELS (as of 26 Jan).\",\"fr\":\"Travaux. Jsq fin 2026, arrêt non desservi. Arrêt du bus 96: ch. Waterloo 346, tram 81 à WIELS (dès le 26/1).\",\"nl\":\"Werken. Tot eind 2026, halte niet bediend. Halte van bus 96: Waterloosestwg 346, T81 aan WIELS (vanaf 26/1).\"}],\"type\":\"Description\"}]",
+            "type": "LongText",
+            "lines": "[{\"id\":\"81\"}]",
+            "priority": 4,
+            "points": "[{\"id\":\"6162\"}]"
+        },
+        {
+            "content": "[{\"text\":[{\"en\":\"Works. Until 2027, stop not served. As of 22 Dec, take tram 82 at ST- DENIS via bus 74 (from this stop).\",\"fr\":\"Travaux. Jusqu'en 2027, arrêt non desservi. Dès le 22/12, prenez le tram 82 à SAINT-DENIS via bus 74 (depuis cet arrêt).\",\"nl\":\"Werken. Tot 2027, halte niet bediend. Vanaf 22/12, neem tram 82 aan SINT-DENIJS via bus 74 (vanaf deze halte).\"}],\"type\":\"Description\"}]",
+            "type": "LongText",
+            "lines": "[{\"id\":\"82\"}]",
+            "priority": 4,
+            "points": "[{\"id\":\"5753F\"},{\"id\":\"5751\"},{\"id\":\"5754\"}]"
+        },
+        {
+            "content": "[{\"text\":[{\"en\":\"Works. Until the end of April, B88 diverted. B14 to UZ-VUB, B88 at GUILL. DE GREEF (stop De Lijn to Dendermonde) via T51\",\"fr\":\"Travaux. Jsq fin avril, B88 dévié. Pour UZ-VUB, bus 14. B88 à GUILL. DE GREEF(arrêt De Lijn vers Dendermonde) via T51.\",\"nl\":\"Werken. Tot eind april, B88 omgeleid. Voor UZ- VUB, B14. B88 aan GUILL. DE GREEF(halte De Lijn naar Dendermonde)via T51\"}],\"type\":\"Description\"}]",
+            "type": "LongText",
+            "lines": "[{\"id\":\"88\"}]",
+            "priority": 4,
+            "points": "[{\"id\":\"2498B\"}]"
+        },
+        {
+            "content": "[{\"text\":[{\"en\":\"Works. 19 Mar to +/-26 Mar, stop GUILLAUME DE GREEF relocated. Temporary stop: bd.de Smet de Naeyerlaan 385.\",\"fr\":\"Travaux. 19/3 au +/- 26/3, arrêt GUILLAUME DE GREEF déplacé. Arrêt provisoire: boulevard de Smet de Naeyer 385.\",\"nl\":\"Werken. 19/3 tot +/- 26/3, halte GUILLAUME DE GREEF verplaatst. Tijdelijke halte: de Smet de Naeyerlaan 385.\"}],\"type\":\"Description\"}]",
+            "type": "LongText",
+            "lines": "[{\"id\":\"88\"},{\"id\":\"53\"}]",
+            "priority": 4,
+            "points": "[{\"id\":\"3483\"}]"
+        },
+        {
+            "content": "[{\"text\":[{\"en\":\"Works. 21 May 2025-mid 2027, stop not served. Tram 55 at TILLEUL or VERBOEKHOVEN (via B59, stop in other direction)\",\"fr\":\"Travaux.21/5/25-mi-2027, arrêt non desservi. Tram 55 à TILLEUL ou à VERBOEKHOVEN (via B59, arrêt dans l’autre sens)\",\"nl\":\"Werken. 21/5/25-midden 2027,halte niet bediend. Tram 55 aan LINDE of aan VERBOEKHOVEN(via B59, halte andere richting)\"}],\"type\":\"Description\"}]",
+            "type": "LongText",
+            "lines": "[{\"id\":\"55\"}]",
+            "priority": 4,
+            "points": "[{\"id\":\"2903F\"}]"
+        },
+        {
+            "content": "[{\"text\":[{\"en\":\"Works. From 26 Jan, bus 65 diverted. Temporary stop: Woluwelaan, after the Kerklaan.\",\"fr\":\"Travaux. Dès le 26/1, bus 65 dévié. Arrêt provisoire: Woluwelaan, après la Kerklaan.\",\"nl\":\"Werken. Vanaf 26/1, bus 65 omgeleid. Tijdelijke halte: Woluwelaan, na de Kerklaan.\"}],\"type\":\"Description\"}]",
+            "type": "LongText",
+            "lines": "[{\"id\":\"65\"}]",
+            "priority": 4,
+            "points": "[{\"id\":\"3042\"}]"
+        },
+        {
+            "content": "[{\"text\":[{\"en\":\"Works. From 4 Aug to December 2026, stop of bus 14 relocated. Take bus 14 on the side lane next to this stop. \",\"fr\":\"Travaux. Du 4/8 à décembre 2026, arrêt du bus 14 déplacé. Bus 14 sur la bande latérale à côté de cet arrêt. \",\"nl\":\"Werken. Van 4/8 tot december 2026, halte van bus 14 verplaatst. Neem bus 14 op de zijstrook naast deze halte.\"}],\"type\":\"Description\"}]",
+            "type": "LongText",
+            "lines": "[{\"id\":\"14\"}]",
+            "priority": 4,
+            "points": "[{\"id\":\"5076B\"}]"
+        },
+        {
+            "content": "[{\"text\":[{\"en\":\"Until 2027, works. Tram 97 temporarily withdrawn. For BARRIERE or MORIS, bus 96 (stop: av. Pont de Luttre)\",\"fr\":\"Jsq 2027, travaux. Tram 97 temporairement supprimé. Pour BARRIERE et MORIS, bus 96 (arrêt: av. Pont de Luttre)\",\"nl\":\"Tot 2027, werken. Tram 97 tijdelijk geschrapt. Voor BAREEL of MORIS, bus 96 (halte: Luttrebruglaan)\"}],\"type\":\"Description\"}]",
+            "type": "LongText",
+            "lines": "[]",
+            "priority": 4,
+            "points": "[{\"id\":\"5175\"}]"
+        },
+        {
+            "content": "[{\"text\":[{\"en\":\"Works. Until mid 2027, stop moved to avenue Maurice Maeterlincklaan, next to number 35.\",\"fr\":\"Travaux. Jusqu'à mi- 2027, arrêt déplacé avenue Maurice Maeterlinck, à hauteur du numéro 35. \",\"nl\":\"Werken. Tot midden 2027, halte verplaatst naar Maurice Maeterlincklaan, ter hoogte van huisnummer 35.\"}],\"type\":\"Description\"}]",
+            "type": "LongText",
+            "lines": "[{\"id\":\"59\"}]",
+            "priority": 5,
+            "points": "[{\"id\":\"3181\"}]"
+        },
+        {
+            "content": "[{\"text\":[{\"en\":\"Works. 4 Aug to December 2026, T51 interrupted. For BELGICA, M2-6 at IJZER to ELISABETH, then M6 to KONING BOUDEWIJN. \",\"fr\":\"Travaux. 4/8 à décembre 2026, T51 interrompu. Pour BELGICA, M2-6 à YSER jsq ELISABETH, puis le M6 vers ROI BAUDOUIN.\",\"nl\":\"Werken. 4/8 tot december 2026, T51 onderbroken. Voor BELGICA, M2-6 aan IJZER tot ELISABETH, dan M6 naar KONING BOUDEWIJN\"}],\"type\":\"Description\"}]",
+            "type": "LongText",
+            "lines": "[{\"id\":\"51\"}]",
+            "priority": 4,
+            "points": "[{\"id\":\"2848F\"}]"
+        },
+        {
+            "content": "[{\"text\":[{\"en\":\"Works. From 27 Feb, 6pm, until end of April, B88 diverted. Take tram 51 until GUILLAUME DE GREEF, then bus 88.\",\"fr\":\"Travaux. Dès le 27/2, 18h, jsq fin avril, B88 dévié. Prenez le tram 51 jusque GUILLAUME DE GREEF, puis bus 88.\",\"nl\":\"Werken. Van 27/2, 18u, tot eind april wordt bus 88 omgeleid. Neem tram 51 tot GUILLAUME DE GREEF, dan bus 88.\"}],\"type\":\"Description\"}]",
+            "type": "LongText",
+            "lines": "[{\"id\":\"88\"}]",
+            "priority": 4,
+            "points": "[{\"id\":\"2584B\"}]"
+        },
+        {
+            "content": "[{\"text\":[{\"en\":\"Works. From 19 Jan to summer 2026, bus 41 diverted. Take the bus at ARCADEN/ARCADES (300m) or KEYM (300m). \",\"fr\":\"Travaux. 19/1-été 2026, bus 41 dévié. B41 à ARCADES (av.de Visé 34: 300m) ou à KEYM (avenue de la Sauvagine: 300m).\",\"nl\":\"Werken. 19/1-zomer 2026, bus  41 omgeleid. Neem de bus aan ARCADEN (de Visélaan 34: 300m) of KEYM(Wildwaterlaan:300m)\"}],\"type\":\"Description\"}]",
+            "type": "LongText",
+            "lines": "[{\"id\":\"41\"}]",
+            "priority": 4,
+            "points": "[{\"id\":\"2080\"}]"
+        },
+        {
+            "content": "[{\"text\":[{\"en\":\"Works. As of 29 Jan, stop ROCHEFORT moved on the other traffic lane, place de Rochefortplein 6.\",\"fr\":\"Travaux. Dès le 29/1, arrêt ROCHEFORT déplacé sur l'autre bande de circulation, place de Rochefort 6.\",\"nl\":\"Werken.Vanaf 29/1, halte ROCHEFORT verplaatst op de andere rijstrook, Rochefortplein 6.\"}],\"type\":\"Description\"}]",
+            "type": "LongText",
+            "lines": "[{\"id\":\"N12\"},{\"id\":\"52\"},{\"id\":\"96\"}]",
+            "priority": 4,
+            "points": "[{\"id\":\"1717\"}]"
+        },
+        {
+            "content": "[{\"text\":[{\"en\":\"Works. 4 Aug to December 2026, T51 interrupted between BELGICA and MARGUERITE DURAS. Info: stib-mivb.be or in app.\",\"fr\":\"Travaux. 4/8 à décembre 2026, T51 interrompu entre BELGICA-MARGUERITE DURAS.Plus d'infos: stib.brussels ou app.\",\"nl\":\"Werken. 4/8 tot december 2026, T51 onderbroken tussen BELGICA en MARGUERITE DURAS. Info: mivb.brussels of in app.\"}],\"type\":\"Description\"}]",
+            "type": "LongText",
+            "lines": "[{\"id\":\"51\"}]",
+            "priority": 5,
+            "points": "[{\"id\":\"5093F\"},{\"id\":\"5008F\"},{\"id\":\"5007F\"},{\"id\":\"5006\"},{\"id\":\"5402\"},{\"id\":\"5088F\"},{\"id\":\"5399F\"},{\"id\":\"5403\"},{\"id\":\"1290\"}]"
+        },
+        {
+            "content": "[{\"text\":[{\"en\":\"Works. Until end of April, bus 14 diverted between STATION JETTE/GARE DE JETTE and CROCQ.\",\"fr\":\"Travaux. Jusqu'à fin avril, bus 14 dévié entre GARE DE JETTE et CROCQ.\",\"nl\":\"Werken. Tot eind april, bus 14 omgeleid tussen STATION JETTE en CROCQ.\"}],\"type\":\"Description\"}]",
+            "type": "LongText",
+            "lines": "[{\"id\":\"14\"}]",
+            "priority": 5,
+            "points": "[{\"id\":\"1767\"},{\"id\":\"1766\"},{\"id\":\"2515B\"},{\"id\":\"1036\"},{\"id\":\"1212\"},{\"id\":\"1056\"},{\"id\":\"3245\"},{\"id\":\"1671\"},{\"id\":\"2498B\"},{\"id\":\"5076B\"},{\"id\":\"1082\"}]"
+        },
+        {
+            "content": "[{\"text\":[{\"en\":\"Works. 21 Mar-22 Mar, 6. 30pm, bus 80 diverted btw FEVRIER and PADUWA. Take bus 80 at FEVRIER (av. Roodebeek 280).\",\"fr\":\"Travaux. 21/3-22/3, 18h30,bus 80 dévié entre FEVRIER et PADUWA.Prenez le bus 80 à FEVRIER (av. Roodebeek 280).\",\"nl\":\"Werken. 21/3-22/3, 18. 30u, bus 80 omgeleid tss FEBRUARI en PADUWA. Neem bus 80 aan FEBRUARI (Roodebeeklaan 280).\"}],\"type\":\"Description\"}]",
+            "type": "LongText",
+            "lines": "[{\"id\":\"80\"}]",
+            "priority": 4,
+            "points": "[{\"id\":\"3904\"},{\"id\":\"3905\"}]"
+        },
+        {
+            "content": "[{\"text\":[{\"en\":\"Bus 59: On Sunday 5AM- 4PM, Market. STOP NOT SERVED. Bus 59 at the next stop MAELBEEK/MAALBEEK.\",\"fr\":\"Bus 59: Le dimanche 5h- 16h, marché. ARRET NON DESSERVI. Bus 59 à l'arrêt suivant MAELBEEK.\",\"nl\":\"Bus 59: Op zondag 5u- 16u, markt. HALTE NIET BEDIEND. Bus 59 aan de volgende halte MAALBEEK.\"}],\"type\":\"Description\"}]",
+            "type": "LongText",
+            "lines": "[{\"id\":\"59\"}]",
+            "priority": 5,
+            "points": "[{\"id\":\"1476\"}]"
+        },
+        {
+            "content": "[{\"text\":[{\"en\":\"Works. 21 Mar-22 Mar, 6. 30pm, bus 21 79 diverted btw RTL HOUSE / CARENE and DIAMANT. Take bus 21 or 79 at DIAMANT.\",\"fr\":\"Travaux. 21/3-22/3, 18h30, bus 21 79 déviés entre RTL HOUSE / CARENE et DIAMANT. Prenez le bus 21 ou 79 à DIAMANT.\",\"nl\":\"Werken. 21/3-22/3, 18. 30u, bus 21 79 omgeleid tss RTL HOUSE / CARINA en DIAMANT. Neem bus 21 of 79 aan DIAMANT\"}],\"type\":\"Description\"}]",
+            "type": "LongText",
+            "lines": "[{\"id\":\"79\"},{\"id\":\"21\"}]",
+            "priority": 4,
+            "points": "[{\"id\":\"3911\"}]"
+        },
+        {
+            "content": "[{\"text\":[{\"en\":\"Works. As of 23 Mar for +/- 3 weeks,B53 diverted bt PETER BENOIT and HOP MILITAIRE. For VAL MARIA, take bus 83.\",\"fr\":\"Travaux.Dès le 23/3 pour +/- 3 semaines, B53 dévié entre PETER BENOIT et HOP MILITAIRE. Pour VAL MARIA, bus 83.\",\"nl\":\"Werken. Vanaf 23/3 voor +/- 3 weken,B53 omgeleid ts P. BENOIT en MILITAIR HOSP. Voor MARIENDAAL, neem bus 83.\"}],\"type\":\"Description\"}]",
+            "type": "LongText",
+            "lines": "[{\"id\":\"53\"}]",
+            "priority": 5,
+            "points": "[{\"id\":\"2813B\"},{\"id\":\"2815B\"},{\"id\":\"2817\"},{\"id\":\"2816\"},{\"id\":\"2814\"}]"
+        },
+        {
+            "content": "[{\"text\":[{\"en\":\"Works. Until May 2026, bus 54 diverted between MA CAMPAGNE and BAILLI / BALJUW via JANSON. Info: stib-mivb.be or app.\",\"fr\":\"Travaux. Jusque mai 2026, bus 54 dévié entre MA CAMPAGNE et BAILLI via JANSON. Info : stib. brussels ou app.\",\"nl\":\"Werken. Tot mei 2026, bus 54 omgeleid tussen MA CAMPAGNE en BALJUW via JANSON. Info: mivb. brussels of app.\"}],\"type\":\"Description\"}]",
+            "type": "LongText",
+            "lines": "[{\"id\":\"54\"}]",
+            "priority": 5,
+            "points": "[{\"id\":\"2955\"},{\"id\":\"2965\"},{\"id\":\"2953\"},{\"id\":\"2957A\"},{\"id\":\"2456\"},{\"id\":\"2951\"},{\"id\":\"2952B\"},{\"id\":\"2954B\"},{\"id\":\"2959\"}]"
+        },
+        {
+            "content": "[{\"text\":[{\"en\":\"Works. From 22 Jan until mid-June,bus 48 diverted btw PORTE DE HAL and ANNEESSENS. Info: stib- mivb.be or app.\",\"fr\":\"Travaux. Du 22/1 à mi- juin, bus 48 dévié entre PORTE DE HAL et ANNEESSENS. Info : stib. brussels ou app.\",\"nl\":\"Werken. Van 22/1 tot midden juni, bus 48 omgeleid tss HALLEPOORT en ANNEESSENS. Info: mivb.brussels of app.\"}],\"type\":\"Description\"}]",
+            "type": "LongText",
+            "lines": "[{\"id\":\"48\"}]",
+            "priority": 5,
+            "points": "[{\"id\":\"2459\"},{\"id\":\"2767\"},{\"id\":\"2778\"},{\"id\":\"2934A\"},{\"id\":\"2775\"},{\"id\":\"2773\"},{\"id\":\"2671\"},{\"id\":\"2460\"}]"
+        },
+        {
+            "content": "[{\"text\":[{\"en\":\"Works. As of 23 Mar for +/- 3 weeks, terminus VAL MARIA / MARIENDAAL of bus 83 moved Kruisberg 28.\",\"fr\":\"Travaux.Dès le 23/3 pour +/- 3 semaines, terminus VAL MARIA du bus 83 déplacé Kruisberg 28.\",\"nl\":\"Werken. Vanaf 23/3 voor +/- 3 weken, eindpunt MARIENDAAL van bus 83 verplaatst Kruisberg 28.\"}],\"type\":\"Description\"}]",
+            "type": "LongText",
+            "lines": "[{\"id\":\"83\"}]",
+            "priority": 5,
+            "points": "[{\"id\":\"2813B\"},{\"id\":\"2756\"},{\"id\":\"2815B\"},{\"id\":\"2365\"},{\"id\":\"2817\"},{\"id\":\"2816\"},{\"id\":\"2814\"}]"
+        },
+        {
+            "content": "[{\"text\":[{\"en\":\"Works. From 31 Mar 2025 to mid-2026, tram 62 limited to BOURGET. Walk to EUROCONTROL (350 meters-3 min). \",\"fr\":\"Travaux. Du 31/3/2025 à mi-2026, tram 62 limité à BOURGET. Continuez à pied jusqu’à EUROCONTROL (350 mètres-3 min).\",\"nl\":\"Werken. Van 31/3/2025 tot midden 2026, tram 62 beperkt tot BOURGET. Ga te voet tot EUROCONTROL (350 meter-3 min). \"}],\"type\":\"Description\"}]",
+            "type": "LongText",
+            "lines": "[{\"id\":\"62\"}]",
+            "priority": 4,
+            "points": "[{\"id\":\"3337F\"}]"
+        },
+        {
+            "content": "[{\"text\":[{\"en\":\"Subsidence. Terminus of bus 59 moved avenue Auguste Rodinlaan, between numbers 49 and 59.\",\"fr\":\"Effondrement de voirie. Terminus du bus 59 déplacé avenue Auguste Rodin, entre les numéros 49 et 59.\",\"nl\":\"Grondverzakking. Eindpunt van bus 59 verplaatst Auguste Rodinlaan, tussen huisnummers 49 en 59.\"}],\"type\":\"Description\"}]",
+            "type": "LongText",
+            "lines": "[{\"id\":\"59\"}]",
+            "priority": 4,
+            "points": "[{\"id\":\"3125\"}]"
+        },
+        {
+            "content": "[{\"text\":[{\"en\":\"Until 2027, works. T97 temporarily withdrawn. For BARRIERE, B96 at MA CAMPAGNE. For ST-DENIS, B54 rue Defacqz 131\",\"fr\":\"Jsq 2027, travaux. T97 temporairement supprimé. Pour BARRIERE, B96 à MA CAMPAGNE. Pour ST-DENIS, B54 rue Defacqz 131.\",\"nl\":\"Tot 2027, werken. T97 tijdelijk geschrapt. Voor BAREEL, B96 aan MA CAMPAGNE.Voor ST-DENIJS, B54 Defacqzstr 131.\"}],\"type\":\"Description\"}]",
+            "type": "LongText",
+            "lines": "[]",
+            "priority": 4,
+            "points": "[{\"id\":\"6428F\"},{\"id\":\"5018F\"}]"
+        },
+        {
+            "content": "[{\"text\":[{\"en\":\"Works. From 21 Mar to 22 Mar at 6.30pm, bus 21 diverted btw DIAMANT and RTL HOUSE. Take bus 21 at DIAMANT.\",\"fr\":\"Travaux. Du 21/3 au 22/3 à 18h30, bus 21 dévié entre DIAMANT et RTL HOUSE. Prenez le bus 21 à DIAMANT.\",\"nl\":\"Werken. Van 21/3 tot 22/3 om 18.30u, bus 21 omgeleid tussen DIAMANT en RTL HOUSE. Neem bus 21 aan DIAMANT.\"}],\"type\":\"Description\"}]",
+            "type": "LongText",
+            "lines": "[{\"id\":\"21\"}]",
+            "priority": 4,
+            "points": "[{\"id\":\"3956\"}]"
+        },
+        {
+            "content": "[{\"text\":[{\"en\":\"Works. From 7 Oct at 10am, stop relocated. Temporary stop: avenue Maurice Maeterlincklaan 35.\",\"fr\":\"Travaux. Dès le 7/10 à 10h, arrêt déplacé. Arrêt provisoire: avenue Maurice Maeterlinck 35.\",\"nl\":\"Werken. Vanaf 7/10 om 10u, halte verplaatst. Tijdelijke halte: Maurice Maeterlincklaan 35.\"}],\"type\":\"Description\"}]",
+            "type": "LongText",
+            "lines": "[{\"id\":\"59\"}]",
+            "priority": 4,
+            "points": "[{\"id\":\"1890\"}]"
+        },
+        {
+            "content": "[{\"text\":[{\"en\":\"Works. 17 May-mid 2027, bus 59 diverted btw HUART-HAMOIR and ANATOLE FRANCE, and btw ST- VINCENT and BORDET STN.\",\"fr\":\"Travaux.17/5/25-mi-2027, bus 59 dévié entre HUART-HAMOIR et ANATOLE FRANCE, et entre SAINT- VINCENT et BORDET STAT.\",\"nl\":\"Werken. 17/5/25-midden 2027,bus 59 omgeleid tss HUART-HAMOIR en ANATOLE FRANCE, en tss ST- VINCENTIUS en BORDET ST.\"}],\"type\":\"Description\"}]",
+            "type": "LongText",
+            "lines": "[{\"id\":\"59\"}]",
+            "priority": 6,
+            "points": "[{\"id\":\"3081\"},{\"id\":\"3180\"},{\"id\":\"1280B\"},{\"id\":\"3158B\"},{\"id\":\"6464\"},{\"id\":\"6158\"},{\"id\":\"3156\"},{\"id\":\"3167\"},{\"id\":\"1582\"},{\"id\":\"3155\"},{\"id\":\"3177\"},{\"id\":\"3165\"},{\"id\":\"3164\"},{\"id\":\"3163\"},{\"id\":\"3162\"},{\"id\":\"3160\"},{\"id\":\"1569B\"},{\"id\":\"1577\"},{\"id\":\"1246\"},{\"id\":\"1476\"},{\"id\":\"3125\"},{\"id\":\"3168\"}]"
+        },
+        {
+            "content": "[{\"text\":[{\"en\":\"Works. Until 2027, stop not served. Walk to UCCLE-STALLE / UKKEL- STALLE.\",\"fr\":\"Travaux. Jusqu'en 2027, arrêt non desservi. Pour rejoindre UCCLE-STALLE, continuez à pied.\",\"nl\":\"Werken. Tot 2027, halte niet bediend. Ga te voet verder om naar UKKEL- STALLE te gaan.\"}],\"type\":\"Description\"}]",
+            "type": "LongText",
+            "lines": "[{\"id\":\"74\"}]",
+            "priority": 4,
+            "points": "[{\"id\":\"2416\"}]"
+        },
+        {
+            "content": "[{\"text\":[{\"en\":\"Works. From 6 Jan, bus 53 83 diverted. Stop of bus 53: rue Beyseghemstraat, 30 meters after number 105.\",\"fr\":\"Travaux. Dès le 6/1, bus 53 83 déviés. Arrêt du bus 53: rue de Beyseghem, 30 mètres après le numéro 105.\",\"nl\":\"Werken. Vanaf 6/1, bus 53 83 omgeleid. Halte van bus 53: Beyseghemstraat, 30 meter na nummer 105.\"}],\"type\":\"Description\"}]",
+            "type": "LongText",
+            "lines": "[{\"id\":\"53\"}]",
+            "priority": 4,
+            "points": "[{\"id\":\"2853\"}]"
+        },
+        {
+            "content": "[{\"text\":[{\"en\":\"Passages of 04:26 - 04: 55 - 08:14 from stop of bus 59 to HOPITAL ETTERBEEK-IXELLES.\",\"fr\":\"Passages de 04:26 - 04: 55 - 08:14 depuis l'arrêt du bus 59 direction HOP. ETTERBEEK-IXELLES.\",\"nl\":\"Doorkomsten van 04:26 - 04:55 - 08:14 vanaf halte bus 59 richting ZIEKH. ETTERBEEK-ELSENE.\"}],\"type\":\"Description\"}]",
+            "type": "LongText",
+            "lines": "[{\"id\":\"21\"}]",
+            "priority": 4,
+            "points": "[{\"id\":\"3214\"}]"
+        },
+        {
+            "content": "[{\"text\":[{\"en\":\"Until 2027, works. Tram 97 temporarily withdrawn. For BARRIERE / BAREEL, take bus 52.\",\"fr\":\"Jusqu’en 2027, travaux. Tram 97 temporairement supprimé. Pour BARRIERE, prenez le bus 52.\",\"nl\":\"Tot 2027, werken. Tram 97 tijdelijk geschrapt. Voor BAREEL, neem bus 52.\"}],\"type\":\"Description\"}]",
+            "type": "LongText",
+            "lines": "[{\"id\":\"82\"}]",
+            "priority": 4,
+            "points": "[{\"id\":\"5151\"}]"
+        },
+        {
+            "content": "[{\"text\":[{\"en\":\"Until 2027, works. T97 temporarily withdrawn.As of 22 Dec,B96 limited to CHARROI. For ST-DENIS, T 82 or B50 at WIELS.\",\"fr\":\"Jsq 2027, travaux. T97 temporairement supprimé. Dès le 22/12, B96 limité à CHARROI.Pour ST-DENIS, T82 ou B50 à WIELS.\",\"nl\":\"Tot 2027, werken. T97 tijdelijk geschrapt. Vanaf 22/12, B96 beperkt tot GERIJ.Voor ST-DENIJS T82 of B50 aan WIELS.\"}],\"type\":\"Description\"}]",
+            "type": "LongText",
+            "lines": "[]",
+            "priority": 4,
+            "points": "[{\"id\":\"5115F\"},{\"id\":\"2404F\"},{\"id\":\"2334F\"}]"
+        },
+        {
+            "content": "[{\"text\":[{\"en\":\"Works. From 21 Mar until 22 Mar at 6.30pm, bus 80 diverted btw FEVRIER and PADUWA. Stop of bus 80: chée de Louvain 862.\",\"fr\":\"Travaux. Du 21/3 au 22/3 à 18h30, bus 80 dévié entre FEVRIER et PADUWA. Arrêt du bus 80: chaussée de Louvain 862.\",\"nl\":\"Werken. van 21/3 tot 22/3 om 18.30u, bus 80 omgeleid tussen FEBRUARI en PADUWA. Halte van bus 80: Leuvensestwg 862\"}],\"type\":\"Description\"}]",
+            "type": "LongText",
+            "lines": "[{\"id\":\"80\"}]",
+            "priority": 4,
+            "points": "[{\"id\":\"3957\"}]"
+        },
+        {
+            "content": "[{\"text\":[{\"en\":\"Works. STOP NOT SERVED. To go to DE BROUCKERE, take metro lines 1 or 5. Stop B89: bd Impératrice / car park Gd Place.\",\"fr\":\"Travaux. ARRET NON DESSERVI. Pour DE BROUCKERE, métro 1 ou 5. Arrêt B89:bd Impératrice / parking Grand-Place\",\"nl\":\"Werken. HALTE NIET BEDIEND. Voor DE BROUCKERE, metro 1 of 5. Halte B89: Keizerinln / parking Grote Markt\"}],\"type\":\"Description\"}]",
+            "type": "LongText",
+            "lines": "[{\"id\":\"89\"},{\"id\":\"29\"},{\"id\":\"71\"}]",
+            "priority": 4,
+            "points": "[{\"id\":\"6447\"}]"
+        },
+        {
+            "content": "[{\"text\":[{\"en\":\"Works. As of 23 Mar for +/- 3 weeks,B53 diverted bt PETER BENOIT and HOP MILITAIRE. For VAL MARIA, B83 at DE WAND.\",\"fr\":\"Travaux.Dès le 23/3 pour +/- 3 semaines, B53 dévié entre PETER BENOIT et HOP MILITAIRE. Pour VAL MARIA, B83 à DE WAND\",\"nl\":\"Werken. Vanaf 23/3 voor +/- 3 weken,B53 omgeleid ts P. BENOIT en MILITAIR HOSP. Voor MARIENDAAL, B83 aan DE WAND.\"}],\"type\":\"Description\"}]",
+            "type": "LongText",
+            "lines": "[{\"id\":\"53\"}]",
+            "priority": 5,
+            "points": "[{\"id\":\"2547\"},{\"id\":\"2811\"},{\"id\":\"2810\"},{\"id\":\"4132B\"},{\"id\":\"2809\"},{\"id\":\"2819\"},{\"id\":\"2824\"}]"
+        },
+        {
+            "content": "[{\"text\":[{\"en\":\"Until 2027, works. Tram 82 at NEERSTALLE. For BARRIERE, temporary bus 96 at WIELS (via tram 82 / bus 50 at NEERSTALLE)\",\"fr\":\"Jsq 2027, travaux. Tram 82 à NEERSTALLE. Pour BARRIERE, bus temporaire 96 à WIELS (via tram 82 / bus 50 à NEERSTALLE)\",\"nl\":\"Tot 2027, werken. Tram 82 aan NEERSTALLE. Voor BAREEL, tijdelijke bus 96 aan WIELS(via tram 82 / bus 50 aan NEERSTALLE)\"}],\"type\":\"Description\"}]",
+            "type": "LongText",
+            "lines": "[{\"id\":\"82\"}]",
+            "priority": 4,
+            "points": "[{\"id\":\"5756F\"},{\"id\":\"1258G\"}]"
+        },
+        {
+            "content": "[{\"text\":[{\"en\":\"Works. 4 Aug to December 2026, T51 interrupted. For BELGICA, take bus 14 at PICARD (500m) or walk (750m).\",\"fr\":\"Travaux.  4/8 à décembre 2026, T51 interrompu. Pour BELGICA, prenez le bus 14 à PICARD (500m) ou allez à pied (750m).\",\"nl\":\"Werken. 4/8 tot december 2026, T51 onderbroken. Voor BELGICA, neem bus 14 aan PICARD (500m) of ga te voet (750m).\"}],\"type\":\"Description\"}]",
+            "type": "LongText",
+            "lines": "[{\"id\":\"51\"}]",
+            "priority": 4,
+            "points": "[{\"id\":\"5089\"}]"
+        },
+        {
+            "content": "[{\"text\":[{\"en\":\"Works. As of 29 Jan, stop COMBAZ moved on the other traffic lane, av. du Parc / Parklaan in front of number 83.\",\"fr\":\"Travaux. Dès le 29/1, arrêt COMBAZ déplacé sur l'autre bande de circulation, av. du Parc, en face du 83.\",\"nl\":\"Werken.Vanaf 29/1, halte COMBAZ verplaatst op de andere rijstrook, Parklaan, tegenover nummer 83.\"}],\"type\":\"Description\"}]",
+            "type": "LongText",
+            "lines": "[{\"id\":\"N12\"},{\"id\":\"52\"},{\"id\":\"96\"}]",
+            "priority": 4,
+            "points": "[{\"id\":\"1735\"}]"
+        },
+        {
+            "content": "[{\"text\":[{\"en\":\"Works. Until end of April, bus 88 diverted between GUILLAUME DE GREEF and CROCQ.\",\"fr\":\"Travaux.  Jusqu'à fin avril, bus 88 dévié entre GUILLAUME DE GREEF et CROCQ.\",\"nl\":\"Werken. Tot eind april, bus 88 omgeleid tussen GUILLAUME DE GREEF en CROCQ.\"}],\"type\":\"Description\"}]",
+            "type": "LongText",
+            "lines": "[{\"id\":\"88\"}]",
+            "priority": 5,
+            "points": "[{\"id\":\"2070\"},{\"id\":\"9026\"},{\"id\":\"2090\"},{\"id\":\"4266\"},{\"id\":\"2088\"},{\"id\":\"3483\"},{\"id\":\"2271\"},{\"id\":\"6173\"},{\"id\":\"2170\"},{\"id\":\"3083\"},{\"id\":\"2305\"},{\"id\":\"1356\"},{\"id\":\"2863\"},{\"id\":\"2554\"},{\"id\":\"3400\"},{\"id\":\"1988B\"},{\"id\":\"4258\"},{\"id\":\"4127\"}]"
+        },
+        {
+            "content": "[{\"text\":[{\"en\":\"Works. From 27 Feb, 6pm, until end of April, B88 diverted. Take tram 19 until GUILLAUME DE GREEF, bus 88.\",\"fr\":\"Travaux. Dès le 27/2, 18h jusqu'à fin avril, bus 88 dévié. Prenez le tram 19 jusque GUILLAUME DE GREEF, puis bus 88.\",\"nl\":\"Werken. Van 27/2, 18u tot eind april, B88 omgeleid. Neem tram 19 tot GUILLAUME DE GREEF, dan bus 88.\"}],\"type\":\"Description\"}]",
+            "type": "LongText",
+            "lines": "[{\"id\":\"88\"}]",
+            "priority": 4,
+            "points": "[{\"id\":\"1035\"},{\"id\":\"3482\"}]"
+        },
+        {
+            "content": "[{\"text\":[{\"en\":\"Until 2027, works. T97 temporarily withdrawn. For BARRIERE, B96 at stop De Lijn. ST-DENIS: B54 at MA CAMPAGNE.\",\"fr\":\"Jsq 2027, travaux. T97 temporairement supprimé. Pour BARRIERE, B96 à l' arrêt De Lijn. ST-DENIS: B54 à MA CAMPAGNE.\",\"nl\":\"Tot 2027, werken. T97 tijdelijk geschrapt.Voor BAREEL, B96 aan halte De Lijn. ST-DENIJS: B54 aan MA CAMPAGNE.\"}],\"type\":\"Description\"}]",
+            "type": "LongText",
+            "lines": "[]",
+            "priority": 4,
+            "points": "[{\"id\":\"6162\"}]"
+        },
+        {
+            "content": "[{\"text\":[{\"en\":\"Works. From 9 Mar to +/- 27 Mar, stop ENSOR not served. Bus 47 at temporary stop ENNEPETAL: Ensorlaan 6.\",\"fr\":\"Travaux. Du 9/3 au +/- 27/3, arrêt ENSOR non desservi. Bus 47 à l'arrêt provisoire ENNEPETAL: Ensorlaan 6.\",\"nl\":\"Werken. Van 9/3 tot +/- 27/3, halte ENSOR niet bediend. Bus 47 aan tijdelijke halte ENNEPETAL: Ensorlaan 6.\"}],\"type\":\"Description\"}]",
+            "type": "LongText",
+            "lines": "[{\"id\":\"47\"}]",
+            "priority": 4,
+            "points": "[{\"id\":\"1485\"}]"
+        },
+        {
+            "content": "[{\"text\":[{\"en\":\"Works. 26 Jan-end 2026, stop not served. Take tram 81 at AVENUE DU ROI (stop of tram 82 to GARE DE BERCHEM).\",\"fr\":\"Travaux. 26/1-fin 2026, arrêt non desservi. Prenez le tram 81 à AVENUE DU ROI (arrêt T82 vers GARE DE BERCHEM).\",\"nl\":\"Werken. 26/1-eind 2026, halte niet bediend. Neem tram 81 aan KONINGSLAAN (halte van tram 82 naar STATION BERCHEM).\"}],\"type\":\"Description\"}]",
+            "type": "LongText",
+            "lines": "[{\"id\":\"81\"}]",
+            "priority": 4,
+            "points": "[{\"id\":\"6166\"}]"
+        },
+        {
+            "content": "[{\"text\":[{\"en\":\"Match. 22 Mar, 3.30pm- 1am, STOP NOT SERVED. Take bus 46 at the previous stop, MEIR.\",\"fr\":\"Match. 22/3, 15h30-1h, ARRET NON DESSERVI. Prenez le bus 46 à l'arrêt précédent, MEIR.\",\"nl\":\"Match. 22/3, 15.30u-1u, HALTE NIET BEDIEND. Neem bus 46 aan de vorige halte, MEIR.\"}],\"type\":\"Description\"}]",
+            "type": "LongText",
+            "lines": "[{\"id\":\"46\"}]",
+            "priority": 4,
+            "points": "[{\"id\":\"2373\"}]"
+        },
+        {
+            "content": "[{\"text\":[{\"en\":\"Works. 21 May 2025-mid 2027, stop not served. Tram 55 at TILLEUL or VERBOEKHOVEN (via bus 59 69 from BORDET STATION).\",\"fr\":\"Travaux.21/5/25-mi-2027, arrêt non desservi. Tram 55 à TILLEUL ou à VERBOEKHOVEN (via bus 59 69 à BORDET STATION).\",\"nl\":\"Werken. 21/5/25-midden 2027,halte niet bediend. Tram 55 aan LINDE of aan VERBOEKHOVEN (via bus 59 69 aan BORDET STATION).\"}],\"type\":\"Description\"}]",
+            "type": "LongText",
+            "lines": "[{\"id\":\"55\"}]",
+            "priority": 4,
+            "points": "[{\"id\":\"5041F\"}]"
+        },
+        {
+            "content": "[{\"text\":[{\"en\":\"Works. From 21 May 2025 to mid 2027, tram 55 interrupted btw TILLEUL and DA VINCI. For BORDET STATION, take bus 59.\",\"fr\":\"Travaux. Du 21/5/25 à mi-2027, tram 55 interrompu entre TILLEUL et DA VINCI. Pour BORDET STATION, bus 59.\",\"nl\":\"Werken. Van 21/5/25 tot midden 2027, tram 55 onderbroken tss LINDE en DA VINCI. Voor BORDET STATION, neem bus 59.\"}],\"type\":\"Description\"}]",
+            "type": "LongText",
+            "lines": "[{\"id\":\"55\"}]",
+            "priority": 5,
+            "points": "[{\"id\":\"5766\"}]"
+        },
+        {
+            "content": "[{\"text\":[{\"en\":\"Works. STOP RELOCATED. Temporary stop: Heldenplein, on site in front of church.\",\"fr\":\"Travaux. ARRET DEPLACE. Arrêt provisoire: Heldenplein, site devant l'église.\",\"nl\":\"Werken. HALTE VERPLAATST. Tijdelijke halte: Heldenplein, site voor de kerk.\"}],\"type\":\"Description\"}]",
+            "type": "LongText",
+            "lines": "[{\"id\":\"47\"}]",
+            "priority": 4,
+            "points": "[{\"id\":\"9787\"}]"
+        },
+        {
+            "content": "[{\"text\":[{\"en\":\"Works. From 17 May 2025 to mid 2027, bus 59 diverted btw ST-VINCENT and BORDET STATION via FONSON and PAIX/VREDE.\",\"fr\":\"Travaux. Du 17/5/25 à mi-2027, bus 59 dévié entre SAINT-VINCENT et BORDET STATION via FONSON et PAIX.\",\"nl\":\"Werken. 17/5/25-midden 2027, bus 59 omgeleid tss ST-VINCENTIUS en BORDET STATION via FONSON en VREDE.\"}],\"type\":\"Description\"}]",
+            "type": "LongText",
+            "lines": "[{\"id\":\"59\"}]",
+            "priority": 5,
+            "points": "[{\"id\":\"3175B\"},{\"id\":\"3174\"},{\"id\":\"3173\"},{\"id\":\"3172\"}]"
+        },
+        {
+            "content": "[{\"text\":[{\"en\":\"Works. 21 May 2025-mid 2027,tram 55 interrupted btw TILLEUL and DA VINCI. For BORDET STN, B59 (stop: sq.Rigasq.37)\",\"fr\":\"Travaux.21/5/25-mi-2027, tram 55 interrompu entre TILLEUL et DA VINCI. Pour BORDET STATION, bus 59 (arrêt: sq. Riga 37)\",\"nl\":\"Werken. 21/5/25-midden 2027,tram 55 onderbroken tss LINDE en DA VINCI. Voor BORDET STATION, B59 (halte: Rigasq. 37)\"}],\"type\":\"Description\"}]",
+            "type": "LongText",
+            "lines": "[{\"id\":\"55\"}]",
+            "priority": 5,
+            "points": "[{\"id\":\"5867F\"}]"
+        },
+        {
+            "content": "[{\"text\":[{\"en\":\"Works. From 27 Feb, 6pm, until end of April, B88 diverted. Stop B88: av. G. De Greeflaan, stop De Lijn to Bru Nord.\",\"fr\":\"Travaux. Dès le 27/2, 18h jsq fin avril, bus 88 dévié. Arrêt bus 88: av. G. De Greef, arrêt De Lijn vers Bxl-Nord.\",\"nl\":\"Werken. Van 27/2, 18u tot eind april, B88 omgeleid. Halte bus 88: G. De Greeflaan, halte De Lijn naar Bru-Noord.\"}],\"type\":\"Description\"}]",
+            "type": "LongText",
+            "lines": "[{\"id\":\"88\"}]",
+            "priority": 4,
+            "points": "[{\"id\":\"1788B\"}]"
+        },
+        {
+            "content": "[{\"text\":[{\"en\":\"Until 2027, works. T82 limited to NEERSTALLE, tram 97 withdrawn.For DROGENBOS, bus 74 at ST- DENIS (as of 22 Dec).\",\"fr\":\"Jsq 2027, travaux. Tram 82 limité à NEERSTALLE, tram 97 supprimé. Pour DROGENBOS, bus 74 à ST- DENIS (dès le 22/12).\",\"nl\":\"Tot 2027,werken. Tram 82 beperkt tot NEERSTALLE, tram 97 geschrapt. Voor DROGENBOS, bus 74 aan ST-DENIJS (vanaf 22/12).\"}],\"type\":\"Description\"}]",
+            "type": "LongText",
+            "lines": "[{\"id\":\"82\"}]",
+            "priority": 5,
+            "points": "[{\"id\":\"5154F\"}]"
+        },
+        {
+            "content": "[{\"text\":[{\"en\":\"Works. From 19 Jan to end of 2026, bus 53 diverted. Take the bus at the previous stop, EMILE DELVA (300m).\",\"fr\":\"Travaux. Du 19/1 à fin 2026, bus 53 dévié. Prenez le bus à l'arrêt précédent, EMILE DELVA (300m).\",\"nl\":\"Werken. Van 19/1 tot eind 2026, bus 53 omgeleid. Neem de bus aan de vorige halte, EMILE DELVA (300m). \"}],\"type\":\"Description\"}]",
+            "type": "LongText",
+            "lines": "[{\"id\":\"53\"}]",
+            "priority": 4,
+            "points": "[{\"id\":\"3084\"}]"
+        },
+        {
+            "content": "[{\"text\":[{\"en\":\"Match. 22 Mar, 3.30pm- 1am, bus 75 diverted. Take bus 75 at the previous stop, VAN BEETHOVEN.\",\"fr\":\"Match. 22/3, 15h30-1h, bus 75 dévié. Prenez le bus 75 à l'arrêt précédent, VAN BEETHOVEN.\",\"nl\":\"Match. 22/3, 15.30u-1u, bus 75 omgeleid. Neem bus 75 aan de vorige halte, VAN BEETHOVEN.\"}],\"type\":\"Description\"}]",
+            "type": "LongText",
+            "lines": "[{\"id\":\"75\"}]",
+            "priority": 4,
+            "points": "[{\"id\":\"6856B\"}]"
+        },
+        {
+            "content": "[{\"text\":[{\"en\":\"Due to bad state of road, stop relocated. Take bus 83 at the stop 10 meters before this stop.\",\"fr\":\"Mauvais état de la voirie, arrêt déplacé. Prenez le bus 83 à l'arrêt 10 mètres avant cet arrêt.\",\"nl\":\"Door slechte staat wegdek, halte verplaatst. Neem bus 83 aan de halte 10 meter voor deze halte.\"}],\"type\":\"Description\"}]",
+            "type": "LongText",
+            "lines": "[{\"id\":\"83\"}]",
+            "priority": 4,
+            "points": "[{\"id\":\"2867\"},{\"id\":\"2874\"}]"
+        },
+        {
+            "content": "[{\"text\":[{\"en\":\"Works. 19 Jan to summer 2026, bus 41 diverted. Bus 41 at FUTAIE (via B41 to HELDEN or on foot) or KEYM (800m). \",\"fr\":\"Travaux. 19/1 à l'été 2026, bus 41 dévié. Bus 41 à FUTAIE (via bus 41 vers HEROS ou 400m à pied) ou à KEYM (800m).\",\"nl\":\"Werken. 19/1 tot zomer 2026, bus  41 omgeleid. Bus 41 aan FUTAIE (via B41 naar HELDEN of 400m te voet) of KEYM (800m).\"}],\"type\":\"Description\"}]",
+            "type": "LongText",
+            "lines": "[{\"id\":\"41\"}]",
+            "priority": 4,
+            "points": "[{\"id\":\"2076\"}]"
+        },
+        {
+            "content": "[{\"text\":[{\"en\":\"Until 2027, works. Tram 97 temporarily withdrawn. For BARRIERE, temporary bus line 96 at WIELS, via tram 82.\",\"fr\":\"Jusqu’en 2027, travaux. Tram 97 temporairement supprimé. Pour BARRIERE, bus temporaire 96 à WIELS via tram 82.\",\"nl\":\"Tot 2027, werken. Tram 97 tijdelijk geschrapt. Voor BAREEL, tijdelijke bus 96 aan WIELS via tram 82.\"}],\"type\":\"Description\"}]",
+            "type": "LongText",
+            "lines": "[{\"id\":\"82\"}]",
+            "priority": 4,
+            "points": "[{\"id\":\"2668\"},{\"id\":\"5155\"},{\"id\":\"2667F\"},{\"id\":\"5162F\"}]"
+        },
+        {
+            "content": "[{\"text\":[{\"en\":\"Works. From 21 Mar to 22 Mar at 6.30pm, bus 80 diverted btw FEVRIER and PADUWA. Stop of bus 80: rue Colonel Bourg 104.\",\"fr\":\"Travaux. Du 21/3 au 22/3 à 18h30, bus 80 dévié entre FEVRIER et PADUWA. Arrêt du bus 80: rue Colonel Bourg 104.\",\"nl\":\"Werken.Van 21/3 tot 22/3 om 18.30u, bus 80 omgeleid tss FEBRUARI en PADUWA. Halte bus 80: Kolonel Bourgstraat 104.\"}],\"type\":\"Description\"}]",
+            "type": "LongText",
+            "lines": "[{\"id\":\"80\"}]",
+            "priority": 4,
+            "points": "[{\"id\":\"3956\"}]"
+        },
+        {
+            "content": "[{\"text\":[{\"en\":\"Works. As of 29 Jan, stop COMBAZ moved on the other traffic lane, av. du Parc/Parklaan, next of house number 85.\",\"fr\":\"Travaux. Dès le 29/1, arrêt COMBAZ déplacé sur l'autre bande de circulation, av. du Parc, à hauteur du 85.\",\"nl\":\"Werken.Vanaf 29/1, halte COMBAZ verplaatst op de andere rijstrook, Parklaan, ter hoogte van huisnummer 85.\"}],\"type\":\"Description\"}]",
+            "type": "LongText",
+            "lines": "[{\"id\":\"N12\"},{\"id\":\"52\"},{\"id\":\"96\"}]",
+            "priority": 4,
+            "points": "[{\"id\":\"1708\"}]"
+        },
+        {
+            "content": "[{\"text\":[{\"en\":\"Until 2027, works. T97 temporarily withdrawn. For WIELS, B96. For ST- DENIS, B52 to BERVOETS, and B50 54 74.\",\"fr\":\"Jsq 2027, travaux. T97 temporairement supprimé. Pour WIELS, B96. Pour ST-DENIS, B52 jsq BERVOETS, et B50 54 74. \",\"nl\":\"Tot 2027, werken. T97 tijdelijk geschrapt. Voor WIELS, B96, voor ST-DENIJS, B52 tot BERVOETS en B50 54 74.\"}],\"type\":\"Description\"}]",
+            "type": "LongText",
+            "lines": "[]",
+            "priority": 4,
+            "points": "[{\"id\":\"6078\"},{\"id\":\"2336G\"}]"
+        },
+        {
+            "content": "[{\"text\":[{\"en\":\"Match. 22 Mar, 3.30pm- 1am, STOP NOT SERVED. Take bus 46 at YSAYE of T81 to MONTGOMERY. B75 at RENE HENRY.\",\"fr\":\"Match. 22/3, 15h30-1h, ARRET NON DESSERVI. B46: à l'arrêt YSAYE du T81 vers MONTGOMERY. B75: à l'arrêt RENE HENRY.\",\"nl\":\"Match. 22/3, 15.30u-1u, HALTE NIET BEDIEND. B46: aan de halte YSAYE van T81 naar MONTGOMERY. B75: aan RENE HENRY.\"}],\"type\":\"Description\"}]",
+            "type": "LongText",
+            "lines": "[{\"id\":\"46\"},{\"id\":\"75\"}]",
+            "priority": 4,
+            "points": "[{\"id\":\"2319\"}]"
+        },
+        {
+            "content": "[{\"text\":[{\"en\":\"Works. From 21 Mar until 22 Mar at 6.30pm, bus 21 diverted between DIAMANT and RTL HOUSE. Take bus 21 at RTL HOUSE.\",\"fr\":\"Travaux. Du 21/3 au 22/3 à 18h30, bus 21 dévié entre DIAMANT et RTL HOUSE. Prenez le bus 21 à RTL HOUSE.\",\"nl\":\"Werken. Van 21/3 tot 22/3 om 18.30u, bus 21 omgeleid tussen DIAMANT en RTL HOUSE. Neem bus 21 aan RTL HOUSE.\"}],\"type\":\"Description\"}]",
+            "type": "LongText",
+            "lines": "[{\"id\":\"21\"}]",
+            "priority": 4,
+            "points": "[{\"id\":\"3904\"}]"
+        },
+        {
+            "content": "[{\"text\":[{\"en\":\"Works. 26 Jan-end 2026, tram 81 interrupted. Take tram 81 at the stop in the other direction.\",\"fr\":\"Travaux. 26/1-fin 2026, tram 81 interrompu. Prenez le tram 81 à l'arrêt dans l'autre sens.\",\"nl\":\"Werken. 26/1-eind 2026, tram 81 onderbroken. Neem tram 81 aan de halte in de andere richting\"}],\"type\":\"Description\"}]",
+            "type": "LongText",
+            "lines": "[{\"id\":\"81\"}]",
+            "priority": 4,
+            "points": "[{\"id\":\"2960F\"}]"
+        },
+        {
+            "content": "[{\"text\":[{\"fr\":\"Le dimanche 5h-16h, marché. ARRET NON DESSERVI. Arrêt provisoire: av. du Maelbeek, face au 43.\",\"nl\":\"Op zondag 5u-16u, markt. HALTE NIET BEDIEND. Tijd. halte: Maalbeeklaan, tegenover nr. 43.\"}],\"type\":\"Description\"}]",
+            "type": "LongText",
+            "lines": "[{\"id\":\"59\"},{\"id\":\"80\"},{\"id\":\"60\"}]",
+            "priority": 5,
+            "points": "[{\"id\":\"3158B\"},{\"id\":\"3160\"}]"
+        },
+        {
+            "content": "[{\"text\":[{\"en\":\"Works. 21 Mar-22 Mar 6. 30pm, bus 79 diverted btw DIAMANT and CARENE. Stop bus 79:av.Grosjean, before the bridge.\",\"fr\":\"Travaux. 21/3-22/3, 18h30,bus 79 dévié entre DIAMANT et CARENE. Arrêt du bus 79: avenue Léon Grosjean, avant le pont.\",\"nl\":\"Werken.21/3-22/3,18.30u, bus 79 omgeleid tussen DIAMANT en CARINA. Halte bus 79: Léon Grosjeanln, voor de brug.\"}],\"type\":\"Description\"}]",
+            "type": "LongText",
+            "lines": "[{\"id\":\"79\"},{\"id\":\"80\"}]",
+            "priority": 4,
+            "points": "[{\"id\":\"3957\"}]"
+        },
+        {
+            "content": "[{\"text\":[{\"en\":\"Works. From 21 Mar to 22 Mar at 6.30pm, bus 21 diverted between DIAMANT and RTL HOUSE. Take bus 21 at RTL HOUSE.\",\"fr\":\"Travaux. Du 21/3 au 22/3 à 18h30, bus 21 dévié entre DIAMANT et RTL HOUSE. Prenez le bus 21 à RTL HOUSE.\",\"nl\":\"Werken. Van 21/3 tot 22/3 om 18.30u, bus 21 omgeleid tussen DIAMANT en RTL HOUSE. Neem bus 21 aan RTL HOUSE.\"}],\"type\":\"Description\"}]",
+            "type": "LongText",
+            "lines": "[{\"id\":\"21\"}]",
+            "priority": 4,
+            "points": "[{\"id\":\"4505\"}]"
+        },
+        {
+            "content": "[{\"text\":[{\"en\":\"Works. From 4 Aug to December 2026, stop relocated. Take the tram at the stop direction Stade/Stadion. \",\"fr\":\"Travaux. Du 4/8 à décembre 2026, arrêt déplacé. Prenez le tram à l'arrêt direction Stade. \",\"nl\":\"Werken. Van 4/8 tot december 2026, halte verplaatst. Neem de tram aan de halte richting Stadion.\"}],\"type\":\"Description\"}]",
+            "type": "LongText",
+            "lines": "[{\"id\":\"51\"}]",
+            "priority": 4,
+            "points": "[{\"id\":\"2851F\"}]"
+        },
+        {
+            "content": "[{\"text\":[{\"en\":\"Works. Until end of April, B88 diverted. B88 at GUILL DE GREEF (stop De Lijn to Dendermonde) via B14 from DEMINEURS.\",\"fr\":\"Travaux. Jsq fin avril, B88 dévié. B88 à GUILL. DE GREEF (arrêt De Lijn vers Dendermonde) via B14 depuis DEMINEURS.\",\"nl\":\"Werken. Tot eind april, B88 omgeleid. B88 aan GUILL. DE GREEF(halte De Lijn naar Dendermonde) via B14 vanaf ONTMIJNERS\"}],\"type\":\"Description\"}]",
+            "type": "LongText",
+            "lines": "[{\"id\":\"88\"}]",
+            "priority": 4,
+            "points": "[{\"id\":\"3484\"}]"
+        },
+        {
+            "content": "[{\"text\":[{\"en\":\"Works. As of 22 Dec, temporary bus 96 does not serve this stop anymore. For FLAGEY, tram 81 at TRINITE.\",\"fr\":\"Travaux. Dès le 22/12, bus temporaire 96 ne dessert plus cet arrêt. Pour FLAGEY, tram 81 à TRINITE.\",\"nl\":\"Werken. Vanaf 22/12 bedient de tijdelijke bus 96 deze halte niet meer. Voor FLAGEY, tram 81 aan DRIEVULDIGHEID.\"}],\"type\":\"Description\"}]",
+            "type": "LongText",
+            "lines": "[{\"id\":\"96\"}]",
+            "priority": 4,
+            "points": "[{\"id\":\"2646\"}]"
+        },
+        {
+            "content": "[{\"text\":[{\"en\":\"Works. From 17 May 2025 to mid 2027, stop not served. For BORDET STATION, take bus 59 or 64.\",\"fr\":\"Travaux. Du 17/5/25 à mi-2027, arrêt non desservi. Pour BORDET STATION, prenez le bus 59 ou 64. \",\"nl\":\"Werken. Van 17/5/25 tot midden 2027, halte niet bediend. Voor BORDET STATION, neem bus 59 of 64.\"}],\"type\":\"Description\"}]",
+            "type": "LongText",
+            "lines": "[{\"id\":\"55\"}]",
+            "priority": 4,
+            "points": "[{\"id\":\"2900F\"},{\"id\":\"5801\"}]"
+        },
+        {
+            "content": "[{\"text\":[{\"en\":\"Works. From 21 Mar until 22 Mar at 6.30pm, B21 diverted btw DIAMANT and RTL HOUSE, B79 diverted btw DIAMANT and CARENE.\",\"fr\":\"Travaux. Du 21/3 au 22/3 à 18h30, bus 21 dévié entre DIAMANT et RTL HOUSE, bus 79 dévié entre DIAMANT et CARENE.\",\"nl\":\"Werken.Van 21/3 tot 22/3 om 18.30u, B21 omgeleid tss DIAMANT en RTL HOUSE, B79 omgeleid tss DIAMANT en CARINA.\"}],\"type\":\"Description\"}]",
+            "type": "LongText",
+            "lines": "[{\"id\":\"79\"},{\"id\":\"21\"}]",
+            "priority": 5,
+            "points": "[{\"id\":\"1403\"},{\"id\":\"3081\"},{\"id\":\"6464\"},{\"id\":\"1402B\"},{\"id\":\"1273\"},{\"id\":\"1419\"},{\"id\":\"1318\"}]"
+        },
+        {
+            "content": "[{\"text\":[{\"en\":\"Works. Until end of April, B14 88 diverted. B14 88 at temporary stop CROCQ: av.Ernest Masoinln, De Lijn stop.\",\"fr\":\"Travaux. Jusqu'à fin avril, bus 14 88 déviés. Bus 14 88 à l'arrêt provisoire CROCQ: avenue Ernest Masoin, De Lijn.\",\"nl\":\"Werken. Tot eind april, B14 88 omgeleid. Neem B14 88 aan tijdelijke halte CROCQ: Ernest Masoinln, De Lijn-halte.\"}],\"type\":\"Description\"}]",
+            "type": "LongText",
+            "lines": "[{\"id\":\"88\"},{\"id\":\"14\"}]",
+            "priority": 4,
+            "points": "[{\"id\":\"2873\"},{\"id\":\"2871\"}]"
+        },
+        {
+            "content": "[{\"text\":[{\"en\":\"Works. 4 Aug to December 2026, T51 interrupted. For BELGICA, B14 at PICARD (500m) or M2-6 to ELISABETH, then M6. \",\"fr\":\"Travaux. 4/8 à décembre 2026, T51 interrompu. Pour BELGICA, B14 à PICARD(500m)ou M2-6 jsq ELISABETH, puis M6.\",\"nl\":\"Werken. 4/8 tot december 2026, T51 onderbroken. Voor BELGICA, B14 aan PICARD (500m) of M2-6 tot ELISABETH, dan M6.\"}],\"type\":\"Description\"}]",
+            "type": "LongText",
+            "lines": "[{\"id\":\"51\"}]",
+            "priority": 4,
+            "points": "[{\"id\":\"5072\"}]"
+        },
+        {
+            "content": "[{\"text\":[{\"en\":\"Works. From 9 Oct, stop relocated. Temporary stop: Stapelhuisstraat/ rue de l'Entrepot, in front of 5A.\",\"fr\":\"Travaux. Dès le 9/10, arrêt déplacé. Arrêt provisoire: rue de l'Entrepot, face au 5A.\",\"nl\":\"Werken. Vanaf 9/10, halte verplaatst. Tijdelijke halte: Stapelhuisstraat, tegenover 5A.\"}],\"type\":\"Description\"}]",
+            "type": "LongText",
+            "lines": "[{\"id\":\"88\"},{\"id\":\"46\"},{\"id\":\"N18\"},{\"id\":\"86\"}]",
+            "priority": 4,
+            "points": "[{\"id\":\"2305\"}]"
+        },
+        {
+            "content": "[{\"text\":[{\"en\":\"Works. Until 2027, stop not served. As of 22 Dec, take tram 82 at ST- DENIS via bus 74 (Stop: Grote Baan 227).\",\"fr\":\"Travaux. Jsq 2027, arrêt non desservi. Dès le 22/12, tram 82 à SAINT- DENIS via bus 74 (arrêt: Grand'Route 227).\",\"nl\":\"Werken. Tot 2027, halte niet bediend. Vanaf 22/12, neem tram 82 aan SINT-DENIJS via bus 74 (halte: Grote Baan 227).\"}],\"type\":\"Description\"}]",
+            "type": "LongText",
+            "lines": "[{\"id\":\"82\"}]",
+            "priority": 4,
+            "points": "[{\"id\":\"5732F\"}]"
+        },
+        {
+            "content": "[{\"text\":[{\"en\":\"Works. As of 26/1, stop BOILEAU moved rue Baron de Castrostraat, next to house number 7.\",\"fr\":\"Travaux. Dès le 26/1, arrêt BOILEAU déplacé rue Baron de Castro, à hauteur du numéro 7.\",\"nl\":\"Werken. Vanaf 26/1, halte BOILEAU verplaatst Baron de Castrostraat, ter hoogte van huisnummer 7.\"}],\"type\":\"Description\"}]",
+            "type": "LongText",
+            "lines": "[{\"id\":\"36\"}]",
+            "priority": 4,
+            "points": "[{\"id\":\"1809\"}]"
+        },
+        {
+            "content": "[{\"text\":[{\"en\":\"Works. As of 5 Jan, bus 50 diverted between BERVOETS and WIELS via UNION. For CHARROI / GERIJ,bus 74 at BERVOETS\",\"fr\":\"Travaux. Dès le 5/1, bus 50 dévié entre BERVOETS et WIELS via UNION. Pour CHARROI, prenez le bus 74 à BERVOETS.\",\"nl\":\"Werken. Vanaf 5/1, bus 50 omgeleid tussen BERVOETS en WIELS via UNION. Voor GERIJ, neem bus 74 aan BERVOETS.\"}],\"type\":\"Description\"}]",
+            "type": "LongText",
+            "lines": "[{\"id\":\"50\"}]",
+            "priority": 5,
+            "points": "[{\"id\":\"9685\"},{\"id\":\"9683\"},{\"id\":\"9679\"},{\"id\":\"9677\"},{\"id\":\"2661\"},{\"id\":\"9681\"},{\"id\":\"9682\"},{\"id\":\"9680\"},{\"id\":\"3604\"},{\"id\":\"3603\"},{\"id\":\"9658\"},{\"id\":\"2662B\"},{\"id\":\"9659\"},{\"id\":\"2659\"}]"
+        },
+        {
+            "content": "[{\"text\":[{\"en\":\"Works. From 19 Jan to end of 2026, bus 53 diverted between EMILE DELVA and LEOPOLD I. Info:stib-mivb.be or app\",\"fr\":\"Travaux. Du 19/1 à fin 2026, bus 53 dévié entre EMILE DELVA et LEOPOLD I. Info: stib.brussels ou app.\",\"nl\":\"Werken. 19/1-eind 2026, bus 53 omgeleid tussen EMILE DELVA en LEOPOLD I. Info: mivb.brussels of app.\"}],\"type\":\"Description\"}]",
+            "type": "LongText",
+            "lines": "[{\"id\":\"53\"}]",
+            "priority": 5,
+            "points": "[{\"id\":\"2823B\"},{\"id\":\"2856B\"},{\"id\":\"2857C\"},{\"id\":\"2170\"},{\"id\":\"2855\"},{\"id\":\"2766\"},{\"id\":\"2854\"},{\"id\":\"2545\"},{\"id\":\"2853\"},{\"id\":\"2875\"},{\"id\":\"1037\"},{\"id\":\"2852\"},{\"id\":\"4131B\"},{\"id\":\"2554\"},{\"id\":\"1057\"},{\"id\":\"2861\"},{\"id\":\"2860\"}]"
+        },
+        {
+            "content": "[{\"text\":[{\"en\":\"Works. Until 2027, stop not served. Walk to DROGENBOS.  \",\"fr\":\"Travaux. Jusqu'en 2027, arrêt non desservi. Pour rejoindre DROGENBOS, continuez à pied.\",\"nl\":\"Werken. Tot 2027, halte niet bediend. Ga te voet verder om naar DROGENBOS te gaan. \"}],\"type\":\"Description\"}]",
+            "type": "LongText",
+            "lines": "[{\"id\":\"82\"}]",
+            "priority": 4,
+            "points": "[{\"id\":\"5729\"},{\"id\":\"5725\"}]"
+        },
+        {
+            "content": "[{\"text\":[{\"en\":\"Works. Stop moved 10m back. Stop B71 toward Delta.\",\"fr\":\"Travaux. Arrêt reculé de 10m. Arrêt du B71 vers Delta.\",\"nl\":\"Werken. Halte achteruitgebracht van 10m. Halte van B71 naar DELTA.\"}],\"type\":\"Description\"}]",
+            "type": "LongText",
+            "lines": "[{\"id\":\"38\"}]",
+            "priority": 4,
+            "points": "[{\"id\":\"6443\"}]"
+        },
+        {
+            "content": "[{\"text\":[{\"en\":\"Works. From 21 May 2025 to mid 2027, tram 55 interrupted btw TILLEUL and DA VINCI. For BORDET STATION, B59 at HELMET\",\"fr\":\"Travaux. Du 21/5/25 à mi-2027, tram 55 interrompu entre TILLEUL et DA VINCI. Pour BORDET STATION, bus 59 à HELMET\",\"nl\":\"Werken. Van 21/5/25 tot midden 2027, tram 55 onderbroken tss LINDE en DA VINCI. Voor BORDET STATION, B59 aan HELMET\"}],\"type\":\"Description\"}]",
+            "type": "LongText",
+            "lines": "[{\"id\":\"55\"}]",
+            "priority": 5,
+            "points": "[{\"id\":\"5865\"},{\"id\":\"5866\"}]"
+        },
+        {
+            "content": "[{\"text\":[{\"en\":\"Works. 4 Aug to December 2026, T51 interrupted btw. MARGUERITE DURAS and BELGICA. Info: stib- mivb.be or in the app.\",\"fr\":\"Travaux. 4/8 à décembre 2026, T51 interrompu entre MARGUERITE DURAS et BELGICA.Plus d'infos: stib.brussels ou l'app.\",\"nl\":\"Werken. 4/8 tot december 2026, T51 onderbroken tussen MARGUERITE DURAS en BELGICA. Info: mivb. brussels of in app.\"}],\"type\":\"Description\"}]",
+            "type": "LongText",
+            "lines": "[{\"id\":\"51\"}]",
+            "priority": 5,
+            "points": "[{\"id\":\"6604F\"},{\"id\":\"6649F\"},{\"id\":\"6601\"},{\"id\":\"2401F\"},{\"id\":\"6608G\"},{\"id\":\"0636\"}]"
+        },
+        {
+            "content": "[{\"text\":[{\"en\":\"Works. Until end 2026, stop not served. Tram 81 at WIELS (as of 26 Jan) via temporary bus 96: cée de Waterloo 208.\",\"fr\":\"Travaux. Jsq fin 2026, arrêt non desservi. T81 à WIELS (dès le 26/1), via bus temporaire 96: chée de Waterloo 208.\",\"nl\":\"Werken. Tot eind 2026, halte niet bediend. T81 aan WIELS (vanaf 26/1), via tijdelijke bus 96: Waterloosesteenweg 208.\"}],\"type\":\"Description\"}]",
+            "type": "LongText",
+            "lines": "[{\"id\":\"81\"}]",
+            "priority": 4,
+            "points": "[{\"id\":\"7614F\"},{\"id\":\"2336G\"}]"
+        },
+        {
+            "content": "[{\"text\":[{\"en\":\"Works. 4 Aug to December 2026, T51 interrupted. T51 at MARGUERITE DURAS via M2-6 to YSER/IJZER, then walk 400m. \",\"fr\":\"Travaux. 4/8 à décembre 2026, T51 interrompu. T51 à MARGUERITE DURAS via métro 2 ou 6 jusqu’à YSER, puis 400m à pied.\",\"nl\":\"Werken. 4/8 tot december 2026, T51 onderbroken. T51 aan MARGUERITE DURAS via metro 2 of 6 tot IJZER, dan 400m te voet.\"}],\"type\":\"Description\"}]",
+            "type": "LongText",
+            "lines": "[{\"id\":\"51\"}]",
+            "priority": 4,
+            "points": "[{\"id\":\"5013F\"}]"
+        },
+        {
+            "content": "[{\"text\":[{\"en\":\"Works. 21 May 2025-mid 2027, stop not served. Tram 55 at TILLEUL or VERBOEKHOVEN (via bus 59 from FONSON).\",\"fr\":\"Travaux.21/5/25-mi-2027, arrêt non desservi. Tram 55 à TILLEUL ou à VERBOEKHOVEN (via bus 59 à FONSON).\",\"nl\":\"Werken. 21/5/25-midden 2027,halte niet bediend. Tram 55 aan LINDE of aan VERBOEKHOVEN (via bus 59 aan FONSON).\"}],\"type\":\"Description\"}]",
+            "type": "LongText",
+            "lines": "[{\"id\":\"55\"}]",
+            "priority": 4,
+            "points": "[{\"id\":\"2902\"}]"
+        },
+        {
+            "content": "[{\"text\":[{\"en\":\"Until 2027, works. Tram 97 temporarily withdrawn. For BARRIERE, take temporary bus 96 at WIELS via T82 or B50.\",\"fr\":\"Jsq 2027, travaux. Tram 97 temporairement supprimé. Pour BARRIERE, bus temporaire 96 à WIELS via T82 ou B50.\",\"nl\":\"Tot 2027, werken. Tram 97 tijdelijk afgeschaft. Voor BAREEL, neem de tijdelijke bus 96 aan WIELS via T82 of B50.\"}],\"type\":\"Description\"}]",
+            "type": "LongText",
+            "lines": "[]",
+            "priority": 4,
+            "points": "[{\"id\":\"5156F\"},{\"id\":\"5164F\"}]"
+        },
+        {
+            "content": "[{\"text\":[{\"en\":\"Works. Until May 2026, bus 54 diverted between BAILLI and MA CAMPAGNE via JANSON. Info: stib- mivb.be or in the app.\",\"fr\":\"Travaux. Jusque mai 2026, bus 54 dévié entre BAILLI et MA CAMPAGNE via JANSON. Info : stib. brussels ou app.\",\"nl\":\"Werken. Tot mei 2026, bus 54 omgeleid tussen BALJUW en MA CAMPAGNE via JANSON. Info: mivb. brussels of app.\"}],\"type\":\"Description\"}]",
+            "type": "LongText",
+            "lines": "[{\"id\":\"54\"}]",
+            "priority": 5,
+            "points": "[{\"id\":\"1734\"},{\"id\":\"1780\"},{\"id\":\"2929\"},{\"id\":\"2928\"},{\"id\":\"3518B\"},{\"id\":\"3506\"}]"
+        },
+        {
+            "content": "[{\"text\":[{\"en\":\"Works. As of 22 Dec, temporary bus 96 limited to TRINITE. Stop of bus 96: chaussée de Waterloosesteenweg 412.\",\"fr\":\"Travaux. Dès le 22/12, bus temporaire 96 limité à TRINITE. Arrêt du bus 96: chaussée de Waterloo 412.\",\"nl\":\"Werken. Vanaf 22/12, tijdelijke B96 beperkt tot DRIEVULDIGHEID. Halte bus 96: Waterloosesteenweg 412.\"}],\"type\":\"Description\"}]",
+            "type": "LongText",
+            "lines": "[{\"id\":\"96\"}]",
+            "priority": 4,
+            "points": "[{\"id\":\"2932\"},{\"id\":\"1848\"}]"
+        },
+        {
+            "content": "[{\"text\":[{\"en\":\"Works. From 21 Mar until 22 Mar at 6.30pm, bus 21 diverted between DIAMANT and RTL HOUSE via place Meiserplein.\",\"fr\":\"Travaux. Du 21/3 au 22/3 à 18h30, bus 21 dévié entre DIAMANT et RTL HOUSE via place Meiser.\",\"nl\":\"Werken. Van 21/3 tot 22/3 om 18.30u, bus 21 omgeleid tussen DIAMANT en RTL HOUSE via Meiserplein.\"}],\"type\":\"Description\"}]",
+            "type": "LongText",
+            "lines": "[{\"id\":\"21\"}]",
+            "priority": 5,
+            "points": "[{\"id\":\"6451\"},{\"id\":\"3366\"},{\"id\":\"1132\"},{\"id\":\"2927\"},{\"id\":\"1262B\"}]"
+        },
+        {
+            "content": "[{\"text\":[{\"en\":\"Works. From 21/3 until 22/3 at 6.30pm, bus 80 diverted between COLONEL BOURG  and PADUWA. CARENE not served.\",\"fr\":\"Travaux. Du 21/3 au 22/3 à 18h30, bus 80 dévié entre COLONEL BOURG et PADUWA. CARENE non desservi.\",\"nl\":\"Werken. Van 21/3 tot 22/3 om 18.30u, bus 80 omgeleid tussen KOLONEL BOURG en PADUWA. CARINA niet bediend.\"}],\"type\":\"Description\"}]",
+            "type": "LongText",
+            "lines": "[{\"id\":\"80\"}]",
+            "priority": 5,
+            "points": "[{\"id\":\"6433\"},{\"id\":\"1141\"},{\"id\":\"1140\"},{\"id\":\"2283\"},{\"id\":\"3160\"},{\"id\":\"1139\"},{\"id\":\"1136\"},{\"id\":\"1113\"},{\"id\":\"1135\"},{\"id\":\"1233\"},{\"id\":\"1729\"},{\"id\":\"1706\"},{\"id\":\"1728\"},{\"id\":\"3952\"},{\"id\":\"3953\"},{\"id\":\"3954\"},{\"id\":\"1824\"}]"
+        },
+        {
+            "content": "[{\"text\":[{\"en\":\"Works. Bus 38 diverted. Take bus 38 at the next stop, ROYALE / KONING.\",\"fr\":\"Travaux. Bus 38 dévié. Prenez le bus 38 à l'arrêt suivant, ROYALE.\",\"nl\":\"Werken. Bus 38 omgeleid. Neem bus 38 aan de volgende halte, KONING.\"}],\"type\":\"Description\"}]",
+            "type": "LongText",
+            "lines": "[{\"id\":\"38\"},{\"id\":\"71\"}]",
+            "priority": 4,
+            "points": "[{\"id\":\"3502\"}]"
+        },
+        {
+            "content": "[{\"text\":[{\"en\":\"Works. As of Monday 4 Aug 6am, bus 47 is diverted for +/- 2 months. Stop moved to (James) Ensorlaan 6.\",\"fr\":\"Travaux. Dès le lundi 4/8, 6h pendant +/- 2 mois, bus 47 est dévié. Arrêt déplacé  (James) Ensorlaan numéro 6.\",\"nl\":\"Werken. Vanaf maandag 4 augustus, 6u wordt bus 47 een 2-tal maand omgeleid. Halte aan (James) Ensorlaan 6.\"}],\"type\":\"Description\"}]",
+            "type": "LongText",
+            "lines": "[]",
+            "priority": 4,
+            "points": "[{\"id\":\"9631\"}]"
+        },
+        {
+            "content": "[{\"text\":[{\"en\":\"Works. 21 May 2025-mid 2027, stop not served. Tram 55 at TILLEUL or VERBOEKHOVEN (via B59, stop B64 BORDET STATION)\",\"fr\":\"Travaux.21/5/25-mi-2027, arrêt non desservi. Tram 55 à TILLEUL ou à VERBOEKHOVEN (via B59, arrêt B64 BORDET STAT)\",\"nl\":\"Werken. 21/5/25-midden 2027,halte niet bediend. Tram 55 aan LINDE of aan VERBOEKHOVEN(via B59, halte B64 BORDET STAT)\"}],\"type\":\"Description\"}]",
+            "type": "LongText",
+            "lines": "[{\"id\":\"55\"}]",
+            "priority": 4,
+            "points": "[{\"id\":\"5872\"}]"
+        },
+        {
+            "content": "[{\"text\":[{\"en\":\"Until 2027, works. Tram 97 temporarily withdrawn. For JANSON, temporary bus 96, for LOUISE,tram 92 at JANSON\",\"fr\":\"Jsq 2027, travaux. Tram 97 temporairement supprimé. Pour JANSON, bus temporaire 96, pour LOUISE, tram 92 à JANSON\",\"nl\":\"Tot 2027, werken. Tram 97 tijdelijk geschrapt. Voor JANSON, tijdelijke bus 96, voor LOUIZA, tram 92 aan JANSON.\"}],\"type\":\"Description\"}]",
+            "type": "LongText",
+            "lines": "[]",
+            "priority": 4,
+            "points": "[{\"id\":\"6077F\"},{\"id\":\"2333F\"},{\"id\":\"6109\"}]"
+        },
+        {
+            "content": "[{\"text\":[{\"en\":\"Works. From 21 Mar to 22 Mar at 6.30pm, bus 79 diverted between CARENE / CARINA and DIAMANT via place Meiserplein.\",\"fr\":\"Travaux. Du 21/3 au 22/3 à 18h30, bus 79 dévié entre CARENE et DIAMANT via place Meiser.\",\"nl\":\"Werken. Van 21/3 tot 22/3 om 18.30u, bus 79 omgeleid tussen CARINA en DIAMANT via Meiserplein.\"}],\"type\":\"Description\"}]",
+            "type": "LongText",
+            "lines": "[{\"id\":\"79\"}]",
+            "priority": 5,
+            "points": "[{\"id\":\"3902\"},{\"id\":\"3903\"},{\"id\":\"1533\"},{\"id\":\"2028\"},{\"id\":\"1531\"},{\"id\":\"1320\"},{\"id\":\"3920\"}]"
+        },
+        {
+            "content": "[{\"text\":[{\"en\":\"Works. From 4 Aug 2025 to May 2026, stop not served. Stop of bus 54: JANSON (rue Defacqzstraat 146).\",\"fr\":\"Travaux. Du 4/8/2025 à mai 2026, arrêt non desservi. Arrêt du bus 54: JANSON (rue Defacqz 146).\",\"nl\":\"Werken. Van 4/8/2025 tot mei 2026, halte niet bediend. Halte van bus 54: JANSON (Defacqzstraat 146).\"}],\"type\":\"Description\"}]",
+            "type": "LongText",
+            "lines": "[{\"id\":\"54\"}]",
+            "priority": 4,
+            "points": "[{\"id\":\"2960\"}]"
+        },
+        {
+            "content": "[{\"text\":[{\"en\":\"Works. From 21 Mar until 22 Mar at 6.30pm, bus 79 diverted between DIAMANT and CARENE via place Meiserplein.\",\"fr\":\"Travaux. Du 21/3 au 22/3 à 18h30, bus 79 dévié entre DIAMANT et CARENE via place Meiser.\",\"nl\":\"Werken. Van 21/3 tot 22/3 om 18.30u, bus 79 omgeleid tussen DIAMANT en CARINA via Meiserplein.\"}],\"type\":\"Description\"}]",
+            "type": "LongText",
+            "lines": "[{\"id\":\"79\"}]",
+            "priority": 5,
+            "points": "[{\"id\":\"1404\"}]"
+        },
+        {
+            "content": "[{\"text\":[{\"en\":\"Works. 26 Jan-end 2026, stop not served. For MONTGOMERY, take tram 81 at TRINITE. For LOUISE, T92\",\"fr\":\"Travaux. 26/1-fin 2026, arrêt non desservi. Pour MONTGOMERY, prenez le tram 81 à TRINITE. Pour LOUISE, T92.\",\"nl\":\"Werken. 26/1-eind 2026, halte niet bediend. Voor MONTGOMERY, neem tram 81 aan DRIEVULDIGHEID. Voor LOUIZA, T92\"}],\"type\":\"Description\"}]",
+            "type": "LongText",
+            "lines": "[{\"id\":\"81\"}]",
+            "priority": 4,
+            "points": "[{\"id\":\"6427F\"}]"
+        },
+        {
+            "content": "[{\"text\":[{\"en\":\"Works. 4 Aug to December 2026, T51 interrupted. Take tram 51 at MARGUERITE DURAS (400m), stop of T51 to STADION.\",\"fr\":\"Travaux. 4/8 à décembre 2026, T51 interrompu. Prenez le tram 51 à MARGUERITE DURAS (400m), arrêt du T51 vers STADE.\",\"nl\":\"Werken. 4/8 tot december 2026, T51 onderbroken. Neem tram 51 aan MARGUERITE DURAS (400m), halte van T51 STADION.\"}],\"type\":\"Description\"}]",
+            "type": "LongText",
+            "lines": "[{\"id\":\"51\"}]",
+            "priority": 4,
+            "points": "[{\"id\":\"6651\"}]"
+        },
+        {
+            "content": "[{\"text\":[{\"en\":\"Works. From 23 Mar at 7am until +/- July 2026, stop STOCKEL / STOKKEL of bus 36 to KONKEL moved pl. Dumonpl. 16.\",\"fr\":\"Travaux. Dès le 23/3 à 7h jusque +/- juillet 2026, arrêt STOCKEL du bus 36 vers KONKEL déplacé place Dumon 16.\",\"nl\":\"Werken. Vanaf 23/3 om 7u tot +/- juli 2026, halte STOKKEL van bus 36 naar KONKEL verplaatst Dumonplein 16.\"}],\"type\":\"Description\"}]",
+            "type": "LongText",
+            "lines": "[{\"id\":\"36\"}]",
+            "priority": 4,
+            "points": "[{\"id\":\"1252\"}]"
+        },
+        {
+            "content": "[{\"text\":[{\"en\":\"Match. 22 Mar, 3.30pm- 1am, bus 46 diverted btw NEERPEDE and ST-GUIDON / ST-GUIDO via avenue Marius Renardlaan.\",\"fr\":\"Match. 22/3, 15h30-1h, bus 46 dévié entre NEERPEDE et SAINT-GUIDON via avenue Marius Renard.\",\"nl\":\"Match. 22/3, 15.30u-1u, bus 46 omgeleid tussen NEERPEDE en SINT-GUIDO via Marius Renardlaan.\"}],\"type\":\"Description\"}]",
+            "type": "LongText",
+            "lines": "[{\"id\":\"46\"}]",
+            "priority": 6,
+            "points": "[{\"id\":\"1203\"},{\"id\":\"1201\"},{\"id\":\"3752\"}]"
+        },
+        {
+            "content": "[{\"text\":[{\"en\":\"Subsidence. From 28 Oct, stop relocated. Take the bus next to this stop. \",\"fr\":\"Effondrement. Dès le 28/10, arrêt déplacé. Prenez le bus à côté de cet arrêt.\",\"nl\":\"Wegverzakking. Vanaf 28/10, halte verplaatst. Neem de bus naast deze halte.\"}],\"type\":\"Description\"}]",
+            "type": "LongText",
+            "lines": "[{\"id\":\"46\"}]",
+            "priority": 4,
+            "points": "[{\"id\":\"2215\"}]"
+        },
+        {
+            "content": "[{\"text\":[{\"en\":\"Works. 26 Jan-end 2026, stop not served. For TRINITE, bus 48 between SERBIE and ROCHEFORT, and temporary bus 96.\",\"fr\":\"Travaux. 26/1-fin 2026, arrêt non desservi. Pour TRINITE, bus 48 entre SERBIE et ROCHEFORT, et bus temporaire 96. \",\"nl\":\"Werken. 26/1-eind 2026, halte niet bediend. Voor DRIEVULDIGHEID, bus 48 tss SERVIE en ROCHEFORT, en tijdelijke bus 96. \"}],\"type\":\"Description\"}]",
+            "type": "LongText",
+            "lines": "[{\"id\":\"81\"}]",
+            "priority": 4,
+            "points": "[{\"id\":\"6106\"}]"
+        },
+        {
+            "content": "[{\"text\":[{\"en\":\"Works. 4 Aug to December 2026, T51 interrupted. Take tram 51 at MARGUERITE DURAS (500m), stop of T51 to STADION.\",\"fr\":\"Travaux. 4/8 à décembre 2026, T51 interrompu. Prenez le tram 51 à MARGUERITE DURAS (500m), arrêt du T51 vers STADE.\",\"nl\":\"Werken. 4/8 tot december 2026, T51 onderbroken. Neem tram 51 aan MARGUERITE DURAS (500m), halte van T51 STADION.\"}],\"type\":\"Description\"}]",
+            "type": "LongText",
+            "lines": "[{\"id\":\"51\"}]",
+            "priority": 4,
+            "points": "[{\"id\":\"5014\"}]"
+        },
+        {
+            "content": "[{\"text\":[{\"en\":\"Works. From 21 Mar to 22 Mar at 6.30pm, bus 79 diverted btw DIAMANT and CARENE. Take bus 79 at DIAMANT.\",\"fr\":\"Travaux. Du 21/3 au 22/3 à 18h30, bus 79 dévié entre DIAMANT et CARENE. Prenez le bus 79 à DIAMANT.\",\"nl\":\"Werken. Van 21/3 tot 22/3 om 18.30u, bus 79 omgeleid tussen DIAMANT en CARINA. Neem bus 79 aan DIAMANT.\"}],\"type\":\"Description\"}]",
+            "type": "LongText",
+            "lines": "[{\"id\":\"79\"}]",
+            "priority": 4,
+            "points": "[{\"id\":\"3956\"}]"
+        },
+        {
+            "content": "[{\"text\":[{\"en\":\"Works. From 26 Jan, bus 65 diverted. Temporary stop: Woluwelaan, before the Nieuwbrugstraat.\",\"fr\":\"Travaux. Dès le 26/1, bus 65 dévié. Arrêt provisoire: Woluwelaan, avant la Nieuwbrugstraat.\",\"nl\":\"Werken. Vanaf 26/1, bus 65 omgeleid. Tijdelijke halte: Woluwelaan, voor de Nieuwbrugstraat.\"}],\"type\":\"Description\"}]",
+            "type": "LongText",
+            "lines": "[{\"id\":\"65\"}]",
+            "priority": 4,
+            "points": "[{\"id\":\"9702\"}]"
+        },
+        {
+            "content": "[{\"text\":[{\"en\":\"Works. 22 Jan-mid-June, bus 48 diverted btw PTE HAL and ANNEESSENS, bus 52 diverted btw PTE HAL and MADELEINE.\",\"fr\":\"Travaux. 22/1-mi-juin, bus 48 dévié entre PORTE DE HAL et ANNEESSENS, bus 52 dévié entre PORTE DE HAL et MADELEINE.\",\"nl\":\"Werken.22/1-midden juni, bus 48 omgeleid tss HALLEPT en ANNEESSENS, bus 52 omgeleid tss HALLEPOORT en MAGDALENA.\"}],\"type\":\"Description\"}]",
+            "type": "LongText",
+            "lines": "[{\"id\":\"48\"},{\"id\":\"52\"}]",
+            "priority": 5,
+            "points": "[{\"id\":\"2467\"}]"
+        }
+    ],
+    "totalCount": 245,
+    "parameters": {},
+    "metadata": {}
+}


### PR DESCRIPTION
Closes #41.

Response remains the same, except that now results are in a `results` key.

API key has been renamed in `.env`.

Also:

- [x] updated documentation
- [x] add data sample from the new API
- [x] prettifies old data sample